### PR TITLE
[docs] Update dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ Install sqlite:
 
 .. code-block:: shell
 
-    sudo apt-get install sqlite3 libsqlite3-dev openssl libssl-dev
+    sudo apt-get install sqlite3 libsqlite3-dev libsqlite3-mod-spatialite openssl libssl-dev
     sudo apt-get install gdal-bin libproj-dev libgeos-dev libspatialite-dev
 
 Install your forked repo:


### PR DESCRIPTION
`libsqlite3-mod-spatialite` is required on Debian Stretch.