### PR TITLE
Add default permissions to admins and operators 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
   # TODO: temporary, remove when django-netjsonconfig 0.9.0 is released
   - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pipenv install git+git://github.com/tinio/pysqlite.git@extension-enabled#egg=pysqlite; fi
   - pipenv run pip install https://github.com/openwisp/django-x509/tarball/master
+  - pipenv run pip install git+https://github.com/openwisp/openwisp-users.git
 
 script:
   # for some reason the migrations check is failing only on django 2.0

--- a/openwisp_controller/config/migrations/0015_add_relevant_permissions_to_admin_and_operators.py
+++ b/openwisp_controller/config/migrations/0015_add_relevant_permissions_to_admin_and_operators.py
@@ -1,0 +1,61 @@
+from django.db import migrations
+from django.contrib.auth.models import Permission
+from django.contrib.auth.management import create_permissions
+
+
+def create_default_permissions(apps, schema_editor):
+    for app_config in apps.get_app_configs():
+        app_config.models_module = True
+        create_permissions(app_config, apps=apps, verbosity=0)
+        app_config.models_module = None
+
+
+def assign_permissions_to_groups(apps, schema_editor):
+    Group = apps.get_model('openwisp_users', 'Group')
+    admin = Group.objects.get(name='Administrator')
+    operator = Group.objects.get(name='Operator')
+    operators_and_admins_can_change = ['device', 'config', 'template']
+    operators_read_only_admins_manage = ['vpn']
+    manage_operations = ['add', 'change', 'delete']
+
+    for model_name in operators_and_admins_can_change:
+        for operation in manage_operations:
+            permission = Permission.objects.get(
+                codename='{}_{}'.format(operation, model_name)
+            )
+            admin.permissions.add(permission.pk)
+            operator.permissions.add(permission.pk)
+            
+    for model_name in operators_read_only_admins_manage:
+        try:
+            permission = Permission.objects.get(
+                codename="view_{}".format(model_name)
+            )
+            operator.permissions.add(permission.pk)
+        except Permission.DoesNotExist:
+            pass
+
+        for operation in manage_operations:
+            admin.permissions.add(
+                Permission.objects.get(codename="{}_{}".format(operation, model_name)).pk
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('openwisp_users', '0004_default_groups'),
+        ('pki', '__first__'),
+        ('geo', '__first__'),
+        ('config', '0014_device_hardware_id'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            create_default_permissions,
+            reverse_code=migrations.RunPython.noop
+        ),
+        migrations.RunPython(
+            assign_permissions_to_groups,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/openwisp_controller/geo/migrations/0002_assign_corresponding_permissions_for_geo.py
+++ b/openwisp_controller/geo/migrations/0002_assign_corresponding_permissions_for_geo.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+from django.contrib.auth.models import Permission
+
+
+def assign_permissions_to_groups(apps, schema_editor):
+    Group = apps.get_model('openwisp_users', 'Group')
+    admin = Group.objects.get(name='Administrator')
+    operator = Group.objects.get(name='Operator')
+    operators_and_admins_can_change = ['location', 'floorplan', ]
+    manage_operations = ['add', 'change', 'delete']
+
+    for model_name in operators_and_admins_can_change:
+        for operation in manage_operations:
+            permission = Permission.objects.get(
+                codename='{}_{}'.format(operation, model_name)
+            )
+            admin.permissions.add(permission.pk)
+            operator.permissions.add(permission.pk)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('openwisp_users', '0004_default_groups'),
+        ('geo', '0001_initial')
+    ]
+
+    operations = [
+        migrations.RunPython(
+            assign_permissions_to_groups,
+            reverse_code=migrations.RunPython.noop
+        )
+    ]

--- a/openwisp_controller/pki/migrations/0007_add_corresponding_pki_model_permissions_to_admins_and_operators.py
+++ b/openwisp_controller/pki/migrations/0007_add_corresponding_pki_model_permissions_to_admins_and_operators.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+from django.contrib.auth.models import Permission
+
+
+def assign_permissions_to_groups(apps, schema_editor):
+    Group = apps.get_model('openwisp_users', 'Group')
+    admin = Group.objects.get(name='Administrator')
+    operator = Group.objects.get(name='Operator')
+    operators_read_only_admins_manage = ['ca', 'cert']
+    manage_operations = ['add', 'change', 'delete']
+
+    for model_name in operators_read_only_admins_manage:
+        try:
+            permission = Permission.objects.get(codename="view_{}".format(model_name))
+            operator.permissions.add(permission.pk)
+        except Permission.DoesNotExist:
+            pass
+
+        for operation in manage_operations:
+            admin.permissions.add(
+                Permission.objects.get(codename="{}_{}".format(operation, model_name)).pk
+            )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('openwisp_users', '0004_default_groups'),
+        ('pki', '0006_add_x509_passphrase_field'),
+    ]
+    operations = [
+            migrations.RunPython(
+                assign_permissions_to_groups,
+                reverse_code=migrations.RunPython.noop
+            )
+    ]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -115,6 +115,8 @@ FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 EMAIL_PORT = '1025'  # for testing purposes
 LOGIN_REDIRECT_URL = 'admin:index'
 ACCOUNT_LOGOUT_REDIRECT_URL = LOGIN_REDIRECT_URL
+OPENWISP_ORGANIZATON_USER_ADMIN = True  # tests will fail without this setting
+OPENWISP_ORGANIZATON_OWNER_ADMIN = True  # tests will fail without this setting
 
 # during development only
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'


### PR DESCRIPTION
fixes issue #48
The consequence of this code is that operators have permissions in accordance with the specifications mentioned in the issue and the admins have access to all the objects mentioned in the issue.