### PR TITLE
[x509] Fix certificates without organization assigned #34 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   - pipenv install $DJANGO
   # fix issues with travis
   - pipenv install --skip-lock "attrs>=17.4.0"
-  - pipenv install --skip-lock "six>=1.11.0"
+  - pipenv install --skip-lock "six"
   # TODO: temporary, remove when django-netjsonconfig 0.9.0 is released
   - if [[ $TRAVIS_PYTHON_VERSION == "2.7" ]]; then pipenv install git+git://github.com/tinio/pysqlite.git@extension-enabled#egg=pysqlite; fi
   - pipenv run pip install https://github.com/openwisp/django-x509/tarball/master

--- a/openwisp_controller/config/models.py
+++ b/openwisp_controller/config/models.py
@@ -192,7 +192,7 @@ class VpnClient(AbstractVpnClient):
         """
         sets the organization on the created client certificate
         """
-        cert.organization = self.vpn.organization
+        cert.organization = self.config.device.organization
         return cert
 
 

--- a/openwisp_controller/config/tests/test_template.py
+++ b/openwisp_controller/config/tests/test_template.py
@@ -94,3 +94,18 @@ class TestTemplate(CreateConfigTemplateMixin, TestVpnX509Mixin,
                               vpn=vpn,
                               config={})
         self._create_config(organization=org)
+
+    def test_auto_generated_certificate_for_organization(self):
+        organization = self._create_org()
+        vpn = self._create_vpn()
+        template = self._create_template(type='vpn', auto_cert=True, vpn=vpn)
+        corresponding_device = self._create_device(organization=organization,)
+        config = self._create_config(
+            device=corresponding_device,
+            organization=corresponding_device.organization
+        )
+        config.templates.add(template)
+        vpn_clients = config.vpnclient_set.all()
+        for vpn_client in vpn_clients:
+            self.assertIsNotNone(vpn_client.cert.organization)
+            self.assertEqual(vpn_client.cert.organization, config.device.organization)


### PR DESCRIPTION
This code effectively, overrides the save() function of Cert to check for a corresponding device every time a Certificate is created and then checks for the organization of that device and updates the cert object accordingly and saves it. 