### PR TITLE
[docs] Remove invisible non-ascii characters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -240,14 +240,14 @@ Build from the Dockerfile:
 
 .. code-block:: shell
 
-   sudo docker build -t openwisp/controller .
+    sudo docker build -t openwisp/controller .
 
 Run the docker container:
 
 .. code-block:: shell
 
-   sudo docker run -it -p 8000:8000 openwisp/controller
-   
+    sudo docker run -it -p 8000:8000 openwisp/controller
+
 Troubleshooting Steps
 ---------------------
 


### PR DESCRIPTION
In `README.rst` there were invisible non-ascii characters which make the install fail on systems where an appropriate locale (`de_DE.utf8` for example) is not installed:

> pip3 install -U https://github.com/openwisp/openwisp-controller/tarball/master
Collecting https://github.com/openwisp/openwisp-controller/tarball/master
  Downloading https://github.com/openwisp/openwisp-controller/tarball/master
     / 286kB 964kB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-gskv33m3-build/setup.py", line 28, in <module>
        long_description=open('README.rst').read(),
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 6460: ordinal not in range(128)