### PR TITLE
[config/models] Fixed Error saving Device without organization #24

### DIFF
--- a/openwisp_controller/config/models.py
+++ b/openwisp_controller/config/models.py
@@ -118,7 +118,8 @@ class Config(OrgMixin, TemplatesVpnMixin, AbstractConfig):
         abstract = False
 
     def clean(self):
-        if not hasattr(self, 'organization') and self._has_device():
+        if not hasattr(self, 'organization') and \
+                all([self._has_device(), hasattr(self.device, 'organization')]):
             self.organization = self.device.organization
         super(Config, self).clean()
 

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -64,3 +64,11 @@ class TestDevice(CreateConfigTemplateMixin, TestOrganizationMixin, TestCase):
         }
         with self.assertRaises(ValidationError):
             self._create_device(**kwargs)
+
+    def test_config_device_without_org(self):
+        option = {
+            'name': 'testdc'
+        }
+        device = self.device_model(**option)
+        with self.assertRaises(ValidationError):
+            self._create_config(device=device)


### PR DESCRIPTION
In the config class, device.organization was assigned to organization
without checking if the device actually had the organization or not.
Performing this check before assignment fixed the issue.

Fixes #24