### PR TITLE
Failing openwisp-controller installation on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-onbuild
+FROM python:3.6-stretch
 
 WORKDIR .
 RUN apt-get update && apt-get install -y \
@@ -9,9 +9,10 @@ RUN apt-get update && apt-get install -y \
     gdal-bin \
     libproj-dev \
     libgeos-dev \
-    libspatialite-dev
+    libspatialite-dev \
+    git
 RUN pip3 install -U pip setuptools wheel
-RUN pip3 install -U .
+RUN git clone https://github.com/openwisp/openwisp-controller && cd openwisp-controller/ && pip3 install -U .
 RUN echo "openwisp-controller installed"
 WORKDIR tests/
 CMD ["./docker-entrypoint.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+django-netjsonconfig>=0.8.0,<0.9.0
+openwisp-utils[users]<0.3
+django-loci>=0.1.1,<0.3.0
+djangorestframework-gis>=0.12.0,<0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-django-netjsonconfig>=0.8.0,<0.9.0
-openwisp-utils[users]<0.3
-django-loci>=0.1.1,<0.3.0
-djangorestframework-gis>=0.12.0,<0.13.0


### PR DESCRIPTION
requirements.txt:
	Added in respect of the issue #103 raised by me.

Dockerfile:
	openwwisp-controller installation in docker failed on step "pip3 install -U ." as there is no setup.py file at location "." in docker. I have cloned the original source (or someone else can clone their too) and install that particular openwisp-controller source into docker.
	
	python3-onbuild created issue with "apt-get update && apt-get install ...." for some repo, so modified it to python:3.6-stretch for temporary.