### PR TITLE
[models] Use hardware_id as string representation if that feature is enabled

### DIFF
--- a/openwisp_controller/config/models.py
+++ b/openwisp_controller/config/models.py
@@ -99,6 +99,9 @@ class Device(OrgMixin, AbstractDevice):
         )
         abstract = False
 
+    def __str__(self):
+        return self.hardware_id if app_settings.HARDWARE_ID_ENABLED else self.name
+
     def get_temp_config_instance(self, **options):
         c = super(Device, self).get_temp_config_instance(**options)
         c.device = self


### PR DESCRIPTION
The hardware_id should be used as the string representation for a device if the hardware_id feature is enabled.