### PR TITLE
[chores] python3.5 or higher + travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 sudo: false
 cache: pip
+dist: trusty
 
 addons:
   apt:
@@ -12,7 +13,7 @@ addons:
       - libspatialite-dev
 
 python:
-  - "3.4"
+  - "3.5"
   - "2.7"
 
 env:
@@ -48,7 +49,7 @@ install:
 script:
   - export PIPENV_IGNORE_VIRTUALENVS=1
   # for some reason the migrations check is failing only on django 2.0
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.4 ]]; then pipenv run ./tests/manage.py makemigrations config pki --dry-run | grep "No changes detected"; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pipenv run ./tests/manage.py makemigrations config pki --dry-run | grep "No changes detected"; fi
   - pipenv run coverage run --source=openwisp_controller runtests.py
   - |
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ An automated installer is available at `ansible-openwisp2 <https://github.com/op
 Dependencies
 ------------
 
-* Python 2.7 or Python >= 3.4
+* Python 2.7 or Python >= 3.5
 * OpenSSL
 
 Install stable version from pypi

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
         'Operating System :: OS Independent',
         'Framework :: Django',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ]
 )


### PR DESCRIPTION
- 3.4 support is dropped by Twisted and it no more works -- hence moved to Python3.5.
- travia's default container is now xenial, hence trusty is mentioned explicitly.