### PR TITLE
[ci] Implicitly get coverage version from coveralls

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 openwisp_controller = {path = ".", editable = true}
 
 [dev-packages]
-coverage = "*"
 coveralls = "*"
 isort = "*"
 flake8 = "*"


### PR DESCRIPTION
The coveralls package already has a dependency on coverage
and sets the boundary according to its support for the coverage library.
We should not duplicate this information.