### PR TITLE
[django] Generalize uuid/key/receive_url logic

### DIFF
--- a/openwisp_controller/config/migrations/0001_squashed_0002_config_settings_uuid.py
+++ b/openwisp_controller/config/migrations/0001_squashed_0002_config_settings_uuid.py
@@ -4,12 +4,13 @@
 import collections
 import django.core.validators
 from django.db import migrations, models
-import django.db.models.deletion
 import django.utils.timezone
 import django_netjsonconfig.base.template
 import django_netjsonconfig.utils
 import jsonfield.fields
 import model_utils.fields
+import openwisp_utils.base
+import openwisp_utils.utils
 import re
 import sortedm2m.fields
 import uuid
@@ -53,7 +54,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
                 ('registration_enabled', models.BooleanField(default=True, help_text='Whether automatic registration of devices is enabled or not', verbose_name='auto-registration enabled')),
-                ('shared_secret', models.CharField(db_index=True, default=django_netjsonconfig.utils.get_random_key, help_text='used for automatic registration of devices', max_length=32, unique=True, validators=[django.core.validators.RegexValidator(re.compile('^[^\\s/\\.]+$', 32), code='invalid', message='Key must not contain spaces, dots or slashes.')], verbose_name='shared secret')),
+                ('shared_secret', openwisp_utils.base.KeyField(db_index=True, default=openwisp_utils.utils.get_random_key, help_text='used for automatic registration of devices', max_length=32, unique=True, validators=[django.core.validators.RegexValidator(re.compile('^[^\\s/\\.]+$'), code='invalid', message='This value must not contain spaces, dots or slashes.')], verbose_name='shared secret')),
                 ('organization', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, related_name='config_settings', to='openwisp_users.Organization', verbose_name='organization')),
             ],
             options={

--- a/openwisp_controller/config/models.py
+++ b/openwisp_controller/config/models.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -11,12 +9,12 @@ from django_netjsonconfig.base.device import AbstractDevice
 from django_netjsonconfig.base.tag import AbstractTaggedTemplate, AbstractTemplateTag
 from django_netjsonconfig.base.template import AbstractTemplate
 from django_netjsonconfig.base.vpn import AbstractVpn, AbstractVpnClient
-from django_netjsonconfig.utils import get_random_key
-from django_netjsonconfig.validators import key_validator, mac_address_validator
+from django_netjsonconfig.validators import mac_address_validator
 from sortedm2m.fields import SortedManyToManyField
 from taggit.managers import TaggableManager
 
 from openwisp_users.mixins import OrgMixin, ShareableOrgMixin
+from openwisp_utils.base import KeyField, UUIDModel
 
 from .utils import get_default_templates_queryset
 
@@ -224,12 +222,11 @@ class VpnClient(AbstractVpnClient):
         return cert
 
 
-class OrganizationConfigSettings(models.Model):
+class OrganizationConfigSettings(UUIDModel):
     """
     Configuration management settings
     specific to each organization
     """
-    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     organization = models.OneToOneField('openwisp_users.Organization',
                                         verbose_name=_('organization'),
                                         related_name='config_settings',
@@ -238,13 +235,11 @@ class OrganizationConfigSettings(models.Model):
                                                default=True,
                                                help_text=_('Whether automatic registration of '
                                                            'devices is enabled or not'))
-    shared_secret = models.CharField(_('shared secret'),
-                                     max_length=32,
-                                     unique=True,
-                                     db_index=True,
-                                     default=get_random_key,
-                                     validators=[key_validator],
-                                     help_text=_('used for automatic registration of devices'))
+    shared_secret = KeyField(max_length=32,
+                             unique=True,
+                             db_index=True,
+                             verbose_name=_('shared secret'),
+                             help_text=_('used for automatic registration of devices'))
 
     class Meta:
         verbose_name = _('Configuration management settings')

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "django-netjsonconfig>=0.9.0,<0.10.0",
-        "openwisp-utils>=0.4.0,<0.5.0",
+        "openwisp-utils>=0.4.1,<0.5.0",
         "openwisp-users>=0.2.0,<0.3.0",
         "django-loci>=0.3.1,<0.4.0",
         "djangorestframework-gis>=0.12.0,<0.16.0",


### PR DESCRIPTION
Removed the logics which were duplicated
in the others modules and redefined it here to enable reusability and ease debugging.

Related to openwisp/openwisp-utils#40