### PR TITLE
Wrong Redis url passed to django.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3"
 services:
   controller:
     image: openwisp/controller-development:latest
+    environment: 
+      - REDIS_URL=redis://redis:6379
     build:
       context: .
     ports:

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -126,7 +126,7 @@ OPENWISP_ORGANIZATON_OWNER_ADMIN = True  # tests will fail without this setting
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 if not TESTING:
-    CELERY_BROKER_URL = 'redis://localhost/1'
+    CELERY_BROKER_URL = os.getenv('REDIS_URL','redis://localhost/1')
 else:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True


### PR DESCRIPTION
Added a variable in docker-compose.yml to pass redis url. If no variable is passed it will pick up the default value which is set in settings.py.