### PR TITLE
[validation] Capture exception when adding device credential without type #180

### DIFF
--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -120,6 +120,17 @@ class TestModels(CreateConnectionsMixin, TestCase):
         else:
             self.fail('ValidationError not raised')
 
+    def test_credentials_connection_missing(self):
+        with self.assertRaises(ValidationError) as e:
+            c = Credentials(name='Test credentials',
+                            connector=None,
+                            params={'username': 'root',
+                                    'password': 'password',
+                                    'port': 22},
+                            organization=self._create_org())
+            c.full_clean()
+            self.assertIn('connector', e.message_dict)
+
     def test_device_connection_schema(self):
         # unrecognized parameter
         try:


### PR DESCRIPTION
An exception occurred before validation of the fields.

Fixes #180