### PR TITLE
[models] Added instance triggering is_working_changed signal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,23 @@ Add the following settings to ``settings.py``:
 
     urlpatterns += staticfiles_urlpatterns()
 
+Signals
+-------
+
+``is_working_changed``
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Path**: ``openwisp_controller.connection.signals.is_working_changed``
+
+**Arguments**:
+
+- ``instance``: instance of ``DeviceConnection`` which got its ``is_working`` modified
+- ``is_working``: bool variable informing working status of device
+
+This signal is emitted every time ``DeviceConnection.is_working`` changes.
+
+It is not triggered when the device is created for the first time.
+
 Settings
 --------
 

--- a/openwisp_controller/connection/models.py
+++ b/openwisp_controller/connection/models.py
@@ -239,4 +239,4 @@ class DeviceConnection(ConnectorMixin, TimeStampedEditableModel):
         self._initial_is_working = self.is_working
 
     def send_is_working_changed_signal(self):
-        is_working_changed.send(sender=self.__class__, is_working=self.is_working)
+        is_working_changed.send(sender=self.__class__, is_working=self.is_working, instance=self)

--- a/openwisp_controller/connection/signals.py
+++ b/openwisp_controller/connection/signals.py
@@ -1,3 +1,3 @@
 from django.dispatch import Signal
 
-is_working_changed = Signal(providing_args=['is_working'])
+is_working_changed = Signal(providing_args=['is_working', 'instance'])

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -331,6 +331,7 @@ class TestModels(CreateConnectionsMixin, TestCase):
             dc.is_working = True
             dc.save()
         handler.assert_called_once_with(
+            instance=dc,
             is_working=True,
             sender=DeviceConnection,
             signal=is_working_changed,


### PR DESCRIPTION
Follow up to PR #179 
I found that custom signals don't provide object **instance** triggering them by default but it would be required in openwisp_monitoring#4, so added the same.