### PR TITLE
[bug] Auto add device credential can fail #172

### DIFF
--- a/openwisp_controller/connection/models.py
+++ b/openwisp_controller/connection/models.py
@@ -87,7 +87,7 @@ class Credentials(ConnectorMixin, ShareableOrgMixin, BaseModel):
         """
         if not self.auto_add:
             return
-        devices = Device.objects.all()
+        devices = Device.objects.exclude(config=None)
         org = self.organization
         if org:
             devices = devices.filter(organization=org)
@@ -170,7 +170,7 @@ class DeviceConnection(ConnectorMixin, TimeStampedEditableModel):
                 'credentials': _('The organization of these credentials doesn\'t '
                                  'match the organization of the device')
             })
-        if not self.update_strategy and hasattr(self.device, 'config'):
+        if not self.update_strategy and self.device._has_config():
             try:
                 self.update_strategy = app_settings.CONFIG_UPDATE_MAPPING[self.device.config.backend]
             except KeyError as e:

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -233,6 +233,12 @@ class TestModels(CreateConnectionsMixin, TestCase):
         self.assertEqual(d.deviceconnection_set.count(), 1)
         self.assertEqual(d.deviceconnection_set.first().credentials, c)
 
+    def test_auto_add_device_missing_config(self):
+        org = Organization.objects.first()
+        self._create_device(organization=org)
+        self._create_credentials(auto_add=True, organization=None)
+        self.assertEqual(Credentials.objects.count(), 1)
+
     _exec_command_path = 'paramiko.SSHClient.exec_command'
 
     def _exec_command_return_value(self, stdin='', stdout='mocked',


### PR DESCRIPTION
Don't add credentials to devices that don't have a config yet
but create the Credential anyways.

Fixes #172