### PR TITLE
[deps] Pin celery to 4.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ django-loci>=0.3.1,<0.4.0
 djangorestframework-gis>=0.12.0,<0.16.0
 paramiko>=2.7.1,<2.8.0
 scp>=0.13.0,<0.14.0
-celery>=4.2.0,<4.5.0
+celery==4.4.2
 redis>=3.4.1,<4.0.0


### PR DESCRIPTION
Pin celery to 4.4.2.

Related to https://github.com/openwisp/openwisp-firmware-upgrader/issues/78