### PR TITLE
[fix] add missing legacy vpn backend migration #234

### DIFF
--- a/openwisp_controller/config/migrations/0032_update_legacy_vpn_backend.py
+++ b/openwisp_controller/config/migrations/0032_update_legacy_vpn_backend.py
@@ -1,5 +1,3 @@
-# Manually Create Migration
-
 from django.db import migrations
 
 

--- a/openwisp_controller/config/migrations/0032_update_legacy_vpn_backend.py
+++ b/openwisp_controller/config/migrations/0032_update_legacy_vpn_backend.py
@@ -1,0 +1,23 @@
+# Manually Create Migration
+
+from django.db import migrations
+
+
+def update_legacy_vpn_backend(apps, schema_editor):
+    Vpn = apps.get_model('config', 'Vpn')
+    Vpn.objects.filter(backend='django_netjsonconfig.vpn_backends.OpenVpn').update(
+        backend='openwisp_controller.vpn_backends.OpenVpn'
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('config', '0031_update_vpn_dh_param'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_legacy_vpn_backend, reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
1. Tested with upgrading a vpn created from version 0.7.0post1
2. Sorry I missed this bug, it's second in the same PR! :sweat: 

Closes #234