### PR TITLE
[fix] Avoid triggering config_modified during registration

### DIFF
--- a/openwisp_controller/config/apps.py
+++ b/openwisp_controller/config/apps.py
@@ -34,17 +34,22 @@ class ConfigConfig(AppConfig):
         m2m_changed.connect(
             self.config_model.clean_templates,
             sender=self.config_model.templates.through,
+            dispatch_uid='config.clean_templates',
         )
         m2m_changed.connect(
             self.config_model.templates_changed,
             sender=self.config_model.templates.through,
+            dispatch_uid='config.templates_changed',
         )
         m2m_changed.connect(
             self.config_model.manage_vpn_clients,
             sender=self.config_model.templates.through,
+            dispatch_uid='config.manage_vpn_clients',
         )
         post_delete.connect(
-            self.vpnclient_model.post_delete, sender=self.vpnclient_model
+            self.vpnclient_model.post_delete,
+            sender=self.vpnclient_model,
+            dispatch_uid='vpnclient.post_delete',
         )
 
     def add_default_menu_items(self):

--- a/openwisp_controller/config/tests/test_template.py
+++ b/openwisp_controller/config/tests/test_template.py
@@ -98,6 +98,8 @@ class TestTemplate(
         temp = self._create_template()
         conf = self._create_config(device=self._create_device(name='test-status'))
         self.assertEqual(conf.status, 'modified')
+        # refresh instance to reset _just_created attribute
+        conf = Config.objects.get(pk=conf.pk)
 
         with catch_signal(config_modified) as handler:
             conf.templates.add(temp)


### PR DESCRIPTION
If SSH push is configured, `config_modified` triggers an attempt to connect to the device, which will fail when a device has just registered.