### PR TITLE
[change] Avoid need of DJANGO_X509_CA_MODEL, DJANGO_X509_CERT_MODEL

### DIFF
--- a/openwisp_controller/pki/apps.py
+++ b/openwisp_controller/pki/apps.py
@@ -1,5 +1,11 @@
 from django.apps import AppConfig
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
+
+if not hasattr(settings, 'DJANGO_X509_CA_MODEL'):
+    setattr(settings, 'DJANGO_X509_CA_MODEL', 'pki.Ca')
+if not hasattr(settings, 'DJANGO_X509_CERT_MODEL'):
+    setattr(settings, 'DJANGO_X509_CERT_MODEL', 'pki.Cert')
 
 
 class PkiConfig(AppConfig):

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -216,8 +216,10 @@ if os.environ.get('SAMPLE_APP', False):
     CONNECTION_CREDENTIALS_MODEL = 'sample_connection.Credentials'
     CONNECTION_DEVICECONNECTION_MODEL = 'sample_connection.DeviceConnection'
 else:
-    DJANGO_X509_CA_MODEL = 'pki.Ca'
-    DJANGO_X509_CERT_MODEL = 'pki.Cert'
+    # not needed, these are the default values, left here only for example purposes
+    # DJANGO_X509_CA_MODEL = 'pki.Ca'
+    # DJANGO_X509_CERT_MODEL = 'pki.Cert'
+    pass
 
 # local settings must be imported before test runner otherwise they'll be ignored
 try:


### PR DESCRIPTION
Let's keep things simple for our users.
The pki models are the default ones, there's no need to require users to set the setting explicitly.

This also simplifies things in ansible-openwisp2, docker-openwisp,
openwisp-monitoring and openwisp-firmware-upgrader, since we won't
have to update the settings of those projects, things will just keep working normally.

I think this is the approach to follow whenever a new setting is added,
we should provide a default value and avoid having the user to define it
explicitly.