### PR TITLE
[config] Fix OPENWISP_CONTROLLER_BACKEND_DEVICE_LIST = False

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -461,7 +461,6 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, UUIDAdmin):
 
 if not app_settings.BACKEND_DEVICE_LIST:  # pragma: nocover
     DeviceAdmin.list_display.remove('backend')
-    DeviceAdmin.list_filter.remove('config__backend')
 
 
 class CloneOrganizationForm(forms.Form):


### PR DESCRIPTION
If OPENWISP_CONTROLLER_BACKEND_DEVICE_LIST is false, the config__backend
filter was not being inserted, so removing it fails.