### PR TITLE
[fix] Validate Config.context and Template.default_values

### DIFF
--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -253,10 +253,17 @@ class AbstractConfig(BaseConfig):
 
     def clean(self):
         """
-        modifies status if key attributes of the configuration
-        have changed (queries the database)
+        * validates context field
+        * modifies status if key attributes of the configuration
+          have changed (queries the database)
         """
         super().clean()
+        if not self.context:
+            self.context = {}
+        if not isinstance(self.context, dict):
+            raise ValidationError(
+                {'context': _('the supplied value is not a JSON object')}
+            )
         if self._state.adding:
             return
         current = self.__class__.objects.get(pk=self.pk)

--- a/openwisp_controller/config/base/template.py
+++ b/openwisp_controller/config/base/template.py
@@ -129,11 +129,19 @@ class AbstractTemplate(ShareableOrgMixin, BaseConfig):
 
     def clean(self, *args, **kwargs):
         """
+        * validates org relationship of VPN if present
+        * validates default_values field
         * ensures VPN is selected if type is VPN
         * clears VPN specific fields if type is not VPN
         * automatically determines configuration if necessary
         """
         self._validate_org_relation('vpn')
+        if not self.default_values:
+            self.default_values = {}
+        if not isinstance(self.default_values, dict):
+            raise ValidationError(
+                {'default_values': _('the supplied value is not a JSON object')}
+            )
         if self.type == 'vpn' and not self.vpn:
             raise ValidationError(
                 {'vpn': _('A VPN must be selected when template type is "VPN"')}


### PR DESCRIPTION
Config.context and Template.default_values must always be a dictionary.
Falsy values will be converted to empty dictionary automatically.