### PR TITLE
[feature] Allow using a different device model in update_config #291

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -182,3 +182,10 @@ class AbstractDevice(OrgMixin, BaseModel):
         config = self.get_config_model()(**options)
         config.device = self
         return config
+
+    def can_be_updated(self):
+        """
+        returns True if the device can and should be updated
+        can be overridden with custom logic if needed
+        """
+        return self.config.status != 'applied'

--- a/openwisp_controller/connection/settings.py
+++ b/openwisp_controller/connection/settings.py
@@ -22,3 +22,6 @@ SSH_AUTH_TIMEOUT = getattr(settings, 'OPENWISP_SSH_AUTH_TIMEOUT', 2)
 SSH_BANNER_TIMEOUT = getattr(settings, 'OPENWISP_SSH_BANNER_TIMEOUT', 60)
 SSH_COMMAND_TIMEOUT = getattr(settings, 'OPENWISP_SSH_COMMAND_TIMEOUT', 30)
 SSH_CONNECTION_TIMEOUT = getattr(settings, 'OPENWISP_SSH_CONNECTION_TIMEOUT', 5)
+
+# this may get overridden by openwisp-monitoring
+UPDATE_CONFIG_MODEL = getattr(settings, 'OPENWISP_UPDATE_CONFIG_MODEL', 'config.Device')

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -1,11 +1,12 @@
 import logging
 import time
 
+import swapper
 from celery import shared_task
 from django.core.exceptions import ObjectDoesNotExist
-from swapper import load_model
 
-Device = load_model('config', 'Device')
+from . import settings as app_settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,13 +16,15 @@ def update_config(device_id):
     Launches the ``update_config()`` operation
     of a specific device in the background
     """
+    Device = swapper.load_model(*swapper.split(app_settings.UPDATE_CONFIG_MODEL))
     # wait for the saving operations of this device to complete
     # (there may be multiple ones happening at the same time)
     time.sleep(2)
     try:
         device = Device.objects.select_related('config').get(pk=device_id)
-        # avoid repeating the operation multiple times
-        if device.config.status == 'applied':
+        # abort operation if device shouldn't be updated
+        if not device.can_be_updated():
+            logger.info(f'{device} (pk: {device_id}) is not going to be updated')
             return
     except ObjectDoesNotExist as e:
         logger.warning(f'update_config("{device_id}") failed: {e}')
@@ -29,4 +32,5 @@ def update_config(device_id):
     qs = device.deviceconnection_set.filter(device_id=device_id, enabled=True)
     conn = qs.first()
     if conn:
+        logger.info(f'Updating {device} (pk: {device_id})')
         conn.update_config()


### PR DESCRIPTION
This allows openwisp-monitoring to override the can_be_updated
method to take into account the monitoring status, so that
push updates won't be attempted

Related to #291