### PR TITLE
[enhancement] Changed "DeviceConnection.failure_reason" field to TextField #298

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -181,9 +181,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
     )
     # usability improvements
     is_working = models.BooleanField(null=True, blank=True, default=None)
-    failure_reason = models.CharField(
-        _('reason of failure'), max_length=128, blank=True
-    )
+    failure_reason = models.TextField(_('reason of failure'), blank=True)
     last_attempt = models.DateTimeField(blank=True, null=True)
 
     class Meta:

--- a/openwisp_controller/connection/migrations/0005_device_connection_failure_reason.py
+++ b/openwisp_controller/connection/migrations/0005_device_connection_failure_reason.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+def truncate_failure_reason(apps, schema_editor):
+    DeviceConnection = apps.get_model('connection', 'DeviceConnection')
+
+    for device_connection in DeviceConnection.objects.iterator():
+        device_connection.failure_reason = device_connection.failure_reason[:128]
+        device_connection.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('connection', '0004_django3_1_upgrade'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='deviceconnection',
+            name='failure_reason',
+            field=models.TextField(blank=True, verbose_name='reason of failure'),
+        ),
+        migrations.RunPython(migrations.RunPython.noop, truncate_failure_reason,),
+    ]

--- a/tests/openwisp2/sample_connection/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_connection/migrations/0001_initial.py
@@ -176,9 +176,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     'failure_reason',
-                    models.CharField(
-                        blank=True, max_length=128, verbose_name='reason of failure'
-                    ),
+                    models.TextField(blank=True, verbose_name='reason of failure'),
                 ),
                 ('last_attempt', models.DateTimeField(blank=True, null=True)),
                 ('details', models.CharField(blank=True, max_length=64, null=True)),


### PR DESCRIPTION
Changed "openwisp_controller.connection.base.models.DeviceConnection" to
"TextField" from "CharField" with limited size.

This mitigates long failed_reason ending up in "django.db.utils.DataError"
error.

Fixes #298