### PR TITLE
[urls] Moved schema.json url to common path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Version 0.8.0 [unreleased]
   but will be removed in the future
 - [api] Added `API documentation <https://github.com/openwisp/openwisp-controller#geo-app>`_
 - improved documentation
+- [change] **Backward incompatible change**: schema url endpoint changed to ``<controller-url>/config/schema.json`` and it's now in config namespace instead of admin namespace.
 
 Version 0.7.0.post1 [2020-07-01]
 --------------------------------

--- a/README.rst
+++ b/README.rst
@@ -1589,9 +1589,10 @@ sample_pki
         # url(r'^controller/', include((get_controller_urls(config_views), 'controller'), namespace='controller'))
 
         # Use only when changing geo API views (discussed below)
-        # url(r'^geo/', include((get_geo_urls(geo_views), 'geo'), namespace='geo'),),
+        # url(r'^geo/', include((get_geo_urls(geo_views), 'geo'), namespace='geo')),
 
         # openwisp-controller urls
+        url(r'', include(('openwisp_controller.config.urls', 'config'), namespace='config')),
         url(r'', include('openwisp_controller.urls')),
     ]
 

--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -35,7 +35,6 @@ from ..admin import MultitenantAdminMixin
 from ..pki.base import PkiReversionTemplatesMixin
 from . import settings as app_settings
 from .utils import send_file
-from .views import schema
 from .widgets import JsonSchemaWidget
 
 logger = logging.getLogger(__name__)
@@ -132,7 +131,6 @@ class BaseConfigAdmin(BaseAdmin):
                 self.admin_site.admin_view(self.context_view),
                 name='{0}_context'.format(url_prefix),
             ),
-            url(r'^netjsonconfig/schema\.json$', schema, name='schema'),
         ] + super().get_urls()
 
     def _get_config_model(self):

--- a/openwisp_controller/config/tests/test_views.py
+++ b/openwisp_controller/config/tests/test_views.py
@@ -25,13 +25,13 @@ class TestViews(
         )
 
     def test_schema_403(self):
-        response = self.client.get(reverse('admin:schema'))
+        response = self.client.get(reverse('config:schema'))
         self.assertEqual(response.status_code, 403)
         self.assertIn('error', response.json())
 
     def test_schema_200(self):
         self.client.force_login(User.objects.get(username='admin'))
-        response = self.client.get(reverse('admin:schema'))
+        response = self.client.get(reverse('config:schema'))
         self.assertEqual(response.status_code, 200)
         self.assertIn('netjsonconfig.OpenWrt', response.json())
 

--- a/openwisp_controller/config/urls.py
+++ b/openwisp_controller/config/urls.py
@@ -1,7 +1,8 @@
-"""
-There are no urls in this file. It has no functional use.
-This file exists only to maintain backward compatibility.
-"""
+from django.urls import path
 
-app_name = 'openwisp_controller'  # pragma: no cover
-urlpatterns = []  # pragma: no cover
+from .views import schema
+
+app_name = 'openwisp_controller'
+urlpatterns = [
+    path('config/schema.json', schema, name='schema'),
+]

--- a/openwisp_controller/config/widgets.py
+++ b/openwisp_controller/config/widgets.py
@@ -9,7 +9,7 @@ class JsonSchemaWidget(AdminTextareaWidget):
     JSON Schema Editor widget
     """
 
-    schema_view_name = 'admin:schema'
+    schema_view_name = 'config:schema'
     netjsonconfig_hint = True
     extra_attrs = {}
     advanced_mode = True

--- a/openwisp_controller/urls.py
+++ b/openwisp_controller/urls.py
@@ -32,6 +32,12 @@ url_metadata = [
         'app': 'openwisp_controller.geo',
         'include': {'module': '{app}.api.urls', 'namespace': 'geo'},
     },
+    # openwisp_controller.config
+    {
+        'regexp': r'^',
+        'app': 'openwisp_controller.config',
+        'include': {'module': '{app}.urls', 'namespace': 'config'},
+    },
 ]
 
 urlpatterns = []

--- a/tests/openwisp2/urls.py
+++ b/tests/openwisp2/urls.py
@@ -27,7 +27,11 @@ if os.environ.get('SAMPLE_APP', False):
                 namespace='controller',
             ),
         ),
-        url(r'^geo/', include((get_geo_urls(geo_views), 'geo'), namespace='geo'),),
+        url(
+            r'',
+            include(('openwisp_controller.config.urls', 'config'), namespace='config'),
+        ),
+        url(r'^geo/', include((get_geo_urls(geo_views), 'geo'), namespace='geo')),
     ]
 
 urlpatterns += [


### PR DESCRIPTION
Current solution:
- Moved schema.json to a seperate url file in openwisp-controller and register it in the main urls file with `include()`. The problem with this approach is that it changes namespace of schema to `config_admin` from `admin`.

Other possible solutions:
1. Monkey-patch `OpenWISPAdminSite` (Avoiding)
2. Override `OpenWISPAdminSite` (Avoiding)
3. Register a hidden Adminclass, which includes the url.

Looking for best possible solution... 

Closes #304