### PR TITLE
[fix] Fixed regression in connection notifications #269

### DIFF
--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -75,7 +75,13 @@ class ConnectionConfig(AppConfig):
         return False
 
     @classmethod
-    def is_working_changed_receiver(cls, instance, is_working, **kwargs):
+    def is_working_changed_receiver(
+        cls, instance, is_working, old_is_working, **kwargs
+    ):
+        # if old_is_working is None, it's a new device connection which wasn't
+        # used yet, so nothing is really changing and we won't notify the user
+        if old_is_working is None:
+            return
         device = instance.device
         notification_opts = dict(sender=instance, target=device)
         if not is_working:


### PR DESCRIPTION
- notifications should not be generated when is_working is None (new device)
- tests were not running because were not inheriting TestCase, hence the code was not properly ported

Related to #269