### PR TITLE
[docs] Updated docs for deafult access credentials

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -832,6 +832,11 @@ OpenWISP will trigger the update in the background) and/or
 `firmware upgrades (via the additional module openwisp-firmware-upgrader)
 <https://github.com/openwisp/openwisp-firmware-upgrader>`_.
 
+**Note**: If you have installed OpenWISP with `openwisp2 Ansbile role <https://galaxy.ansible.com/openwisp/openwisp2>`_
+then you can skip the following steps. The Ansible role automatically creates a
+default template to update ``authorized_keys`` on networking devices using the
+default access credentials.
+
 1. Generate SSH key
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Using openwisp2 Ansible role does not require to manually configure
push updates.