### PR TITLE
[controller-tests] Avoid error logging to print noisy output during t…

### DIFF
--- a/openwisp_controller/config/tests/test_controller.py
+++ b/openwisp_controller/config/tests/test_controller.py
@@ -8,6 +8,7 @@ from swapper import load_model
 
 from openwisp_users.tests.utils import TestOrganizationMixin
 from openwisp_utils.tests import catch_signal
+from openwisp_utils.tests import capture_any_output
 
 from ..signals import (
     checksum_requested,
@@ -101,12 +102,14 @@ class TestController(
                 request=response.wsgi_request,
             )
 
+    @capture_any_output()
     def test_device_checksum_400(self):
         d = self._create_device_config()
         response = self.client.get(reverse('controller:device_checksum', args=[d.pk]))
         self.assertEqual(response.status_code, 400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_device_checksum_403(self):
         d = self._create_device_config()
         response = self.client.get(
@@ -159,6 +162,7 @@ class TestController(
                 request=response.wsgi_request,
             )
 
+    @capture_any_output()
     def test_device_download_config_400(self):
         d = self._create_device_config()
         response = self.client.get(
@@ -167,6 +171,7 @@ class TestController(
         self.assertEqual(response.status_code, 400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_device_download_config_403(self):
         d = self._create_device_config()
         path = reverse('controller:device_download_config', args=[d.pk])
@@ -196,12 +201,14 @@ class TestController(
         )
         self.assertEqual(response.status_code, 404)
 
+    @capture_any_output()
     def test_vpn_checksum_400(self):
         v = self._create_vpn()
         response = self.client.get(reverse('controller:vpn_checksum', args=[v.pk]))
         self.assertEqual(response.status_code, 400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_vpn_checksum_403(self):
         v = self._create_vpn()
         response = self.client.get(
@@ -234,6 +241,7 @@ class TestController(
         )
         self.assertEqual(response.status_code, 404)
 
+    @capture_any_output()
     def test_vpn_download_config_400(self):
         v = self._create_vpn()
         response = self.client.get(
@@ -242,6 +250,7 @@ class TestController(
         self.assertEqual(response.status_code, 400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_vpn_download_config_403(self):
         v = self._create_vpn()
         path = reverse('controller:vpn_download_config', args=[v.pk])
@@ -312,6 +321,7 @@ class TestController(
         )
         self.assertContains(response, 'already exists', status_code=400)
 
+    @capture_any_output()
     def test_register_failed_creation_wrong_backend(self):
         self.test_register()
         response = self.client.post(
@@ -510,6 +520,7 @@ class TestController(
         )
         self.assertEqual(response.status_code, 404)
 
+    @capture_any_output()
     def test_device_report_status_400(self):
         d = self._create_device_config()
         response = self.client.post(
@@ -528,6 +539,7 @@ class TestController(
         self.assertEqual(response.status_code, 400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_device_report_status_403(self):
         d = self._create_device_config()
         response = self.client.post(
@@ -601,6 +613,7 @@ class TestController(
         self.assertEqual(response.status_code, 400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_device_update_info_403(self):
         d = self._create_device_config()
         params = {
@@ -763,6 +776,7 @@ class TestController(
         self.assertEqual(d.config.templates.filter(pk=t_shared.pk).count(), 1)
         self.assertEqual(d.config.templates.filter(pk=t2.pk).count(), 0)
 
+    @capture_any_output()
     def test_register_400(self):
         self._get_org()
         # missing secret
@@ -811,6 +825,7 @@ class TestController(
         self.assertContains(response, 'mac_address', status_code=400)
         self._check_header(response)
 
+    @capture_any_output()
     def test_register_403(self):
         self._get_org()
         # wrong secret
@@ -839,6 +854,7 @@ class TestController(
         self.assertContains(response, 'wrong backend', status_code=403)
         self._check_header(response)
 
+    @capture_any_output()
     def test_register_403_disabled_registration(self):
         org = self._get_org()
         org.config_settings.registration_enabled = False
@@ -859,6 +875,7 @@ class TestController(
         ).count()
         self.assertEqual(count, 0)
 
+    @capture_any_output()
     def test_register_403_disabled_org(self):
         self._create_org(is_active=False)
         response = self.client.post(

--- a/openwisp_controller/config/tests/test_controller.py
+++ b/openwisp_controller/config/tests/test_controller.py
@@ -7,8 +7,7 @@ from django.urls import reverse
 from swapper import load_model
 
 from openwisp_users.tests.utils import TestOrganizationMixin
-from openwisp_utils.tests import catch_signal
-from openwisp_utils.tests import capture_any_output
+from openwisp_utils.tests import capture_any_output, catch_signal
 
 from ..signals import (
     checksum_requested,

--- a/openwisp_controller/connection/connectors/exceptions.py
+++ b/openwisp_controller/connection/connectors/exceptions.py
@@ -1,6 +1,12 @@
+from openwisp_utils.tests import capture_any_output
+
+@capture_any_output()
 class CommandFailedException(Exception):
+
+
     """
     raised when a command returns an unexpected result
     """
+
 
     pass

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -9,6 +9,7 @@ from swapper import load_model
 
 from openwisp_users.models import Group, Organization
 from openwisp_utils.tests import catch_signal
+from openwisp_utils.tests import capture_any_output
 
 from .. import settings as app_settings
 from ..apps import _TASK_NAME
@@ -262,6 +263,7 @@ class TestModels(BaseTestModels, TestCase):
         self.assertEqual(Credentials.objects.count(), 1)
 
     @mock.patch(_connect_path)
+    @capture_any_output()
     def test_ssh_exec_exit_code(self, *args):
         ckey = self._create_credentials_with_key(port=self.ssh_server.port)
         dc = self._create_device_connection(credentials=ckey)
@@ -274,6 +276,7 @@ class TestModels(BaseTestModels, TestCase):
             mocked.assert_called_once()
 
     @mock.patch(_connect_path)
+    @capture_any_output()
     def test_ssh_exec_timeout(self, *args):
         ckey = self._create_credentials_with_key(port=self.ssh_server.port)
         dc = self._create_device_connection(credentials=ckey)
@@ -286,6 +289,7 @@ class TestModels(BaseTestModels, TestCase):
             mocked.assert_called_once()
 
     @mock.patch(_connect_path)
+    @capture_any_output()
     def test_ssh_exec_exception(self, *args):
         ckey = self._create_credentials_with_key(port=self.ssh_server.port)
         dc = self._create_device_connection(credentials=ckey)

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -8,8 +8,7 @@ from django.test import TestCase, TransactionTestCase
 from swapper import load_model
 
 from openwisp_users.models import Group, Organization
-from openwisp_utils.tests import catch_signal
-from openwisp_utils.tests import capture_any_output
+from openwisp_utils.tests import capture_any_output, catch_signal
 
 from .. import settings as app_settings
 from ..apps import _TASK_NAME

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -402,6 +402,7 @@ class TestModelsTransaction(BaseTestModels, TransactionTestCase):
         conf.full_clean()
         return conf
 
+    @capture_any_output()
     @mock.patch(_connect_path)
     @mock.patch('time.sleep')
     def test_device_config_update(self, mocked_sleep, mocked_connect):


### PR DESCRIPTION
…ests #187

Identified and marked all the noisy tests with @capture_any_output decorator to reduce noise.

Fixes #187