### PR TITLE
[deps] Drop support for Django 2.2 #297

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           - 3.6
           - 3.7
         django-version:
-          - django~=2.2
+          
           - django~=3.0
           - django~=3.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
           - 3.6
           - 3.7
         django-version:
-          
           - django~=3.0
           - django~=3.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=2.2,<3.2
+django>=3.0,<3.2
 django-sortedm2m>=3.0.0,<3.1.0
 django-reversion>=3.0.5,<3.1.0
 django-x509~=0.9.2


### PR DESCRIPTION
Edited the files that supported Django 2.2 , removed its support and upgraded the version to Django 3.0

Fixes #297