### PR TITLE
[fix] Hardened config validation of OpenVpn backend

### DIFF
--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -73,9 +73,15 @@ class TestVpn(
             backend='openwisp_controller.vpn_backends.OpenVpn',
             config=config,
         )
-        # ensure django ValidationError is raised
-        with self.assertRaises(ValidationError):
-            v.full_clean()
+        with self.subTest('test invalid openvpn key'):
+            with self.assertRaises(ValidationError):
+                v.full_clean()
+
+        with self.subTest('test missing openvpn key'):
+            del v.backend_instance
+            v.config = {'files': []}
+            with self.assertRaises(ValidationError):
+                v.full_clean()
 
     def test_json(self):
         v = self._create_vpn()
@@ -143,6 +149,7 @@ class TestVpn(
             ca=different_ca,
             cert=cert,
             backend='openwisp_controller.vpn_backends.OpenVpn',
+            config=self._vpn_config,
         )
         try:
             vpn.full_clean()

--- a/openwisp_controller/vpn_backends.py
+++ b/openwisp_controller/vpn_backends.py
@@ -17,6 +17,8 @@ limited_schema['properties']['openvpn']['items'].update(
         ]
     }
 )
+limited_schema['required'] = limited_schema.get('required', [])
+limited_schema['required'].append('openvpn')
 
 # default values for ca, cert and key
 limited_schema['definitions']['tunnel']['properties']['ca']['default'] = 'ca.pem'


### PR DESCRIPTION
If the config misses the "openvpn" key, validation must fail, because it is surely a mistake.