### PR TITLE
[change] Reworked config_modified signal implementation

### DIFF
--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -426,8 +426,3 @@ class AbstractConfig(BaseConfig):
 
 
 AbstractConfig._meta.get_field('config').blank = True
-
-# kept for backward compatibility to avoid
-# breaking openwisp-controller 0.2.x
-# TODO: remove in 0.7.x
-sortedm2m__str__ = TemplatesThrough.__str__

--- a/openwisp_controller/config/base/template.py
+++ b/openwisp_controller/config/base/template.py
@@ -127,13 +127,13 @@ class AbstractTemplate(ShareableOrgMixinUniqueName, BaseConfig):
             )
 
     def _update_related_config_status(self):
-        changing_status = list(self.config_relations.exclude(status='modified'))
+        changing_status = list(self.config_relations.exclude(status='modified').values_list('pk', flat=True))
         self.config_relations.update(status='modified')
         for config in self.config_relations.select_related('device').iterator():
             # config modified signal sent regardless
             config._send_config_modified_signal()
             # config status changed signal sent only if status changed
-            if config in changing_status:
+            if config.pk in changing_status:
                 config._send_config_status_changed_signal()
 
     def clean(self, *args, **kwargs):

--- a/openwisp_controller/config/signals.py
+++ b/openwisp_controller/config/signals.py
@@ -4,7 +4,9 @@ checksum_requested = Signal(providing_args=['instance', 'request'])
 config_download_requested = Signal(providing_args=['instance', 'request'])
 config_status_changed = Signal(providing_args=['instance'])
 # device and config args are maintained for backward compatibility
-config_modified = Signal(providing_args=['instance', 'device', 'config'])
+config_modified = Signal(
+    providing_args=['instance', 'device', 'config', 'previous_status', 'action']
+)
 device_registered = Signal(providing_args=['instance', 'is_new'])
 management_ip_changed = Signal(
     providing_args=['instance', 'management_ip', 'old_management_ip']

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -167,6 +167,7 @@ if not TESTING and SHELL:
         }
     )
 
+DJANGO_LOCI_GEOCODE_STRICT_TEST = False
 OPENWISP_CONTROLLER_CONTEXT = {'vpnserver1': 'vpn.testdomain.com'}
 
 TEST_RUNNER = 'openwisp_utils.tests.TimeLoggingTestRunner'


### PR DESCRIPTION
- the signal is now always emitted on templates changes m2m events,
  also if config.status is modified, with the differences that
  only post_add and post_remove m2m events are used, while
  post_clear is ignored, which fixes the duplicate signal emission
  caused by the implementation of sortedm2m;
  i made sure to document these details in the README
- added action and previous_status arguments, which allow to
  understand where the config_modified signal is being emitted from,
  this allows more advanced usage of the signal by custom implementations

Closes #394