### PR TITLE
[fix] Unsaved changes js trigger when device have location defined #388

### DIFF
--- a/openwisp_controller/config/static/config/js/unsaved_changes.js
+++ b/openwisp_controller/config/static/config/js/unsaved_changes.js
@@ -12,7 +12,9 @@
                     name == 'csrfmiddlewaretoken' ||
                     // ignore hidden inline helper fields
                     name.indexOf('__prefix__') >= 0 ||
-                    name.indexOf('root') === 0) {
+                    name.indexOf('root') === 0 ||
+                    // ignore device location field
+                    name.substr(0, 14) == 'devicelocation') {
                     return;
                 }
                 // fix checkbox values inconsistency


### PR DESCRIPTION
Unsaved changes js is triggered when device have geographic location defined,
fixed it by ignoring the input field for device location inside `unsaved_changes.js`

Fixes #388