### PR TITLE
[fix] Update related config when template default_values are changed

### DIFF
--- a/openwisp_controller/config/tests/test_template.py
+++ b/openwisp_controller/config/tests/test_template.py
@@ -657,11 +657,27 @@ class TestTemplateTransaction(
             conf.set_status_applied()
             mocked_task.assert_not_called()
 
-        with self.subTest('task is called when template is assigned to conf'):
+        with self.subTest('task is called when template conf is changed'):
             template.config['interfaces'][0]['name'] = 'eth1'
             template.full_clean()
             template.save()
             mocked_task.assert_called_with(template.pk)
+
+        mocked_task.reset_mock()
+
+        with self.subTest('task is called when template default_values are changed'):
+            template.refresh_from_db()
+            template.default_values = {'a': 'a'}
+            template.full_clean()
+            template.save()
+            mocked_task.assert_called_with(template.pk)
+
+        mocked_task.reset_mock()
+
+        with self.subTest('task is not called when there are no changes'):
+            template.full_clean()
+            template.save()
+            mocked_task.assert_not_called()
 
     @mock.patch.object(task_logger, 'warning')
     def test_task_failure(self, mocked_warning):


### PR DESCRIPTION
The config related to a template were not being flagged for update
when default_values were changed.
Moreover, during debugging, I found out that in some cases
the action was being performed even if there were no real changes,
the only difference being the new value was an instance of dict
while the value loaded from the model is an instance of OrderedDict.

This change fixes both issues.