### PR TITLE
[change] Move changes check to save methods

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -167,6 +167,17 @@ class AbstractDevice(OrgMixin, BaseModel):
 
         self.check_management_ip_changed()
 
+    def _check_management_ip_changed(self):
+        if self.management_ip != self._initial_management_ip:
+            management_ip_changed.send(
+                sender=self.__class__,
+                management_ip=self.management_ip,
+                old_management_ip=self._initial_management_ip,
+                instance=self,
+            )
+
+        self._initial_management_ip = self.management_ip
+
     @property
     def backend(self):
         """
@@ -209,14 +220,3 @@ class AbstractDevice(OrgMixin, BaseModel):
         can be overridden with custom logic if needed
         """
         return self.config.status != 'applied'
-
-    def check_management_ip_changed(self):
-        if self.management_ip != self._initial_management_ip:
-            management_ip_changed.send(
-                sender=self.__class__,
-                management_ip=self.management_ip,
-                old_management_ip=self._initial_management_ip,
-                instance=self,
-            )
-
-        self._initial_management_ip = self.management_ip

--- a/openwisp_controller/config/tests/test_config.py
+++ b/openwisp_controller/config/tests/test_config.py
@@ -584,10 +584,6 @@ class TestConfig(
         with catch_signal(config_status_changed) as handler:
             c.config = {'general': {'description': 'test'}}
             c.full_clean()
-            self.assertEqual(c.status, 'modified')
-            handler.assert_not_called()
-
-        with catch_signal(config_status_changed) as handler:
             c.save()
             handler.assert_called_once_with(
                 sender=Config, signal=config_status_changed, instance=c
@@ -611,15 +607,6 @@ class TestConfig(
         with catch_signal(config_modified) as handler:
             c.config = {'general': {'description': 'test'}}
             c.full_clean()
-            handler.assert_not_called()
-            self.assertEqual(c.status, 'modified')
-
-        with catch_signal(config_modified) as handler:
-            c.config = {'general': {'description': 'hey'}}
-            c.full_clean()
-            handler.assert_not_called()
-
-        with catch_signal(config_modified) as handler:
             c.save()
             handler.assert_called_once_with(
                 sender=Config,
@@ -648,6 +635,11 @@ class TestConfig(
                 action='config_changed',
             )
             self.assertEqual(c.status, 'modified')
+
+    def test_check_changes_query(self):
+        config = self._create_config(organization=self._get_org())
+        with self.assertNumQueries(1):
+            config._check_changes()
 
     def test_config_get_system_context(self):
         config = self._create_config(

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -65,7 +65,6 @@ class TestDevice(CreateConfigTemplateMixin, TestOrganizationMixin, TestCase):
         self.assertEqual(c.status, 'modified')
 
     def test_key_validator(self):
-
         d = Device(
             organization=self._get_org(),
             name='test',
@@ -313,3 +312,13 @@ class TestDevice(CreateConfigTemplateMixin, TestOrganizationMixin, TestCase):
             'Device with this Name and Organization already exists.',
             message_dict['__all__'],
         )
+
+    def test_check_name_changed_query(self):
+        org = self._get_org()
+        device = self._create_device(name='test', organization=org)
+        device.refresh_from_db()
+        with self.assertNumQueries(1):
+            device._check_name_changed()
+        with self.assertNumQueries(2):
+            device.name = 'changed'
+            device._check_name_changed()


### PR DESCRIPTION
[change] Perform checks for changed name or config during save()

Perform checks to know whether the device name has been changed
or the configuration details have changed during save() rather
than clean(), because clean() may be called multiple times
before save() and we want to execute these operations only once.