### PR TITLE
[fix] Fixed multiple requests made for fetching default template values #423

### DIFF
--- a/openwisp_controller/config/static/config/js/default_templates.js
+++ b/openwisp_controller/config/static/config/js/default_templates.js
@@ -42,8 +42,11 @@ django.jQuery(function ($) {
             $.get(url).done(function (data) {
                 unCheckInputs();
                 $.each(data.default_templates, function (i, uuid) {
-                    $('input.sortedm2m[value=' + uuid + ']').trigger('click');
+                    $('input.sortedm2m[value=' + uuid + ']').prop('checked', true);
                 });
+                $('input[name="config-0-templates"]').attr('value', data.default_templates.join(','));
+                $('.sortedm2m-items:first').trigger('change');
+
             });
         },
         bindDefaultTemplateLoading = function (urls) {

--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -333,12 +333,6 @@
             }
         });
 
-        // fill device context field with default values of selected templates.
-        getDefaultValues(true);
-
-        $('.sortedm2m-items').on('change', function() {
-            getDefaultValues();
-        });
         // so that other files can use updateContext
         window.updateContext = updateContext;
     };
@@ -368,6 +362,11 @@
                 }
                 $(document).trigger('jsonschema-schemaloaded');
             });
+        });
+        // fill device context field with default values of selected templates.
+        getDefaultValues(true);
+        $('.sortedm2m-items').on('change', function() {
+            getDefaultValues();
         });
     };
 

--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -363,11 +363,6 @@
                 $(document).trigger('jsonschema-schemaloaded');
             });
         });
-        // fill device context field with default values of selected templates.
-        getDefaultValues(true);
-        $('.sortedm2m-items').on('change', function() {
-            getDefaultValues();
-        });
     };
 
     $(function () {
@@ -377,6 +372,11 @@
         addConfig.click(bindLoadUi);
         // otherwise load immediately
         bindLoadUi();
+        // fill device context field with default values of selected templates.
+        getDefaultValues(true);
+        $('.sortedm2m-items').on('change', function() {
+            getDefaultValues();
+        });
     });
 }(django.jQuery));
 


### PR DESCRIPTION
The JS code made multiple HTTP request for fetching default template
values when any of organization or backend field were updated.

Fixed it not triggering "click" event of sortedm2m-items and manaully
updating primary keys of templates using JS.

Closes #423