### PR TITLE
[docs] Fixed the typo of Geo App API Endpoint #430

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -182,7 +182,7 @@ endpoint, which provides a paginated list of such locations in GeoJSON format:
 
 .. code-block:: text
 
-    GET /api/v1/device/geojson/
+    GET /api/v1/location/geojson/
 
 Settings
 --------


### PR DESCRIPTION
closes #430