### PR TITLE
[fix] Fixed outdated failure reason for connection working notification #415

### DIFF
--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -25,6 +25,7 @@ class ConnectionConfig(AppConfig):
         which will be executed in the background
         """
         self.register_notification_types()
+        self.notification_cache_update()
         config_modified.connect(
             self.config_modified_receiver, dispatch_uid='connection.update_config'
         )
@@ -124,4 +125,13 @@ class ConnectionConfig(AppConfig):
                     'is {notification.verb}. {notification.actor.failure_reason}'
                 ),
             },
+        )
+
+    def notification_cache_update(self):
+        from openwisp_notifications.handlers import register_notification_cache_update
+
+        register_notification_cache_update(
+            model=load_model('connection', 'DeviceConnection'),
+            signal=is_working_changed,
+            dispatch_uid='notification_device_cache_invalidation',
         )

--- a/tests/openwisp2/sample_connection/tests.py
+++ b/tests/openwisp2/sample_connection/tests.py
@@ -8,6 +8,9 @@ from openwisp_controller.connection.tests.test_models import (
 from openwisp_controller.connection.tests.test_notifications import (
     TestNotifications as BaseTestNotifications,
 )
+from openwisp_controller.connection.tests.test_notifications import (
+    TestNotificationTransaction as BaseTestNotificationTransaction,
+)
 from openwisp_controller.connection.tests.test_ssh import TestSsh as BaseTestSsh
 
 
@@ -32,8 +35,13 @@ class TestNotifications(BaseTestNotifications):
     app_label = 'sample_connection'
 
 
+class TestNotificationTransaction(BaseTestNotificationTransaction):
+    app_label = 'sample_connection'
+
+
 del BaseTestAdmin
 del BaseTestModels
 del BaseTestModelsTransaction
 del BaseTestSsh
 del BaseTestNotifications
+del BaseTestNotificationTransaction


### PR DESCRIPTION
Invalidating cache using "openwisp_notification.handlers.register_notification_cache_update"
before creating notification fixed the issue. The notification module was using connection object from the cache
and not from the database.

Closes #415