### PR TITLE
[fix] Fixed JSONSchema editor select2 fields getting disabled #505

### DIFF
--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -845,3 +845,64 @@ JSONEditor.defaults.editors.multiple.prototype.setValue = function (val, initial
     this.refreshValue();
     self.onChange();
 };
+
+// Overriding following methods on the JSONEditor is required for
+// working of select2 fields. Refer to https://git.io/J4Qcp for
+// more information.
+JSONEditor.defaults.editors.select.prototype.enable = function () {
+    if (!this.always_disabled) {
+        this.input.disabled = false;
+        if (this.select2) {
+            this.select2.disabled = false;
+        }
+    }
+    this.disabled = false;
+};
+
+JSONEditor.defaults.editors.select.prototype.disable = function () {
+    this.input.disabled = true;
+    if (this.select2) {
+        this.select2.disabled = true;
+    }
+    this.disabled = true;
+};
+
+JSONEditor.defaults.editors.multiselect.prototype.enable = function () {
+    if (!this.always_disabled) {
+        if (this.input) {
+            this.input.disabled = false;
+        } else if (this.inputs) {
+            for (var i in this.inputs) {
+                if (!this.inputs.hasOwnProperty(i)) {
+                    continue;
+                }
+                this.inputs[i].disabled = false;
+            }
+        }
+        // Modified code begins
+        if (this.select2) {
+            this.select2.disabled = false;
+        }
+        this.disabled = false;
+        // Modified code ends
+    }
+};
+
+JSONEditor.defaults.editors.multiselect.prototype.disable = function () {
+    if (this.input) {
+        this.input.disabled = true;
+    } else if (this.inputs) {
+        for (var i in this.inputs) {
+            if (!this.inputs.hasOwnProperty(i)) {
+                continue;
+            }
+            this.inputs[i].disabled = true;
+        }
+    }
+    // Modified code begins
+    if (this.select2) {
+        this.select2.disabled = true;
+        this._super();
+        // Modified code ends
+    }
+};


### PR DESCRIPTION
The issue arose because the JSON Schema library uses selec2('enable') for
enabling or disabling select2 fields. According to the "Migrating from 3.5" section
in select2 documentation, select2('enable') has been deprecated.
The solution is to override the methods using it to simply modify
select2.disabled property.

Closes #505