### PR TITLE
[fix] Fixed advanced editor quirks #506

### DIFF
--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -70,7 +70,7 @@
         }
     },
     toggleFullScreen = function () {
-        var advanced = $('#advanced_editor');
+        var advanced = $('.advanced_editor:visible');
         if (!inFullScreenMode) {
             advanced.addClass('full-screen');
             $('html').addClass('editor-full');
@@ -88,8 +88,13 @@
     };
 
     var initAdvancedEditor = function (target, data, schema, disableSchema) {
-        var advanced = $("<div id='advanced_editor'></div>");
-        $(advanced).insertBefore($(target));
+        var advanced = $(target).prev('.advanced_editor');
+        if (advanced.length === 0){
+            advanced = $('<div class="advanced_editor"></div>');
+            $(advanced).insertBefore($(target));
+        } else {
+            advanced.empty();
+        }
         $(target).hide();
         // if disableSchema is true, do not validate againsts schema, default is false
         schema = disableSchema ? {} : schema;
@@ -106,7 +111,7 @@
             schema: schema
         };
 
-        var editor = new advancedJSONEditor(document.getElementById(advanced.attr('id')), options, data);
+        var editor = new advancedJSONEditor(advanced.get(0), options, data);
         editor.aceEditor.setOptions({
             fontSize: 14,
             showInvisibles: true
@@ -124,7 +129,7 @@
         // hide on esc button
         $('html').on('keydown', function (e) {
             if (inFullScreenMode && e.keyCode === 27) { // ESC
-                $('#advanced_editor').find('.jsoneditor-exit').click();
+                $('.advanced_editor:visible').find('.jsoneditor-exit').click();
             }
         });
         return editor;
@@ -234,7 +239,7 @@
         django._jsonEditors[id] = editor;
         // initialise advanced json editor here (disable schema validation in VPN admin)
         advancedEditor = initAdvancedEditor(field, value, options.schema, $('#vpn_form').length === 1);
-        $advancedEl = $('#advanced_editor');
+        $advancedEl = $(advancedEditor.container);
         getEditorValue = function () {
             return JSON.stringify(editor.getValue(), null, 4);
         };


### PR DESCRIPTION
Bugs fixed:
- Executing a command, would raise a 'Invalid JSON' alert in the
  advance mode of the configuration even if the JSON is valid
- The device page deals with two schema and the container for
  advance mode editor used 'id="advanced_editor"'. Fetching the advance
  mode editor using the 'id' always returned the first occurence
  (advance mode editor of configuration). This used to create multiple
  advance mode editor DOM elements inside the container all of which
  had their own event listeners. Hence, full screen toggling was not
  working properly.

Closes #506