### PR TITLE
[fix] Registered menu group in connection app #512

### DIFF
--- a/openwisp_controller/config/apps.py
+++ b/openwisp_controller/config/apps.py
@@ -87,39 +87,6 @@ class ConfigConfig(AppConfig):
 
     def register_menu_groups(self):
         register_menu_group(
-            position=30,
-            config={
-                'label': 'Configurations',
-                'items': {
-                    1: {
-                        'label': 'Templates',
-                        'model': get_model_name('config', 'Template'),
-                        'name': 'changelist',
-                        'icon': 'ow-template',
-                    },
-                    2: {
-                        'label': 'VPN Servers',
-                        'model': get_model_name('config', 'Vpn'),
-                        'name': 'changelist',
-                        'icon': 'ow-vpn',
-                    },
-                    3: {
-                        'label': 'Access Credentials',
-                        'model': get_model_name('connection', 'Credentials'),
-                        'name': 'changelist',
-                        'icon': 'ow-access-credential',
-                    },
-                    4: {
-                        'label': 'Device Groups',
-                        'model': get_model_name('config', 'DeviceGroup'),
-                        'name': 'changelist',
-                        'icon': 'ow-device-group',
-                    },
-                },
-                'icon': 'ow-config',
-            },
-        )
-        register_menu_group(
             position=20,
             config={
                 'label': 'Devices',

--- a/openwisp_controller/config/apps.py
+++ b/openwisp_controller/config/apps.py
@@ -95,6 +95,33 @@ class ConfigConfig(AppConfig):
                 'icon': 'ow-device',
             },
         )
+        register_menu_group(
+            position=30,
+            config={
+                'label': 'Configurations',
+                'items': {
+                    1: {
+                        'label': 'Templates',
+                        'model': get_model_name('config', 'Template'),
+                        'name': 'changelist',
+                        'icon': 'ow-template',
+                    },
+                    2: {
+                        'label': 'VPN Servers',
+                        'model': get_model_name('config', 'Vpn'),
+                        'name': 'changelist',
+                        'icon': 'ow-vpn',
+                    },
+                    4: {
+                        'label': 'Device Groups',
+                        'model': get_model_name('config', 'DeviceGroup'),
+                        'name': 'changelist',
+                        'icon': 'ow-device-group',
+                    },
+                },
+                'icon': 'ow-config',
+            },
+        )
 
     def register_notification_types(self):
         register_notification_type(

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1253,22 +1253,9 @@ class TestDeviceGroupAdmin(
         self.assertNotContains(response, 'Org2 APs')
 
     def test_admin_menu_groups(self):
-        # Test menu group (openwisp-utils menu group) for Device Group, Template
-        # and Vpn models
-        self.client.force_login(self._get_admin())
-        models = ['devicegroup', 'template', 'vpn']
-        response = self.client.get(reverse('admin:index'))
-        for model in models:
-            with self.subTest(f'test_admin_group_for_{model}_model'):
-                url = reverse(f'admin:{self.app_label}_{model}_changelist')
-                self.assertContains(response, f'<a class="mg-link" href="{url}">')
-        with self.subTest('test_configuration_group_is_registered'):
-            self.assertContains(
-                response,
-                '<div class="mg-dropdown-label">Configurations </div>',
-                html=True,
-            )
         # Test Device is registered as menu item
+        self.client.force_login(self._get_admin())
+        response = self.client.get(reverse('admin:index'))
         with self.subTest('test_device_is_registered_as_menu_item'):
             url = reverse(f'admin:{self.app_label}_device_changelist')
             self.assertContains(response, f'<a class="menu-item" href="{url}">')

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1253,9 +1253,22 @@ class TestDeviceGroupAdmin(
         self.assertNotContains(response, 'Org2 APs')
 
     def test_admin_menu_groups(self):
-        # Test Device is registered as menu item
+        # Test menu group (openwisp-utils menu group) for Device Group, Template
+        # and Vpn models
+        models = ['devicegroup', 'template', 'vpn']
         self.client.force_login(self._get_admin())
         response = self.client.get(reverse('admin:index'))
+        for model in models:
+            with self.subTest(f'test_menu_group_for_{model}_model'):
+                url = reverse(f'admin:{self.app_label}_{model}_changelist')
+                self.assertContains(response, f'<a class="mg-link" href="{url}">')
+        with self.subTest('test_configuration_group_is_registered'):
+            self.assertContains(
+                response,
+                '<div class="mg-dropdown-label">Configurations </div>',
+                html=True,
+            )
+        # Test Device is registered as menu item
         with self.subTest('test_device_is_registered_as_menu_item'):
             url = reverse(f'admin:{self.app_label}_device_changelist')
             self.assertContains(response, f'<a class="menu-item" href="{url}">')

--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -9,7 +9,7 @@ from openwisp_notifications.signals import notify
 from openwisp_notifications.types import register_notification_type
 from swapper import get_model_name, load_model
 
-from openwisp_utils.admin_theme.menu import MENU, ModelLink
+from openwisp_utils.admin_theme.menu import register_menu_subitem
 
 from ..config.signals import config_modified
 from .signals import is_working_changed
@@ -166,17 +166,13 @@ class ConnectionConfig(AppConfig):
         )
 
     def register_menu_groups(self):
-        config_group = MENU[30]
-        if config_group:
-            config_group.items.update(
-                {
-                    3: ModelLink(
-                        {
-                            'label': 'Access Credentials',
-                            'model': get_model_name('connection', 'Credentials'),
-                            'name': 'changelist',
-                            'icon': 'ow-access-credential',
-                        }
-                    )
-                }
-            )
+        register_menu_subitem(
+            group_position=30,
+            item_position=3,
+            config={
+                'label': _('Access Credentials'),
+                'model': get_model_name('connection', 'Credentials'),
+                'name': 'changelist',
+                'icon': 'ow-access-credential',
+            },
+        )

--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -7,7 +7,9 @@ from django.db.models.signals import post_save
 from django.utils.translation import ugettext_lazy as _
 from openwisp_notifications.signals import notify
 from openwisp_notifications.types import register_notification_type
-from swapper import load_model
+from swapper import get_model_name, load_model
+
+from openwisp_utils.admin_theme.menu import register_menu_group
 
 from ..config.signals import config_modified
 from .signals import is_working_changed
@@ -28,6 +30,7 @@ class ConnectionConfig(AppConfig):
         """
         self.register_notification_types()
         self.notification_cache_update()
+        self.register_menu_groups()
 
         Config = load_model('config', 'Config')
         Credentials = load_model('connection', 'Credentials')
@@ -160,4 +163,39 @@ class ConnectionConfig(AppConfig):
             model=load_model('connection', 'DeviceConnection'),
             signal=is_working_changed,
             dispatch_uid='notification_device_cache_invalidation',
+        )
+
+    def register_menu_groups(self):
+        register_menu_group(
+            position=30,
+            config={
+                'label': 'Configurations',
+                'items': {
+                    1: {
+                        'label': 'Templates',
+                        'model': get_model_name('config', 'Template'),
+                        'name': 'changelist',
+                        'icon': 'ow-template',
+                    },
+                    2: {
+                        'label': 'VPN Servers',
+                        'model': get_model_name('config', 'Vpn'),
+                        'name': 'changelist',
+                        'icon': 'ow-vpn',
+                    },
+                    3: {
+                        'label': 'Access Credentials',
+                        'model': get_model_name('connection', 'Credentials'),
+                        'name': 'changelist',
+                        'icon': 'ow-access-credential',
+                    },
+                    4: {
+                        'label': 'Device Groups',
+                        'model': get_model_name('config', 'DeviceGroup'),
+                        'name': 'changelist',
+                        'icon': 'ow-device-group',
+                    },
+                },
+                'icon': 'ow-config',
+            },
         )

--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -9,7 +9,7 @@ from openwisp_notifications.signals import notify
 from openwisp_notifications.types import register_notification_type
 from swapper import get_model_name, load_model
 
-from openwisp_utils.admin_theme.menu import register_menu_group
+from openwisp_utils.admin_theme.menu import MENU, ModelLink
 
 from ..config.signals import config_modified
 from .signals import is_working_changed
@@ -166,36 +166,17 @@ class ConnectionConfig(AppConfig):
         )
 
     def register_menu_groups(self):
-        register_menu_group(
-            position=30,
-            config={
-                'label': 'Configurations',
-                'items': {
-                    1: {
-                        'label': 'Templates',
-                        'model': get_model_name('config', 'Template'),
-                        'name': 'changelist',
-                        'icon': 'ow-template',
-                    },
-                    2: {
-                        'label': 'VPN Servers',
-                        'model': get_model_name('config', 'Vpn'),
-                        'name': 'changelist',
-                        'icon': 'ow-vpn',
-                    },
-                    3: {
-                        'label': 'Access Credentials',
-                        'model': get_model_name('connection', 'Credentials'),
-                        'name': 'changelist',
-                        'icon': 'ow-access-credential',
-                    },
-                    4: {
-                        'label': 'Device Groups',
-                        'model': get_model_name('config', 'DeviceGroup'),
-                        'name': 'changelist',
-                        'icon': 'ow-device-group',
-                    },
-                },
-                'icon': 'ow-config',
-            },
-        )
+        config_group = MENU[30]
+        if config_group:
+            config_group.items.update(
+                {
+                    3: ModelLink(
+                        {
+                            'label': 'Access Credentials',
+                            'model': get_model_name('connection', 'Credentials'),
+                            'name': 'changelist',
+                            'icon': 'ow-access-credential',
+                        }
+                    )
+                }
+            )

--- a/openwisp_controller/connection/tests/test_admin.py
+++ b/openwisp_controller/connection/tests/test_admin.py
@@ -126,23 +126,9 @@ class TestConnectionAdmin(TestAdminMixin, CreateConnectionsMixin, TestCase):
         models = ['credentials']
         response = self.client.get(reverse('admin:index'))
         for model in models:
-            with self.subTest(f'test_admin_group_for_{model}_model'):
+            with self.subTest(f'test_menu_group_for_{model}_model'):
                 url = reverse(f'admin:{self.app_label}_{model}_changelist')
                 self.assertContains(response, f'<a class="mg-link" href="{url}">')
-
-        # Test menu group (openwisp-utils menu group) for Device Group, Template
-        # and Vpn models
-        models = ['devicegroup', 'template', 'vpn']
-        for model in models:
-            with self.subTest(f'test_admin_group_for_{model}_model'):
-                url = reverse(f'admin:{self.config_app_label}_{model}_changelist')
-                self.assertContains(response, f'<a class="mg-link" href="{url}">')
-        with self.subTest('test_configuration_group_is_registered'):
-            self.assertContains(
-                response,
-                '<div class="mg-dropdown-label">Configurations </div>',
-                html=True,
-            )
 
 
 class TestCommandInlines(TestAdminMixin, CreateConnectionsMixin, TestCase):

--- a/openwisp_controller/connection/tests/test_admin.py
+++ b/openwisp_controller/connection/tests/test_admin.py
@@ -130,6 +130,20 @@ class TestConnectionAdmin(TestAdminMixin, CreateConnectionsMixin, TestCase):
                 url = reverse(f'admin:{self.app_label}_{model}_changelist')
                 self.assertContains(response, f'<a class="mg-link" href="{url}">')
 
+        # Test menu group (openwisp-utils menu group) for Device Group, Template
+        # and Vpn models
+        models = ['devicegroup', 'template', 'vpn']
+        for model in models:
+            with self.subTest(f'test_admin_group_for_{model}_model'):
+                url = reverse(f'admin:{self.config_app_label}_{model}_changelist')
+                self.assertContains(response, f'<a class="mg-link" href="{url}">')
+        with self.subTest('test_configuration_group_is_registered'):
+            self.assertContains(
+                response,
+                '<div class="mg-dropdown-label">Configurations </div>',
+                html=True,
+            )
+
 
 class TestCommandInlines(TestAdminMixin, CreateConnectionsMixin, TestCase):
     config_app_label = 'config'


### PR DESCRIPTION
Moved group registration and its test code to the connection app. And the device(including tests) is still being registered in the config app.

close #512 