### PR TITLE
[chores] Ensure Device.group.verbose_name is lowercase for consistency

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -68,7 +68,7 @@ class AbstractDevice(OrgMixin, BaseModel):
     notes = models.TextField(blank=True, help_text=_('internal notes'))
     group = models.ForeignKey(
         get_model_name('config', 'DeviceGroup'),
-        verbose_name=_('Group'),
+        verbose_name=_('group'),
         on_delete=models.SET_NULL,
         blank=True,
         null=True,

--- a/openwisp_controller/config/migrations/0036_device_group.py
+++ b/openwisp_controller/config/migrations/0036_device_group.py
@@ -93,7 +93,7 @@ class Migration(migrations.Migration):
                 null=True,
                 on_delete=django.db.models.deletion.SET_NULL,
                 to=swapper.get_model_name('config', 'DeviceGroup'),
-                verbose_name='Group',
+                verbose_name='group',
             ),
         ),
         migrations.RunPython(

--- a/tests/openwisp2/sample_config/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_config/migrations/0001_initial.py
@@ -720,7 +720,7 @@ class Migration(migrations.Migration):
                         null=True,
                         on_delete=django.db.models.deletion.SET_NULL,
                         to=swapper.get_model_name('config', 'DeviceGroup'),
-                        verbose_name='Group',
+                        verbose_name='group',
                     ),
                 ),
                 (


### PR DESCRIPTION
@pandafy let's ensure verbose names are always lowercase (they get converted to have the first letter uppercase if needed), unless the labels are acronyms.