### PR TITLE
[fix] Fix failed command suppressed output + fixed a few tests in TestSsh

### DIFF
--- a/openwisp_controller/connection/connectors/ssh.py
+++ b/openwisp_controller/connection/connectors/ssh.py
@@ -170,9 +170,11 @@ class Ssh(object):
         # abort the operation if any of the command
         # returned with a non-zero exit status
         if exit_status not in exit_codes and raise_unexpected_exit:
-            logger.error('Unexpected exit code: {0}'.format(exit_status))
+            log_message = 'Unexpected exit code: {0}'.format(exit_status)
+            logger.error(log_message)
             message = error if error else output
-            raise CommandFailedException(message)
+            # if message is empty, use log_message
+            raise CommandFailedException(message or log_message)
         return output, exit_status
 
     def update_config(self):  # pragma: no cover

--- a/openwisp_controller/connection/tests/test_ssh.py
+++ b/openwisp_controller/connection/tests/test_ssh.py
@@ -36,9 +36,9 @@ class TestSsh(CreateConnectionsMixin, TestCase):
         self.assertTrue(dc.is_working)
         with mock.patch('logging.Logger.info') as mocked_logger:
             dc.connector_instance.exec_command('echo test')
-            mocked_logger.assert_has_calls(
-                [mock.call('Executing command: echo test'), mock.call('test\n')]
-            )
+        mocked_logger.assert_has_calls(
+            [mock.call('Executing command: echo test'), mock.call('test\n')]
+        )
 
     @mock.patch.object(ssh_logger, 'info')
     @mock.patch.object(ssh_logger, 'debug')
@@ -49,11 +49,12 @@ class TestSsh(CreateConnectionsMixin, TestCase):
         with self.assertRaises(Exception):
             with mock.patch('logging.Logger.error') as mocked_logger:
                 dc.connector_instance.exec_command('wrongcommand')
-                mocked_logger.assert_has_calls(
-                    [
-                        mock.call('/bin/sh: 1: wrongcommand: not found'),
-                        mock.call('Unexpected exit code: 127'),
-                    ]
+        mocked_logger.assert_has_calls(
+            [
+                mock.call('/bin/sh: 1: wrongcommand: not found\n'),
+                mock.call('Unexpected exit code: 127'),
+            ]
+        )
 
     @mock.patch.object(ssh_logger, 'info')
     @mock.patch.object(ssh_logger, 'debug')


### PR DESCRIPTION
#### [fix] CommandFailedException: ensure error message is always present

If a command with suppressed output failed, CommandFailedException
would be raised with an emptry string as argument, which makes
debugging issues really hard.

In this cases we shall instantiate the exception with the same
message passed to the log.

#### [fix/tests] TestSsh: fixed assert_has_calls not being called

I found out these assertions were not being called while working
on the previous commit.

PS: found this while debugging https://github.com/openwisp/openwisp-firmware-upgrader/issues/151.
