### PR TITLE
[enhancement] Improved validation of subnet division rules #520

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1916,6 +1916,20 @@ Important Notes
   `device subnet division rule <#device-subnet-division-rule>`_ can be used, which only requires
   `creating a subnet and a subnet division rule <#1-create-a-subnet-and-a-subnet-division-rule>`_.
 
+- In the current implementation, it is not possible to change "Size", "Number of Subnets" and
+  "Number of IPs" fields of an existing subnet division rule due to following reasons:
+
+  - **Size**: Allowing to change size of provisioned subnets of an existing subnet division rule
+    will require rebuilding of Subnets and IP addresses which has possibility of breaking
+    existing configurations.
+  - **Number of Subnets**: Allowing to decrease number of subnets of an existing subnet division
+    rule can create patches of unused subnets dispersed everywhere in the master subnet.
+    Allowing to increase number of subnets will break the continuous allocation of subnets for
+    every device. It can also break configuration of devices.
+  - **Number of IPs**: Allowing to decrease number of IPs of an existing subnet division rule
+    will lead to deletion of IP Addresses which can break configuration of devices being used.
+    It **is allowed** to increase number of IPs.
+
 Signals
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -1893,8 +1893,8 @@ under the `System Defined Variables <#system-defined-variables>`_.
 Voila! You can now use these variables in configuration of the device. Refer to `How to use configuration variables <#how-to-use-configuration-variables>`_
 section of this documentation to learn how to use configuration variables.
 
-Important Notes
-~~~~~~~~~~~~~~~
+Important notes for using Subnet Division
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - In the above example Subnet, VPN Server, and VPN Client Template belonged to the **default** organization.
   You can use **Systemwide Shared** Subnet, VPN Server, or VPN Client Template too, but
@@ -1916,19 +1916,38 @@ Important Notes
   `device subnet division rule <#device-subnet-division-rule>`_ can be used, which only requires
   `creating a subnet and a subnet division rule <#1-create-a-subnet-and-a-subnet-division-rule>`_.
 
-- In the current implementation, it is not possible to change "Size", "Number of Subnets" and
-  "Number of IPs" fields of an existing subnet division rule due to following reasons:
+Limitations of Subnet Division
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  - **Size**: Allowing to change size of provisioned subnets of an existing subnet division rule
-    will require rebuilding of Subnets and IP addresses which has possibility of breaking
-    existing configurations.
-  - **Number of Subnets**: Allowing to decrease number of subnets of an existing subnet division
-    rule can create patches of unused subnets dispersed everywhere in the master subnet.
-    Allowing to increase number of subnets will break the continuous allocation of subnets for
-    every device. It can also break configuration of devices.
-  - **Number of IPs**: Allowing to decrease number of IPs of an existing subnet division rule
-    will lead to deletion of IP Addresses which can break configuration of devices being used.
-    It **is allowed** to increase number of IPs.
+In the current implementation, it is not possible to change "Size", "Number of Subnets" and
+"Number of IPs" fields of an existing subnet division rule due to following reasons:
+
+Size
+""""
+
+Allowing to change size of provisioned subnets of an existing subnet division rule
+will require rebuilding of Subnets and IP addresses which has possibility of breaking
+existing configurations.
+
+Number of Subnets
+"""""""""""""""""
+
+Allowing to decrease number of subnets of an existing subnet division
+rule can create patches of unused subnets dispersed everywhere in the master subnet.
+Allowing to increase number of subnets will break the continuous allocation of subnets for
+every device. It can also break configuration of devices.
+
+Number of IPs
+"""""""""""""
+
+Allowing to decrease number of IPs of an existing subnet division rule
+will lead to deletion of IP Addresses which can break configuration of devices being used.
+It **is allowed** to increase number of IPs.
+
+If you want to make changes to any of above fields, delete the existing rule and create a
+new one. The automation will provision for all existing devices that meets the criteria
+for provisioning. **WARNING**: It is possible that devices get different subnets and IPs
+from previous provisioning.
 
 Signals
 -------

--- a/openwisp_controller/subnet_division/admin.py
+++ b/openwisp_controller/subnet_division/admin.py
@@ -32,7 +32,8 @@ class SubnetDivisionRuleInlineAdmin(
             '"Number of IPs" will not be possible.'
         ),
         'documentation_url': (
-            'https://github.com/openwisp/openwisp-controller/tree/1.0.x#important-notes'
+            'https://github.com/openwisp/openwisp-controller/tree/master'
+            '#limitations-of-subnet-division'
         ),
     }
 

--- a/openwisp_controller/subnet_division/admin.py
+++ b/openwisp_controller/subnet_division/admin.py
@@ -26,6 +26,10 @@ class SubnetDivisionRuleInlineAdmin(
     model = SubnetDivisionRule
     extra = 0
 
+    class Media:
+        js = ['admin/js/jquery.init.js', 'subnet-division/js/subnet-division.js']
+        css = {'all': ['subnet-division/css/subnet-division.css']}
+
 
 # Monkey patching DeviceAdmin to allow filtering using subnet
 DeviceAdmin.list_filter.append(SubnetFilter)

--- a/openwisp_controller/subnet_division/admin.py
+++ b/openwisp_controller/subnet_division/admin.py
@@ -8,7 +8,7 @@ from swapper import load_model
 
 from openwisp_controller.config.admin import DeviceAdmin
 from openwisp_users.multitenancy import MultitenantAdminMixin, MultitenantOrgFilter
-from openwisp_utils.admin import TimeReadonlyAdminMixin
+from openwisp_utils.admin import HelpTextStackedInline, TimeReadonlyAdminMixin
 
 from . import settings as app_settings
 from .filters import DeviceFilter, SubnetFilter, SubnetListFilter
@@ -21,14 +21,23 @@ Device = load_model('config', 'Device')
 
 
 class SubnetDivisionRuleInlineAdmin(
-    MultitenantAdminMixin, TimeReadonlyAdminMixin, admin.StackedInline
+    MultitenantAdminMixin, TimeReadonlyAdminMixin, HelpTextStackedInline
 ):
     model = SubnetDivisionRule
     extra = 0
+    help_text = {
+        'text': _(
+            'Please keep in mind that once the subnet division rule is created '
+            'changing changing "Size", "Number of Subnets" or decreasing '
+            '"Number of IPs" will not be possible.'
+        ),
+        'documentation_url': (
+            'https://github.com/openwisp/openwisp-controller/tree/1.0.x#important-notes'
+        ),
+    }
 
     class Media:
         js = ['admin/js/jquery.init.js', 'subnet-division/js/subnet-division.js']
-        css = {'all': ['subnet-division/css/subnet-division.css']}
 
 
 # Monkey patching DeviceAdmin to allow filtering using subnet

--- a/openwisp_controller/subnet_division/admin.py
+++ b/openwisp_controller/subnet_division/admin.py
@@ -32,7 +32,7 @@ class SubnetDivisionRuleInlineAdmin(
             '"Number of IPs" will not be possible.'
         ),
         'documentation_url': (
-            'https://github.com/openwisp/openwisp-controller/tree/master'
+            'https://github.com/openwisp/openwisp-controller'
             '#limitations-of-subnet-division'
         ),
     }

--- a/openwisp_controller/subnet_division/static/subnet-division/css/subnet-division.css
+++ b/openwisp_controller/subnet_division/static/subnet-division/css/subnet-division.css
@@ -1,0 +1,14 @@
+input.readonly {
+  border: 1px solid rgba(0, 0, 0, 0.05) !important;
+  background-color: rgba(0, 0, 0, 0.07);
+}
+.help-text-warning {
+  background-color: #ffe5e5;
+  padding: 5px 10px;
+  font-size: 15px;
+  font-weight: bolder;
+  display: flex;
+}
+.help-text-warning img {
+  min-width: 30px;
+}

--- a/openwisp_controller/subnet_division/static/subnet-division/js/subnet-division.js
+++ b/openwisp_controller/subnet_division/static/subnet-division/js/subnet-division.js
@@ -1,0 +1,56 @@
+'use strict';
+
+if (typeof gettext === 'undefined') {
+    var gettext = function (word) {
+        return word;
+    };
+}
+
+django.jQuery(function ($) {
+    if ($('#subnetdivisionrule_set-group').length === 0) {
+        return;
+    }
+    // Do not allow decreasing number_of_ips
+    $('input[name$="-number_of_ips"]:visible').each(function (index, el) {
+        if (($(el).val() !== '') && ($(el).attr('min') === "0")) {
+            $(el).attr('min', $(el).val());
+        }
+    });
+    // Disable subnet size field
+    $('#subnetdivisionrule_set-group input[name$="-size"]:visible').prop('readonly', true);
+    $('#subnetdivisionrule_set-group input[name$="-size"]:visible').addClass('readonly');
+
+    // Disable number of subnets field
+    $('#subnetdivisionrule_set-group input[name$="-number_of_subnets"]:visible').prop('readonly', true);
+    $('#subnetdivisionrule_set-group input[name$="-number_of_subnets"]:visible').addClass('readonly');
+
+    // If subnet is not shared, hide organization field from Subnet Division Rule
+    function hideOrganizationFieldForNonSharedSubnet() {
+        if ($('#id_organization').val() !== '') {
+            $('#subnetdivisionrule_set-group select[name$="-organization"]').each(
+                function (index, element) {
+                    element = $(element);
+                    if ((element.val() === '') || (element.val() === $('#id_organization').val())) {
+                        element.val($('#id_organization').val());
+                        element.parent().parent().parent().hide();
+                    } else {
+                        element.parent().parent().parent().show();
+                    }
+                });
+        } else {
+            $('#subnetdivisionrule_set-group .form-row.field-organization').show();
+        }
+    }
+    hideOrganizationFieldForNonSharedSubnet();
+    $('#subnetdivisionrule_set-group .add-row a').click(hideOrganizationFieldForNonSharedSubnet);
+    $('#id_organization').change(hideOrganizationFieldForNonSharedSubnet);
+
+    // Insert change warning
+    $('#subnetdivisionrule_set-group .add-row a').click(function () {
+        var warningText = gettext('Please keep in mind that once the subnet division rule is created and used, changing "Size" and "Number of Subnets" and decreasing "Number of IPs" will not be possible.') +
+            ' ' + gettext('Please read') + ' ' + '<a target="_blank" href="https://github.com/openwisp/openwisp-controller/tree/1.0.x#important-notes">' +
+            gettext('documentation') + '</a>' + ' ' + gettext('for more information'),
+            html = `<div class="help-text-warning"><img src="/static/admin/img/icon-alert.svg"><p>${warningText}</p><div>`;
+        $('.last-related > fieldset:visible:last').before(html);
+    });
+});

--- a/openwisp_controller/subnet_division/static/subnet-division/js/subnet-division.js
+++ b/openwisp_controller/subnet_division/static/subnet-division/js/subnet-division.js
@@ -44,13 +44,4 @@ django.jQuery(function ($) {
     hideOrganizationFieldForNonSharedSubnet();
     $('#subnetdivisionrule_set-group .add-row a').click(hideOrganizationFieldForNonSharedSubnet);
     $('#id_organization').change(hideOrganizationFieldForNonSharedSubnet);
-
-    // Insert change warning
-    $('#subnetdivisionrule_set-group .add-row a').click(function () {
-        var warningText = gettext('Please keep in mind that once the subnet division rule is created and used, changing "Size" and "Number of Subnets" and decreasing "Number of IPs" will not be possible.') +
-            ' ' + gettext('Please read') + ' ' + '<a target="_blank" href="https://github.com/openwisp/openwisp-controller/tree/1.0.x#important-notes">' +
-            gettext('documentation') + '</a>' + ' ' + gettext('for more information'),
-            html = `<div class="help-text-warning"><img src="/static/admin/img/icon-alert.svg"><p>${warningText}</p><div>`;
-        $('.last-related > fieldset:visible:last').before(html);
-    });
 });

--- a/run-qa-checks
+++ b/run-qa-checks
@@ -15,8 +15,10 @@ rm -rf ./openwisp_controller/geo/tests/.pytest_cache \
 jshint openwisp_controller/pki/static/admin/pki/js/*.js
 jshint openwisp_controller/config/static/config/js/*.js
 jshint openwisp_controller/connection/static/connection/js/*.js
+jshint openwisp_controller/subnet_division/static/subnet-division/js/*.js
 stylelint "openwisp_controller/config/static/config/css/*.css"
 stylelint "openwisp_controller/connection/static/connection/css/*.css"
+stylelint "openwisp_controller/subnet_division/static/subnet-division/css/*.css"
 
 
 # CSS checks


### PR DESCRIPTION
Validation:
- Size of provisioned subnets cannot be changed
- Number of provisioned subnets cannot be changed
- Number of provisioned IP can only be increased

UX:
- If a subnet is not shared, organization fields of related
  Subnet Divsion Rule will be hidden and automatically set
  to organization of the subnet.

Closes #520