### PR TITLE
[ci] Add new python runtime #561

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.6
           - 3.7
+          - 3.8
+          - 3.9
         django-version:
           - django~=3.0.0
           - django~=3.1.0


### PR DESCRIPTION
Add python version 3.8 and 3.9 to github action ci tests. Remove python 3.7.
Fixes #561