### PR TITLE
[fix] Fixed configuration download URLs #583

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -16,7 +16,7 @@ from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.template.loader import get_template
 from django.template.response import TemplateResponse
-from django.urls import path, reverse
+from django.urls import path, re_path, reverse
 from django.utils.translation import gettext_lazy as _
 from flat_json_widget.widgets import FlatJsonWidget
 from swapper import load_model
@@ -137,8 +137,8 @@ class BaseConfigAdmin(BaseAdmin):
         options = getattr(self.model, '_meta')
         url_prefix = '{0}_{1}'.format(options.app_label, options.model_name)
         return [
-            path(
-                'download/<uuid:pk>/',
+            re_path(
+                r'^download/(?P<pk>[^/]+)/$',
                 self.admin_site.admin_view(self.download_view),
                 name='{0}_download'.format(url_prefix),
             ),
@@ -147,8 +147,8 @@ class BaseConfigAdmin(BaseAdmin):
                 self.admin_site.admin_view(self.preview_view),
                 name='{0}_preview'.format(url_prefix),
             ),
-            path(
-                '<uuid:pk>/context.json',
+            re_path(
+                r'^(?P<pk>[^/]+)/context\.json$',
                 self.admin_site.admin_view(self.context_view),
                 name='{0}_context'.format(url_prefix),
             ),

--- a/openwisp_controller/config/tests/pytest.py
+++ b/openwisp_controller/config/tests/pytest.py
@@ -5,7 +5,7 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from channels.testing import WebsocketCommunicator
 from django.contrib.auth.models import Permission
-from django.urls import path
+from django.urls import re_path
 from swapper import load_model
 
 from openwisp_users.tests.utils import TestOrganizationMixin
@@ -26,8 +26,8 @@ class TestDeviceConsumer(CreateDeviceMixin, TestOrganizationMixin):
                 AuthMiddlewareStack(
                     URLRouter(
                         [
-                            path(
-                                'ws/controller/device/<uuid:pk>/',
+                            re_path(
+                                r'^ws/controller/device/(?P<pk>[^/]+)/$',
                                 BaseDeviceConsumer.as_asgi(),
                             )
                         ]

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -549,7 +549,7 @@ class TestAdmin(
     def test_download_device_config(self):
         d = self._create_device(name='download')
         self._create_config(device=d)
-        path = reverse(f'admin:{self.app_label}_device_download', args=[d.pk])
+        path = reverse(f'admin:{self.app_label}_device_download', args=[d.pk.hex])
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get('content-type'), 'application/octet-stream')

--- a/openwisp_controller/connection/api/urls.py
+++ b/openwisp_controller/connection/api/urls.py
@@ -11,12 +11,12 @@ def get_api_urls(api_views):
     """
     return [
         path(
-            'api/v1/controller/device/<uuid:id>/command/',
+            'api/v1/controller/device/<str:id>/command/',
             api_views.command_list_create_view,
             name='device_command_list',
         ),
         path(
-            'api/v1/controller/device/<uuid:id>/command/<uuid:command_id>/',
+            'api/v1/controller/device/<str:id>/command/<uuid:command_id>/',
             api_views.command_details_view,
             name='device_command_details',
         ),

--- a/openwisp_controller/connection/channels/routing.py
+++ b/openwisp_controller/connection/channels/routing.py
@@ -1,11 +1,12 @@
-from django.urls import path
+from django.urls import re_path
 
 from . import consumers as ow_consumer
 
 
 def get_routes(consumer=ow_consumer):
     return [
-        path(
-            'ws/controller/device/<uuid:pk>/command', consumer.CommandConsumer.as_asgi()
+        re_path(
+            r'^ws/controller/device/(?P<pk>[^/]+)/command$',
+            consumer.CommandConsumer.as_asgi(),
         )
     ]


### PR DESCRIPTION
The ConfigAdmin download URL pattern used "uuid" converter
which does not allow UUID hex code.

Improvement to #583