### PR TITLE
[change] Made updating Device reversion follow updatable #577

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -537,16 +537,18 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, UUIDAdmin):
 
     @classmethod
     def add_reversion_following(cls, follow):
-        # DeviceAdmin is used by other modules that register InlineModelAdmin
-        # using monkey patching. The default implementation of reversion.register
-        # ignore such inlines and does not update the "follow" field accordingly.
-        # This method updates the "follow" fields of the Device model
-        # by unregistering the Device model from reversion and re-registering it.
-        # Only the "follow" option is updated.
+        """
+        DeviceAdmin is used by other modules that register InlineModelAdmin
+        using monkey patching. The default implementation of reversion.register
+        ignore such inlines and does not update the "follow" field accordingly.
+        This method updates the "follow" fields of the Device model
+        by unregistering the Device model from reversion and re-registering it.
+        Only the" "follow" option is updated.
+        """
         device_reversion_options = reversion.revisions._registered_models[
             reversion.revisions._get_registration_key(Device)
         ]
-        following = set(device_reversion_options.follow) | set(follow)
+        following = set(device_reversion_options.follow).union(set(follow))
         reversion.unregister(Device)
         reversion.register(
             model=Device,

--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -540,7 +540,7 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, UUIDAdmin):
         """
         DeviceAdmin is used by other modules that register InlineModelAdmin
         using monkey patching. The default implementation of reversion.register
-        ignore such inlines and does not update the "follow" field accordingly.
+        ignores such inlines and does not update the "follow" field accordingly.
         This method updates the "follow" fields of the Device model
         by unregistering the Device model from reversion and re-registering it.
         Only the" "follow" option is updated.

--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -1,6 +1,7 @@
 import json
 import logging
 
+import reversion
 from django import forms
 from django.conf import settings
 from django.contrib import admin, messages
@@ -534,14 +535,28 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, UUIDAdmin):
                 inlines.append(inline)
         return inlines
 
-    def reversion_register(self, model, **options):
-        if model == Device:
-            options['follow'] = (
-                *(options['follow']),
-                'deviceconnection_set',
-                'devicelocation',
-            )
-        return super().reversion_register(model, **options)
+    @classmethod
+    def add_reversion_following(cls, follow):
+        # DeviceAdmin is used by other modules that register InlineModelAdmin
+        # using monkey patching. The default implementation of reversion.register
+        # ignore such inlines and does not update the "follow" field accordingly.
+        # This method updates the "follow" fields of the Device model
+        # by unregistering the Device model from reversion and re-registering it.
+        # Only the "follow" option is updated.
+        device_reversion_options = reversion.revisions._registered_models[
+            reversion.revisions._get_registration_key(Device)
+        ]
+        following = set(device_reversion_options.follow) | set(follow)
+        reversion.unregister(Device)
+        reversion.register(
+            model=Device,
+            fields=device_reversion_options.fields,
+            follow=following,
+            format=device_reversion_options.format,
+            for_concrete_model=device_reversion_options.for_concrete_model,
+            ignore_duplicates=device_reversion_options.ignore_duplicates,
+            use_natural_foreign_keys=device_reversion_options.use_natural_foreign_keys,
+        )
 
 
 class CloneOrganizationForm(forms.Form):

--- a/openwisp_controller/connection/admin.py
+++ b/openwisp_controller/connection/admin.py
@@ -173,3 +173,4 @@ DeviceAdmin.conditional_inlines += [
     # or the JS logic will not work
     CommandInline,
 ]
+DeviceAdmin.add_reversion_following(follow=['deviceconnection_set'])

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -466,6 +466,6 @@ class TestConnectionApi(TestAdminMixin, TestCase, CreateConnectionsMixin):
         dc = self._create_device_connection()
         d1 = dc.device.id
         path = reverse('connection_api:deviceconnection_detail', args=(d1, dc.pk))
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.delete(path)
         self.assertEqual(response.status_code, 204)

--- a/openwisp_controller/geo/admin.py
+++ b/openwisp_controller/geo/admin.py
@@ -102,3 +102,4 @@ class DeviceLocationFilter(admin.SimpleListFilter):
 DeviceAdmin.inlines.insert(1, DeviceLocationInline)
 DeviceAdmin.list_filter.append(DeviceLocationFilter)
 reversion.register(model=DeviceLocation, follow=['device'])
+DeviceAdmin.add_reversion_following(follow=['devicelocation'])


### PR DESCRIPTION
DeviceAdmin is used by other modules that register InlineModelAdmin
using monkey patching. The default implementation of reversion.register
ignore such inlines and does not update the "follow" field accordingly.

Thus, a classmethod is added in  DeviceAdmin to update the
"follow" fields of the Device model. This is achieved by unregistering
the Device model from reversion and re-registering it with updated
"follow" fields without altering other options.

Related to #577
