### PR TITLE
[fix] Fixed bug in device location API browsable UI page

### DIFF
--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -21,7 +21,11 @@ DeviceLocation = load_model('geo', 'DeviceLocation')
 
 class DevicePermission(BasePermission):
     def has_object_permission(self, request, view, obj):
-        return request.query_params.get('key') == obj.key
+        # checks for presence of key attribute first
+        # because in the browsable UI this method is
+        # getting passed also Location instances,
+        # which do not have the key attribute
+        return hasattr(obj, 'key') and request.query_params.get('key') == obj.key
 
 
 class ListViewPagination(pagination.PageNumberPagination):

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -57,6 +57,15 @@ class TestApi(TestGeoMixin, TestCase):
         )
         self.assertEqual(self.location_model.objects.count(), 1)
 
+    def test_get_existing_location_html(self):
+        """
+        Regression test for browsable web UI bug
+        """
+        dl = self._create_object_location()
+        url = reverse(self.url_name, args=[dl.device.pk])
+        r = self.client.get(url, {'key': dl.device.key}, HTTP_ACCEPT='text/html')
+        self.assertEqual(r.status_code, 200)
+
     def test_get_create_location(self):
         self.assertEqual(self.location_model.objects.count(), 0)
         device = self._create_object()


### PR DESCRIPTION
Checks for presence of key attribute first, because in the browsable UI this method is getting passed also Location instances, which do not have the key attribute.