### PR TITLE
[fix] Unsubscribe button alignment #573

### DIFF
--- a/openwisp_controller/connection/static/connection/css/command-inline.css
+++ b/openwisp_controller/connection/static/connection/css/command-inline.css
@@ -217,3 +217,6 @@ li.commands {
     padding: 5px 0px;
   }
 }
+.ow-object-notify {
+  height: 20px;
+}


### PR DESCRIPTION
- Fixed unsub-btn alignment
Fixes #573

#### Screenshots :

#### BEFORE :

- You can easily see there is a `< 1px` difference from a button between those two buttons.

![Screenshot from 2022-01-25 01-04-49](https://user-images.githubusercontent.com/56113566/150852986-6e1c5304-7659-49ba-92c3-8c10e83e0e43.png)

#### AFTER :

- Properly aligned buttons

![Screenshot from 2022-01-25 01-02-56](https://user-images.githubusercontent.com/56113566/150853144-81866ca3-f77c-4887-8a41-a8a2db12bb84.png)

