### PR TITLE
[change] Updated log levels for connection.connectors.ssh

### DIFF
--- a/openwisp_controller/connection/connectors/ssh.py
+++ b/openwisp_controller/connection/connectors/ssh.py
@@ -163,7 +163,6 @@ class Ssh(object):
         # log standard error
         error = stderr.read().decode('utf-8', 'ignore')
         if error:
-            logger.error(error)
             if not output.endswith('\n'):
                 output += '\n'
             output += error
@@ -171,7 +170,7 @@ class Ssh(object):
         # returned with a non-zero exit status
         if exit_status not in exit_codes and raise_unexpected_exit:
             log_message = 'Unexpected exit code: {0}'.format(exit_status)
-            logger.error(log_message)
+            logger.info(log_message)
             message = error if error else output
             # if message is empty, use log_message
             raise CommandFailedException(message or log_message)

--- a/openwisp_controller/connection/tests/test_ssh.py
+++ b/openwisp_controller/connection/tests/test_ssh.py
@@ -47,11 +47,9 @@ class TestSsh(CreateConnectionsMixin, TestCase):
         dc = self._create_device_connection(credentials=ckey)
         dc.connector_instance.connect()
         with self.assertRaises(Exception):
-            with mock.patch('logging.Logger.error') as mocked_logger:
-                dc.connector_instance.exec_command('wrongcommand')
-        mocked_logger.assert_has_calls(
+            dc.connector_instance.exec_command('wrongcommand')
+        mocked_info.assert_has_calls(
             [
-                mock.call('/bin/sh: 1: wrongcommand: not found\n'),
                 mock.call('Unexpected exit code: 127'),
             ]
         )
@@ -65,12 +63,11 @@ class TestSsh(CreateConnectionsMixin, TestCase):
         dc = self._create_device_connection(credentials=ckey)
         dc.connector_instance.connect()
         with self.assertRaises(Exception) as ctx:
-            with mock.patch('logging.Logger.error') as mocked_logger:
-                dc.connector_instance.exec_command(
-                    'rm /thisfilesurelydoesnotexist 2> /dev/null'
-                )
+            dc.connector_instance.exec_command(
+                'rm /thisfilesurelydoesnotexist 2> /dev/null'
+            )
         log_message = 'Unexpected exit code: 1'
-        mocked_logger.assert_has_calls([mock.call(log_message)])
+        mocked_info.assert_has_calls([mock.call(log_message)])
         self.assertEqual(str(ctx.exception), log_message)
 
     @mock.patch('scp.SCPClient.putfo')


### PR DESCRIPTION
We don't need to log in the application because the output is shown to the user anyway.