### PR TITLE
[fix] SSH Connection: fixed OpenWrt >= 19 authentication failure #643

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       run: sudo npm install -g jshint stylelint
 
     - name: Upgrade python system packages
-      run: pip install -U "pip==20.2.4" wheel setuptools
+      run: pip install -U pip wheel setuptools
 
     - name: Install openwisp-controller
       run: |

--- a/openwisp_controller/connection/connectors/ssh.py
+++ b/openwisp_controller/connection/connectors/ssh.py
@@ -107,20 +107,46 @@ class Ssh(object):
             raise ValueError('No valid IP addresses to initiate connections found')
         for address in addresses:
             try:
-                self.shell.connect(
-                    address,
-                    auth_timeout=app_settings.SSH_AUTH_TIMEOUT,
-                    banner_timeout=app_settings.SSH_BANNER_TIMEOUT,
-                    timeout=app_settings.SSH_CONNECTION_TIMEOUT,
-                    **self.params
-                )
+                self._connect(address)
             except Exception as e:
                 exception = e
             else:
                 success = True
                 break
         if not success:
+            self.disconnect()
             raise exception
+
+    def _connect(self, address):
+        """
+        Tries to instantiate the SSH connection,
+        if the connection fails, it tries again
+        by disabling the new deafult HostKeyAlgorithms
+        used by newer versions of Paramiko
+        """
+        params = self.params
+        for attempt in [1, 2]:
+            try:
+                self.shell.connect(
+                    address,
+                    auth_timeout=app_settings.SSH_AUTH_TIMEOUT,
+                    banner_timeout=app_settings.SSH_BANNER_TIMEOUT,
+                    timeout=app_settings.SSH_CONNECTION_TIMEOUT,
+                    **params
+                )
+            except paramiko.ssh_exception.AuthenticationException as e:
+                # the authentication failure may be caused by the issue
+                # described at https://github.com/paramiko/paramiko/issues/1961
+                # let's retry by disabling the new default HostKeyAlgorithms,
+                # which can work on older systems.
+                if e.args == ('Authentication failed.',) and attempt == 1:
+                    params['disabled_algorithms'] = {
+                        'pubkeys': ['rsa-sha2-512', 'rsa-sha2-256']
+                    }
+                    continue
+                raise e
+            else:
+                break
 
     def disconnect(self):
         self.shell.close()


### PR DESCRIPTION
Paramiko versions > 2.8 try to use sha2 as a default
HostKeyAlgorithms if the target SSH server doesn't
advertise the preferred HostKeyAlgorithms, which
is the case for OpenWrt <= 19.

This causes SSH connections to fail with:
"Pubkey auth attempt with unknown algo",
because dropbear on OpenWrt <= 19 doesn't
support sha2.

The fix suggested by Paramiko is to disable
the sha2 HostKeyAlgorithms,
which is not great for systems where newer versions of
OpenWrt and dropbear are in use, for this reason, this
patch disables the sha2 HostKeyAlgorithms only if a first
SSH connection attempt fails by raising the exception
paramiko.ssh_exception.AuthenticationException.

As a bonus fix, I found out that it's better
to explicitly close the SSH connection when the authentication
fails, otherwise a lingering SSH connection can stay open
for a while.

Closes #643