### PR TITLE
[fix] Fixed changed signals emitting on the creation of new device #649

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -187,8 +187,10 @@ class AbstractDevice(OrgMixin, BaseModel):
                 self.key = KeyField.default_callable()
             else:
                 self.key = self.generate_key(shared_secret)
+        state_adding = self._state.adding
         super().save(*args, **kwargs)
-        self._check_changed_fields()
+        if not state_adding:
+            self._check_changed_fields()
 
     def _check_changed_fields(self):
         self._get_initial_values_for_checked_fields()

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -189,6 +189,9 @@ class AbstractDevice(OrgMixin, BaseModel):
                 self.key = self.generate_key(shared_secret)
         state_adding = self._state.adding
         super().save(*args, **kwargs)
+        # The value of "self._state.adding" will always be "False"
+        # after performing the save operation. Hence, the actual value
+        # is stored in the "state_adding" variable.
         if not state_adding:
             self._check_changed_fields()
 

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -389,8 +389,10 @@ class TestDevice(
             )
 
     def test_device_group_changed_not_emitted_on_creation(self):
+        org = self._get_org()
+        device_group = self._create_device_group(organization=org)
         with catch_signal(device_group_changed) as handler:
-            self._create_device(organization=self._get_org())
+            self._create_device(name='test', organization=org, group=device_group)
         handler.assert_not_called()
 
     def test_device_field_changed_checks(self):


### PR DESCRIPTION
Creating a new device object from the admin dashboard
emitted "device_group_changed" and "device_name_changed"
signals. The code for checking the values of changed fields
didn't take creating a device from admin into consideration.

Fixed the code that checks changed fields and added an
automated test for the same.

Closes #649