### PR TITLE
[fix] Show reversion button to operators too

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -37,7 +37,6 @@ from openwisp_utils.admin import (
 )
 
 from ..admin import MultitenantAdminMixin
-from ..pki.base import PkiReversionTemplatesMixin
 from . import settings as app_settings
 from .base.vpn import AbstractVpn
 from .utils import send_file
@@ -69,7 +68,7 @@ class SystemDefinedVariableMixin(object):
     system_context.short_description = _('System Defined Variables')
 
 
-class BaseAdmin(TimeReadonlyAdminMixin, PkiReversionTemplatesMixin, ModelAdmin):
+class BaseAdmin(TimeReadonlyAdminMixin, ModelAdmin):
     history_latest_first = True
 
 

--- a/openwisp_controller/pki/admin.py
+++ b/openwisp_controller/pki/admin.py
@@ -6,16 +6,13 @@ from swapper import load_model
 from openwisp_users.multitenancy import MultitenantOrgFilter
 
 from ..admin import MultitenantAdminMixin
-from .base import PkiReversionTemplatesMixin
 
 Ca = load_model('django_x509', 'Ca')
 Cert = load_model('django_x509', 'Cert')
 
 
 @admin.register(Ca)
-class CaAdmin(
-    MultitenantAdminMixin, PkiReversionTemplatesMixin, AbstractCaAdmin, VersionAdmin
-):
+class CaAdmin(MultitenantAdminMixin, AbstractCaAdmin, VersionAdmin):
     history_latest_first = True
 
 
@@ -26,9 +23,7 @@ CaAdmin.Media.js += ('admin/pki/js/show-org-field.js',)
 
 
 @admin.register(Cert)
-class CertAdmin(
-    MultitenantAdminMixin, PkiReversionTemplatesMixin, AbstractCertAdmin, VersionAdmin
-):
+class CertAdmin(MultitenantAdminMixin, AbstractCertAdmin, VersionAdmin):
     multitenant_shared_relations = ('ca',)
     history_latest_first = True
 

--- a/openwisp_controller/pki/base/__init__.py
+++ b/openwisp_controller/pki/base/__init__.py
@@ -1,2 +1,0 @@
-class PkiReversionTemplatesMixin(object):
-    change_list_template = 'pki/change_list.html'

--- a/openwisp_controller/pki/templates/pki/change_list.html
+++ b/openwisp_controller/pki/templates/pki/change_list.html
@@ -1,9 +1,0 @@
-{% extends "admin/change_list.html" %}
-{% load i18n admin_urls %}
-
-{% block object-tools-items %}
-    {% if not is_popup and request.user.is_superuser %}
-        <li><a href="{% url opts|admin_urlname:'recoverlist' %}" class="recoverlink">{% blocktrans with cl.opts.verbose_name_plural|escape as name %}Recover deleted {{name}}{% endblocktrans %}</a></li>
-    {% endif %}
-    {{block.super}}
-{% endblock %}

--- a/openwisp_controller/tests/utils.py
+++ b/openwisp_controller/tests/utils.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.urls import reverse
 
 from openwisp_users.tests.utils import TestMultitenantAdminMixin
 
@@ -6,6 +7,13 @@ user_model = get_user_model()
 
 
 class TestAdminMixin(TestMultitenantAdminMixin):
+    def _test_changelist_recover_deleted(self, app_label, model_label):
+        self._test_multitenant_admin(
+            url=reverse('admin:{0}_{1}_changelist'.format(app_label, model_label)),
+            visible=[],
+            hidden=[],
+        )
+
     def _login(self, username='admin', password='tester'):
         self.client.force_login(user_model.objects.get(username=username))
 


### PR DESCRIPTION
For some obscure reasons the django-reversion button
was not being shown to operators.

I concluded this was not done on purpose and proceeded
to remove the bogus code.

@atb00ker I have no idea how this code ended up here in GSOC20 lol.