### PR TITLE
[fix] Fixed tests failing due to openwisp-notification 1.0.2

### DIFF
--- a/openwisp_controller/config/tests/test_notifications.py
+++ b/openwisp_controller/config/tests/test_notifications.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from django.apps.registry import apps
-from django.test import TestCase
+from django.test import TransactionTestCase
 from swapper import load_model
 
 from openwisp_controller.config.tests.utils import CreateConfigMixin
@@ -15,7 +15,7 @@ Notification = load_model('openwisp_notifications', 'Notification')
 notification_qs = Notification.objects.all()
 
 
-class TestNotifications(CreateConfigMixin, TestOrganizationMixin, TestCase):
+class TestNotifications(CreateConfigMixin, TestOrganizationMixin, TransactionTestCase):
     app_label = 'config'
 
     def setUp(self):


### PR DESCRIPTION
Bug:
In openwisp-notification 1.0.2, the operation for creating notification
settings when an organization is created is wrapped in transaction.on_commit.
Tests which relied on this functionality and which inherited from
TestCase class were failing.

Fix:
Moved these tests to test class which inherits from TransactionTestCase.