### PR TITLE
[fix] Close ssh session before opening a new one

### DIFF
--- a/openwisp_controller/connection/connectors/ssh.py
+++ b/openwisp_controller/connection/connectors/ssh.py
@@ -145,6 +145,7 @@ class Ssh(object):
                     params['disabled_algorithms'] = {
                         'pubkeys': ['rsa-sha2-512', 'rsa-sha2-256']
                     }
+                    self.shell.close()
                     continue
                 raise e
             else:

--- a/openwisp_controller/connection/tests/test_ssh.py
+++ b/openwisp_controller/connection/tests/test_ssh.py
@@ -53,7 +53,7 @@ class TestSsh(CreateConnectionsMixin, TestCase):
             dc.connect()
         self.assertEqual(mocked_connect.call_count, 2)
         self.assertFalse(dc.is_working)
-        mocked_ssh_close.assert_called_once()
+        self.assertEqual(mocked_ssh_close.call_count, 2)
         if sys.version_info[0:2] > (3, 7):
             self.assertNotIn('disabled_algorithms', mocked_connect.mock_calls[0].kwargs)
             self.assertIn('disabled_algorithms', mocked_connect.mock_calls[1].kwargs)


### PR DESCRIPTION
SSH servers don't like it when sessions aren't closed by clients...