### PR TITLE
[change] Allowed defining subnet and IP address for VPN with OpenVPN backend #707

### DIFF
--- a/openwisp_controller/config/static/config/js/vpn.js
+++ b/openwisp_controller/config/static/config/js/vpn.js
@@ -33,18 +33,11 @@ django.jQuery(function ($) {
         // Show IP and Subnet field only for WireGuard backend
         var backendValue = $('#id_backend').val() === undefined ? '' : $('#id_backend').val().toLocaleLowerCase().toLocaleLowerCase();
         if (backendValue.includes('wireguard') || backendValue.includes('vxlan')) {
-            $('label[for="id_subnet"]').parent().parent().show();
-            $('label[for="id_ip"]').parent().parent().show();
             $('label[for="id_webhook_endpoint"]').parent().parent().show();
             $('label[for="id_auth_token"]').parent().parent().show();
         } else {
-            $('label[for="id_subnet"]').parent().parent().hide();
-            $('label[for="id_ip"]').parent().parent().hide();
             $('label[for="id_webhook_endpoint"]').parent().parent().hide();
             $('label[for="id_auth_token"]').parent().parent().hide();
-            // Reset IP and Subnet fields
-            $('#id_subnet').val(null);
-            $('#id_ip').val(null);
         }
 
         if (backendValue.includes('openvpn')) {

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -609,8 +609,8 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         vpn.save()
         self.assertEqual(vpn.public_key, '')
         self.assertEqual(vpn.private_key, '')
-        self.assertEqual(vpn.subnet, None)
-        self.assertEqual(vpn.ip, None)
+        self.assertEqual(vpn.subnet, subnet)
+        self.assertNotEqual(vpn.ip, None)
 
     def test_wireguard_vpn_without_subnet(self):
         with self.assertRaises(ValidationError) as context_manager:

--- a/openwisp_controller/subnet_division/tests/helpers.py
+++ b/openwisp_controller/subnet_division/tests/helpers.py
@@ -9,7 +9,7 @@ from openwisp_controller.subnet_division.rule_types.device import (
     DeviceSubnetDivisionRuleType,
 )
 
-from ...config.tests.utils import CreateConfigTemplateMixin, TestWireguardVpnMixin
+from ...config.tests.utils import CreateConfigTemplateMixin
 from ..rule_types.vpn import VpnSubnetDivisionRuleType
 
 SubnetDivisionRule = load_model('subnet_division', 'SubnetDivisionRule')
@@ -17,9 +17,7 @@ SubnetDivisionIndex = load_model('subnet_division', 'SubnetDivisionIndex')
 Subnet = load_model('openwisp_ipam', 'Subnet')
 
 
-class SubnetDivisionTestMixin(
-    CreateConfigTemplateMixin, TestWireguardVpnMixin, SubnetIpamMixin
-):
+class SubnetDivisionTestMixin(CreateConfigTemplateMixin, SubnetIpamMixin):
     @property
     def subnet_query(self):
         return Subnet.objects.exclude(name__contains='Reserved')


### PR DESCRIPTION
VPN server with OpenVPN backend can be assigned a subnet and an IP address. VpnClients created for such VPN server can also utilise subnet division rule functionality.

Closes #707