### PR TITLE
[chores] Added `.coverage.*` files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ pip-delete-this-directory.txt
 htmlcov/
 .tox/
 .coverage
+# When running coverage testing 
+# it creates .coverage-username.123x* files
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
- When running coverage testing, it creates `.coverage.*` files, this change will exclude them from git.