### PR TITLE
[fix] Fixed broken shared template preview #742

### DIFF
--- a/openwisp_controller/config/static/config/js/preview.js
+++ b/openwisp_controller/config/static/config/js/preview.js
@@ -27,6 +27,14 @@ django.jQuery(function ($) {
             if (name.indexOf('config-0-') === 0) {
                 name = name.replace('config-0-', '');
             }
+            // Systemwide shared objects are identified
+            // with a "null" id in the backend. When submitting
+            // a preview form, Django will raise a validation error 
+            // if the form field corresponding to the object ID 
+            // is not empty or does not contain a valid UUID string.
+            if ($field.attr('name') === 'organization' && $field.val() === 'null') {
+                $field.val('');
+            }
             data[name] = $field.val();
         });
         // show preview

--- a/openwisp_controller/config/static/config/js/preview.js
+++ b/openwisp_controller/config/static/config/js/preview.js
@@ -27,11 +27,7 @@ django.jQuery(function ($) {
             if (name.indexOf('config-0-') === 0) {
                 name = name.replace('config-0-', '');
             }
-            // Systemwide shared objects are identified
-            // with a "null" id in the backend. When submitting
-            // a preview form, Django will raise a validation error 
-            // if the form field corresponding to the object ID 
-            // is not empty or does not contain a valid UUID string.
+            // Avoid sending null which would raise a validation error
             if ($field.attr('name') === 'organization' && $field.val() === 'null') {
                 $field.val('');
             }


### PR DESCRIPTION
Systemwide shared objects are identified with a **"null"** id in the backend. When submitting a preview form, Django will raise an validation error if the form field corresponding to the object ID is not empty or does not contain a valid `UUID` string.

![Screenshot from 2023-03-13 16-45-50](https://user-images.githubusercontent.com/56113566/224687700-998dd302-329a-4629-90d6-14a77d682439.png)

Fixes #742

