### PR TITLE
[fix:ui] Fixed relevant templates JS bug corner case

### DIFF
--- a/openwisp_controller/config/static/config/js/relevant_templates.js
+++ b/openwisp_controller/config/static/config/js/relevant_templates.js
@@ -109,6 +109,8 @@ django.jQuery(function ($) {
                 // enabled templates on the top
                 if (selectedTemplates !== undefined) {
                     selectedTemplates.forEach(function (templateId, index) {
+                        // corner case in which backend of template does not match
+                        if (!data[templateId]) { return; }
                         var element = getTemplateOptionElement(index, templateId, data[templateId], true, false),
                             prefixElement = getTemplateOptionElement(index, templateId, data[templateId], true, true);
                         sortedm2mUl.append(element);
@@ -123,6 +125,8 @@ django.jQuery(function ($) {
                 // in the database.
                 var counter = selectedTemplates !== undefined ? selectedTemplates.length : 0;
                 Object.keys(data).forEach(function (templateId, index) {
+                    // corner case in which backend of template does not match
+                    if (!data[templateId]) { return; }
                     index = index + counter;
                     var isSelected = (data[templateId].default && (selectedTemplates === undefined)) && (!data[templateId].required),
                         element = getTemplateOptionElement(index, templateId, data[templateId], isSelected),


### PR DESCRIPTION
If the device has a template assigned to it with a backend which doesn't match the backend of the device, the code breaks, making it impossible for the admin to fix the issue using the web UI.