### PR TITLE
[fix] Fixed updating template puts devices in perennial "modified" state #213

### DIFF
--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -481,16 +481,15 @@ class AbstractConfig(BaseConfig):
         if self.backend != current.backend:
             # storing old backend to send backend change signal after save
             self._old_backend = current.backend
-        for attr in ['backend', 'config', 'context']:
-            if getattr(self, attr) == getattr(current, attr):
-                continue
+        if hasattr(self, 'backend_instance'):
+            del self.backend_instance
+        if self.checksum != current.checksum:
             if self.status != 'modified':
                 self.set_status_modified(save=False)
             else:
                 # config modified signal is always sent
                 # regardless of the current status
                 self._send_config_modified_after_save = True
-            break
 
     def _send_config_modified_signal(self, action):
         """

--- a/openwisp_controller/config/base/template.py
+++ b/openwisp_controller/config/base/template.py
@@ -112,13 +112,10 @@ class AbstractTemplate(ShareableOrgMixinUniqueName, BaseConfig):
         """
         update_related_config_status = False
         if not self._state.adding:
+            if hasattr(self, 'backend_instance'):
+                del self.backend_instance
             current = self.__class__.objects.get(pk=self.pk)
-            for attr in ['backend', 'config', 'default_values']:
-                new_value = _get_value_for_comparison(getattr(self, attr))
-                current_value = _get_value_for_comparison(getattr(current, attr))
-                if new_value != current_value:
-                    update_related_config_status = True
-                    break
+            update_related_config_status = self.checksum != current.checksum
         # save current changes
         super().save(*args, **kwargs)
         # update relations

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1122,6 +1122,11 @@ class TestAdmin(
     def test_existing_template_backend(self):
         t = Template.objects.first()
         t.backend = 'netjsonconfig.OpenWisp'
+        t.config = {
+            'general': {'hostname': '{{ hostname}}'},
+        }
+        t.default_values = {'hostname': 'placeholder'}
+        t.full_clean()
         t.save()
         path = reverse(f'admin:{self.app_label}_template_change', args=[t.pk])
         response = self.client.get(path)

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -919,7 +919,7 @@ class TestModelsTransaction(TransactionTestMixin, BaseTestModels, TransactionTes
             self.assertEqual(conf.status, 'applied')
 
         with self.subTest('openwisp_config < 0.6.0a: exit_code 0'):
-            conf.config = '{"interfaces": []}'
+            conf.config = '{"interfaces": [{"name": "eth00","type": "ethernet"}]}'
             conf.full_clean()
             with mock.patch(_exec_command_path) as mocked_exec_command:
                 mocked_exec_command.return_value = self._exec_command_return_value(


### PR DESCRIPTION
The status of related Config objects will only be updated if the checksum of template's configuration changes.

Closes #213