### PR TITLE
[fix] Fixed re-ordering applied templates in device config

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -362,7 +362,7 @@ class ConfigForm(AlwaysHasChangedMixin, BaseForm):
         return templates
 
     def save(self, *args, **kwargs):
-        templates = self.cleaned_data.pop('templates', [])
+        templates = self.cleaned_data.get('templates', [])
         instance = super().save(*args, **kwargs)
         # as group templates are not forced so if user remove any selected
         # group template, we need to remove it from the config instance


### PR DESCRIPTION
Bug:
It was not possible to change the ordering of the applied templates from the device's change page.