### PR TITLE
[feature] Removing VPN template will not delete related Cert #827

### DIFF
--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -356,7 +356,7 @@ class AbstractConfig(BaseConfig):
 
     @classmethod
     def certificate_updated(cls, instance, created, **kwargs):
-        if created:
+        if created or instance.revoked:
             return
         try:
             config = instance.vpnclient.config

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -921,10 +921,14 @@ class AbstractVpnClient(models.Model):
         if instance.vpn._is_backend_type('zerotier'):
             instance.vpn._remove_zt_network_member(instance.zerotier_member_id)
         try:
-            # only deletes related certificates
-            # if auto_cert field is set to True
+            # For OpenVPN, the related certificates are revoked, not deleted.
+            # This is because if the device retains a copy of the certificate,
+            # it could continue using it against the OpenVPN CA.
+            # By revoking the certificate, it gets added to the
+            # Certificate Revocation List (CRL). OpenVPN can then use this
+            # CRL to reject the certificate, thereby ensuring its invalidation.
             if instance.cert and instance.auto_cert:
-                instance.cert.delete()
+                instance.cert.revoke()
         except ObjectDoesNotExist:
             pass
         try:

--- a/openwisp_controller/config/tests/test_config.py
+++ b/openwisp_controller/config/tests/test_config.py
@@ -468,7 +468,7 @@ class TestConfig(
         self.assertNotEqual(c.vpnclient_set.count(), 0)
         self.assertNotEqual(cert_model.objects.filter(pk=cert.pk).count(), 0)
 
-    def test_automatically_created_cert_deleted_post_remove(self):
+    def test_automatically_created_cert_revoked_post_remove(self):
         self.test_create_cert()
         c = Config.objects.get(device__name='test-create-cert')
         t = Template.objects.get(name='test-create-cert')
@@ -477,7 +477,7 @@ class TestConfig(
         cert_model = cert.__class__
         c.templates.remove(t)
         self.assertEqual(c.vpnclient_set.count(), 0)
-        self.assertEqual(cert_model.objects.filter(pk=cert.pk).count(), 0)
+        self.assertEqual(cert_model.objects.filter(pk=cert.pk, revoked=True).count(), 1)
 
     def test_create_cert_false(self):
         vpn = self._create_vpn()

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -132,7 +132,7 @@ class TestVpn(BaseTestVpn, TestCase):
         else:
             self.fail('unique_together clause not triggered')
 
-    def test_vpn_client_auto_cert_deletes_cert(self):
+    def test_vpn_client_auto_cert_revokes_cert(self):
         org = self._get_org()
         vpn = self._create_vpn()
         t = self._create_template(name='vpn-test', type='vpn', vpn=vpn, auto_cert=True)
@@ -143,7 +143,7 @@ class TestVpn(BaseTestVpn, TestCase):
         self.assertEqual(Cert.objects.filter(pk=cert_pk).count(), 1)
         c.delete()
         self.assertEqual(VpnClient.objects.filter(pk=vpnclient.pk).count(), 0)
-        self.assertEqual(Cert.objects.filter(pk=cert_pk).count(), 0)
+        self.assertEqual(Cert.objects.filter(pk=cert_pk, revoked=True).count(), 1)
 
     def test_vpn_client_cert_post_deletes_cert(self):
         org = self._get_org()
@@ -251,7 +251,9 @@ class TestVpn(BaseTestVpn, TestCase):
             self.assertEqual(Cert.objects.filter(pk=cert.pk).count(), 1)
             self.assertEqual(VpnClient.objects.filter(pk=vpn_client.pk).count(), 1)
             vpnclient.delete()
-            self.assertEqual(Cert.objects.filter(pk=cert.pk).count(), cert_ct)
+            self.assertEqual(
+                Cert.objects.filter(pk=cert.pk, revoked=False).count(), cert_ct
+            )
             self.assertEqual(
                 VpnClient.objects.filter(pk=vpn_client.pk).count(), vpn_client_ct
             )

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -287,7 +287,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name='cert1')
         self.assertFalse(cert1.revoked)
         path = reverse('pki_api:cert_revoke', args=[cert1.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
Removing VPN template from a device will not delete related Cert object. Instead, it will mark the certificate as revoked.

Closes #827