### PR TITLE
[change] DeviceConnection.update_config will not flag as applied

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -368,7 +368,6 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             except Exception as e:
                 logger.exception(e)
             else:
-                self.device.config.set_status_applied()
                 self.disconnect()
 
     def save(self, *args, **kwargs):

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -928,7 +928,7 @@ class TestModelsTransaction(TransactionTestMixin, BaseTestModels, TransactionTes
                 args, _ = mocked_exec_command.call_args_list[1]
                 self.assertIn('OW_CONFIG_PID', args[0])
             conf.refresh_from_db()
-            self.assertEqual(conf.status, 'applied')
+            self.assertEqual(conf.status, 'modified')
 
         with self.subTest('openwisp_config < 0.6.0a: exit_code 0'):
             conf.config = '{"interfaces": [{"name": "eth00","type": "ethernet"}]}'
@@ -942,7 +942,7 @@ class TestModelsTransaction(TransactionTestMixin, BaseTestModels, TransactionTes
                 _assert_version_check_command(mocked_exec_command)
                 _assert_applying_conf_test_command(mocked_exec_command)
             conf.refresh_from_db()
-            self.assertEqual(conf.status, 'applied')
+            self.assertEqual(conf.status, 'modified')
 
         with self.subTest('openwisp_config < 0.6.0a: exit_code 1'):
             conf.config = '{"radios": []}'


### PR DESCRIPTION
DeviceConnection.update_config used to report the config as applied automatically, but this can potentially lead to inconsistencies. The config applied status is reported by the openwisp agent once the config has been applied successfully.