### PR TITLE
[feature] API: added name and mac_address to device list filters

### DIFF
--- a/openwisp_controller/config/api/filters.py
+++ b/openwisp_controller/config/api/filters.py
@@ -84,6 +84,14 @@ class DeviceListFilterBackend(DjangoFilterBackend):
 
 
 class DeviceListFilter(BaseConfigAPIFilter):
+    mac_address = filters.CharFilter(
+        field_name='mac_address',
+        lookup_expr='icontains',
+    )
+    name = filters.CharFilter(
+        field_name='name',
+        lookup_expr='icontains',
+    )
     created__gte = filters.DateTimeFilter(
         field_name='created',
         lookup_expr='gte',
@@ -106,6 +114,8 @@ class DeviceListFilter(BaseConfigAPIFilter):
     class Meta(BaseConfigAPIFilter.Meta):
         model = Device
         fields = BaseConfigAPIFilter.Meta.fields + [
+            'name',
+            'mac_address',
             'config__status',
             'config__backend',
             'config__templates',

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -209,7 +209,10 @@ class TestConfigApi(
         org2 = self._create_org(name='test org 2')
         dg2 = self._create_device_group(organization=org2)
         d2 = self._create_device(
-            mac_address='00:11:22:33:44:66', group=dg2, organization=org2
+            name='second.device',
+            mac_address='A0:11:B2:33:44:66',
+            group=dg2,
+            organization=org2,
         )
         t2 = self._create_template(name='t2', organization=org2)
         c2 = self._create_config(device=d2, backend='netjsonconfig.OpenWisp')
@@ -236,6 +239,18 @@ class TestConfigApi(
             self.assertIn('created', data['results'][0].keys())
             if device.group:
                 self.assertEqual(data['results'][0]['group'], device.group.pk)
+
+        with self.subTest('Test filtering by name'):
+            r1 = self.client.get(f'{path}?name={d1.name.upper()}')
+            _assert_device_list_filter(response=r1, device=d1)
+            r2 = self.client.get(f'{path}?name={d1.name[0:3]}')
+            _assert_device_list_filter(response=r2, device=d1)
+
+        with self.subTest('Test filtering by mac_address'):
+            r1 = self.client.get(f'{path}?mac_address={d2.mac_address.lower()}')
+            _assert_device_list_filter(response=r1, device=d2)
+            r2 = self.client.get(f'{path}?mac_address={d2.mac_address[0:8]}')
+            _assert_device_list_filter(response=r2, device=d2)
 
         with self.subTest('Test filtering using config backend'):
             r1 = self.client.get(f'{path}?config__backend=netjsonconfig.OpenWrt')


### PR DESCRIPTION
Allow searching by name and/or mac address (case insensitive) in the device API list endpoint.