### PR TITLE
[fix] Fixed celery tasks timeouts

### DIFF
--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -56,7 +56,7 @@ def create_vpn_dh(vpn_pk):
         vpn.save()
 
 
-@shared_task(base=OpenwispCeleryTask)
+@shared_task(soft_time_limit=7200)
 def invalidate_devicegroup_cache_change(instance_id, model_name):
     from .api.views import DeviceGroupCommonName
 
@@ -72,7 +72,7 @@ def invalidate_devicegroup_cache_change(instance_id, model_name):
         DeviceGroupCommonName.certificate_change_invalidates_cache(instance_id)
 
 
-@shared_task(base=OpenwispCeleryTask)
+@shared_task(soft_time_limit=7200)
 def invalidate_vpn_server_devices_cache_change(vpn_pk):
     Vpn = load_model('config', 'Vpn')
     VpnClient = load_model('config', 'VpnClient')
@@ -80,7 +80,7 @@ def invalidate_vpn_server_devices_cache_change(vpn_pk):
     VpnClient.invalidate_clients_cache(vpn)
 
 
-@shared_task(base=OpenwispCeleryTask)
+@shared_task(soft_time_limit=7200)
 def invalidate_devicegroup_cache_delete(instance_id, model_name, **kwargs):
     from .api.views import DeviceGroupCommonName
 

--- a/openwisp_controller/subnet_division/tasks.py
+++ b/openwisp_controller/subnet_division/tasks.py
@@ -5,8 +5,6 @@ from django.db import transaction
 from django.utils.translation import gettext_lazy as _
 from swapper import load_model
 
-from openwisp_utils.tasks import OpenwispCeleryTask
-
 logger = logging.getLogger(__name__)
 
 Subnet = load_model('openwisp_ipam', 'Subnet')
@@ -71,7 +69,7 @@ def update_subnet_name_description(rule_id):
     )
 
 
-@shared_task(base=OpenwispCeleryTask)
+@shared_task(soft_time_limit=7200)
 def provision_extra_ips(rule_id, old_number_of_ips):
     def _create_ipaddress_and_subnetdivision_index_objects(ips, indexes):
         IpAddress.objects.bulk_create(ips)


### PR DESCRIPTION
We should not use OpenwispCeleryTask class on celery tasks that queries over several objects in the database.