### PR TITLE
[fix] JS workaround for using mac address variable

### DIFF
--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -469,6 +469,11 @@
     var varValidationWorkaround = function(value, schema) {
       if (value && value.interfaces) {
         $.each(value.interfaces, function(i, interf) {
+          if (interf.mac && interf.mac.indexOf('{{') > -1) {
+            try {
+              delete schema.definitions.interface_settings.properties.mac.pattern;
+            } catch (e) {}
+          }
           if (interf.addresses) {
             $.each(interf.addresses, function(i, ip) {
               if (ip.address && ip.address.indexOf('{{') > -1) {


### PR DESCRIPTION
I applied the same workaround applied for allowing to use variables in IP address fields.