### PR TITLE
[fix] Fixed subnet division rule validation on empty subnet  #866

### DIFF
--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -108,7 +108,7 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
             master_subnet = self.master_subnet.subnet
             if not master_subnet:
                 raise ValidationError(
-                    {'master_subnet': _('Master subnet must have a valid subnet.')}
+                    {'master_subnet': _('Master subnet must be a valid subnet.')}
                 )
         except AttributeError:
             raise ValidationError(

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -71,6 +71,7 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
     def clean(self):
         super().clean()
         self._validate_label()
+        self._validate_master_subnet_validity()
         self._validate_master_subnet_consistency()
         self._validate_ip_address_consistency()
         if not self._state.adding:
@@ -85,6 +86,10 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
                     )
                 }
             )
+
+    def _validate_master_subnet_validity(self):
+        if not self.master_subnet.subnet:
+            raise ValidationError({'master_subnet': _('Invalid master subnet.')})
 
     def _validate_existing_fields(self):
         db_instance = self._meta.model.objects.get(id=self.id)
@@ -103,15 +108,11 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
             )
 
     def _validate_master_subnet_consistency(self):
-        # Try to retrieve and validate master_subnet
         master_subnet = self.master_subnet.subnet
-        if not master_subnet:
-            raise ValidationError(
-                {'master_subnet': _('Master subnet is required and cannot be empty.')}
-            )
         # Try to generate subnets and validate size
         try:
             next(master_subnet.subnets(new_prefix=self.size))
+        # if size is not consistent, raise error
         except ValueError:
             raise ValidationError(
                 {
@@ -122,7 +123,6 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
                     )
                 }
             )
-
         # Ensure that master subnet can accommodate
         # the required number of generated subnets
         available = 2 ** (self.size - master_subnet.prefixlen)
@@ -139,7 +139,6 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
                     )
                 }
             )
-
         # Validate organization of master subnet
         if (
             self.master_subnet.organization is not None

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -104,13 +104,8 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
 
     def _validate_master_subnet_consistency(self):
         # Try to retrieve and validate master_subnet
-        try:
-            master_subnet = self.master_subnet.subnet
-            if not master_subnet:
-                raise ValidationError(
-                    {'master_subnet': _('Master subnet must be a valid subnet.')}
-                )
-        except AttributeError:
+        master_subnet = self.master_subnet.subnet
+        if not master_subnet:
             raise ValidationError(
                 {'master_subnet': _('Master subnet is required and cannot be empty.')}
             )

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -103,9 +103,18 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
             )
 
     def _validate_master_subnet_consistency(self):
-        master_subnet = self.master_subnet.subnet
-        # Ensure that the size of the generated subnet
-        # is not greater than size of master subnet
+        # Try to retrieve and validate master_subnet
+        try:
+            master_subnet = self.master_subnet.subnet
+            if not master_subnet:
+                raise ValidationError(
+                    {'master_subnet': _('Master subnet must have a valid subnet.')}
+                )
+        except AttributeError:
+            raise ValidationError(
+                {'master_subnet': _('Master subnet is required and cannot be empty.')}
+            )
+        # Try to generate subnets and validate size
         try:
             next(master_subnet.subnets(new_prefix=self.size))
         except ValueError:

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -956,6 +956,57 @@ class TestSubnetDivisionRule(
             device_rule.number_of_subnets,
         )
 
+    def test_empty_master_subnet(self):
+        try:
+            rule = SubnetDivisionRule(
+                type='openwisp_controller.subnet_division.rule_types.vpn.'
+                'VpnSubnetDivisionRuleType',
+                label='TEST',
+                size=28,
+                number_of_subnets=2,
+                number_of_ips=2,
+                organization=self.org,
+                # master_subnet is intentionally omitted
+            )
+            rule.full_clean()
+        except ValidationError as e:
+            # Ensure custom error message is present
+            self.assertIn(
+                'Master subnet is required and cannot be empty.',
+                e.message_dict.get('master_subnet', []),
+            )
+            # Ensure default error message is also present
+            self.assertIn(
+                'This field cannot be null.', e.message_dict.get('master_subnet', [])
+            )
+        else:
+            self.fail('ValidationError not raised')
+
+    def test_invalid_master_subnet(self):
+        try:
+            invalid_subnet = Subnet(
+                name='Invalid Subnet'
+            )  # Create a subnet without setting its 'subnet' attribute
+            rule = SubnetDivisionRule(
+                type='openwisp_controller.subnet_division.rule_types.vpn.'
+                'VpnSubnetDivisionRuleType',
+                label='TEST',
+                size=28,
+                number_of_subnets=2,
+                number_of_ips=2,
+                organization=self.org,
+                master_subnet=invalid_subnet,  # Set an invalid master_subnet
+            )
+            rule.full_clean()
+        except ValidationError as e:
+            # Ensure custom error message is present
+            self.assertIn(
+                'Master subnet must have a valid subnet.',
+                e.message_dict.get('master_subnet', []),
+            )
+        else:
+            self.fail('ValidationError not raised')
+
 
 class TestOpenVPNSubnetDivisionRule(
     SubnetDivisionTestMixin,

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -957,55 +957,35 @@ class TestSubnetDivisionRule(
         )
 
     def test_empty_master_subnet(self):
-        try:
-            rule = SubnetDivisionRule(
-                type='openwisp_controller.subnet_division.rule_types.vpn.'
-                'VpnSubnetDivisionRuleType',
-                label='TEST',
-                size=28,
-                number_of_subnets=2,
-                number_of_ips=2,
-                organization=self.org,
-                # master_subnet is intentionally omitted
-            )
+        rule = SubnetDivisionRule(
+            type='openwisp_controller.subnet_division.rule_types.vpn.'
+            'VpnSubnetDivisionRuleType',
+            label='TEST',
+            size=28,
+            number_of_subnets=2,
+            number_of_ips=2,
+            organization=self.org,
+            # master_subnet is intentionally omitted
+        )
+        with self.assertRaises(ValidationError) as context:
             rule.full_clean()
-        except ValidationError as e:
-            # Ensure custom error message is present
-            self.assertIn(
-                'Master subnet is required and cannot be empty.',
-                e.message_dict.get('master_subnet', []),
-            )
-            # Ensure default error message is also present
-            self.assertIn(
-                'This field cannot be null.', e.message_dict.get('master_subnet', [])
-            )
-        else:
-            self.fail('ValidationError not raised')
+        self.assertIn('This field cannot be null.', str(context.exception))
 
     def test_invalid_master_subnet(self):
-        try:
-            invalid_subnet = Subnet(
-                name='Invalid Subnet'
-            )  # Create a subnet without setting its 'subnet' attribute
-            rule = SubnetDivisionRule(
-                type='openwisp_controller.subnet_division.rule_types.vpn.'
-                'VpnSubnetDivisionRuleType',
-                label='TEST',
-                size=28,
-                number_of_subnets=2,
-                number_of_ips=2,
-                organization=self.org,
-                master_subnet=invalid_subnet,  # Set an invalid master_subnet
-            )
+        # Instantiate a subnet without setting its 'subnet' attribute
+        invalid_subnet = Subnet(name='Invalid Subnet')
+        rule = SubnetDivisionRule(
+            type='openwisp_controller.subnet_division.rule_types.vpn.'
+            'VpnSubnetDivisionRuleType',
+            label='TEST',
+            size=28,
+            number_of_subnets=2,
+            number_of_ips=2,
+            organization=self.org,
+            master_subnet=invalid_subnet,  # Invalid master_subnet
+        )
+        with self.assertRaises(ValidationError):
             rule.full_clean()
-        except ValidationError as e:
-            # Ensure custom error message is present
-            self.assertIn(
-                'Master subnet must have a valid subnet.',
-                e.message_dict.get('master_subnet', []),
-            )
-        else:
-            self.fail('ValidationError not raised')
 
 
 class TestOpenVPNSubnetDivisionRule(

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -984,8 +984,13 @@ class TestSubnetDivisionRule(
             organization=self.org,
             master_subnet=invalid_subnet,  # Invalid master_subnet
         )
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ValidationError) as cm:
             rule.full_clean()
+        e = cm.exception
+        self.assertIn(
+            'Master subnet must be a valid subnet.',
+            e.message_dict.get('master_subnet', []),
+        )
 
 
 class TestOpenVPNSubnetDivisionRule(

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -956,21 +956,6 @@ class TestSubnetDivisionRule(
             device_rule.number_of_subnets,
         )
 
-    def test_empty_master_subnet(self):
-        rule = SubnetDivisionRule(
-            type='openwisp_controller.subnet_division.rule_types.vpn.'
-            'VpnSubnetDivisionRuleType',
-            label='TEST',
-            size=28,
-            number_of_subnets=2,
-            number_of_ips=2,
-            organization=self.org,
-            # master_subnet is intentionally omitted
-        )
-        with self.assertRaises(ValidationError) as context:
-            rule.full_clean()
-        self.assertIn('This field cannot be null.', str(context.exception))
-
     def test_invalid_master_subnet(self):
         # Instantiate a subnet without setting its 'subnet' attribute
         invalid_subnet = Subnet(name='Invalid Subnet')
@@ -988,7 +973,7 @@ class TestSubnetDivisionRule(
             rule.full_clean()
         e = cm.exception
         self.assertIn(
-            'Master subnet must be a valid subnet.',
+            'Invalid master subnet.',
             e.message_dict.get('master_subnet', []),
         )
 


### PR DESCRIPTION
Fixes #866

-The issue occurs because the code assumes that self.master_subnet and self.master_subnet.subnet are always set, but in this case, they can be None. By adding a check at the beginning of the method, we ensure that a proper validation error is raised when the master subnet is empty or not set.
-The validation error will be caught and displayed in the UI instead of causing a 500 internal server error.