### PR TITLE
[BUG] MAC address set to uppercase when creating a registering a new

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -222,6 +222,7 @@ class AbstractDevice(OrgMixin, BaseModel):
                 )
 
     def clean(self, *args, **kwargs):
+        self.mac_address = self.mac_address.upper()
         super().clean(*args, **kwargs)
         self._validate_unique_name()
         self._validate_org_relation('group', field_error='group')

--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -287,7 +287,10 @@ class DeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
                 device_model._meta.get_field(attr)
             except FieldDoesNotExist:
                 continue
-            options[attr] = kwargs.get(attr)
+            if attr == 'mac_address':
+                options[attr] = kwargs.get(attr).upper()
+            else:
+                options[attr] = kwargs.get(attr)
         # do not specify key if:
         #   app_settings.CONSISTENT_REGISTRATION is False
         #   if key is ``None`` (it would cause exception)

--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -287,10 +287,7 @@ class DeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
                 device_model._meta.get_field(attr)
             except FieldDoesNotExist:
                 continue
-            if attr == 'mac_address':
-                options[attr] = kwargs.get(attr).upper()
-            else:
-                options[attr] = kwargs.get(attr)
+            options[attr] = kwargs.get(attr)
         # do not specify key if:
         #   app_settings.CONSISTENT_REGISTRATION is False
         #   if key is ``None`` (it would cause exception)


### PR DESCRIPTION
[BUG] MAC address set to uppercase when creating a registering a new

In device registration view, Made changes to the init object and included  checked if attribute is mac_address then it should be changed to upper case

Fixes #922

## Checklist

- [* ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [* ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

