### PR TITLE
[fix] Allow updating templates with invalid configurations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,8 +53,8 @@ Other popular building blocks that are part of the OpenWISP ecosystem are:
   provides device status monitoring, collection of metrics, charts,
   alerts, possibility to define custom checks
 - `openwisp-firmware-upgrader
-  <https://openwisp.io/docs/stable/firmware-upgrader/>`_: automated firmware
-  upgrades (single devices or mass network upgrades)
+  <https://openwisp.io/docs/stable/firmware-upgrader/>`_: automated
+  firmware upgrades (single devices or mass network upgrades)
 - `openwisp-radius <https://openwisp.io/docs/stable/user/radius.html>`_:
   based on FreeRADIUS, allows to implement network access authentication
   systems like 802.1x WPA2 Enterprise, captive portal authentication,
@@ -65,10 +65,11 @@ Other popular building blocks that are part of the OpenWISP ecosystem are:
   daemons or other network software (e.g.: OpenVPN); it can be used in
   conjunction with openwisp-monitoring to get a better idea of the state
   of the network
-- `openwisp-ipam <https://openwisp.io/docs/stable/ipam/>`_: allows to manage
-  the assignment of IP addresses used in the network
-- `openwisp-notifications <https://openwisp.io/docs/stable/notifications/>`_:
-  allows users to be aware of important events happening in the network.
+- `openwisp-ipam <https://openwisp.io/docs/stable/ipam/>`_: allows to
+  manage the assignment of IP addresses used in the network
+- `openwisp-notifications
+  <https://openwisp.io/docs/stable/notifications/>`_: allows users to be
+  aware of important events happening in the network.
 
 **For a more complete overview of the OpenWISP modules and architecture**,
 see the `OpenWISP Architecture Overview

--- a/openwisp_controller/__init__.py
+++ b/openwisp_controller/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 1, 0, 'final')
+VERSION = (1, 2, 0, 'alpha')
 __version__ = VERSION  # alias
 
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

A new regression prevented fixing an invalid template configuration via the UI: the cache invalidation mechanism triggered the evaluation of the configuration which can fail if the configuration is invalid (eg: due to schema updates), hence there was an uncaught ValidationError bubbling up and preventing updates.

This patch fixes this issue.
