### PR TITLE
[tests] Fix test failures with Python 3.12 #953

### DIFF
--- a/openwisp_controller/config/tests/test_controller.py
+++ b/openwisp_controller/config/tests/test_controller.py
@@ -1346,7 +1346,7 @@ class TestController(CreateConfigTemplateMixin, TestVpnX509Mixin, TestCase):
         self.assertIsNone(c1.device.management_ip)
         self.assertEqual(c2.device.management_ip, '192.168.1.99')
         # other organization is not affected
-        self.assertEquals(c3.device.last_ip, '127.0.0.1')
+        self.assertEqual(c3.device.last_ip, '127.0.0.1')
         self.assertEqual(c3.device.management_ip, '192.168.1.99')
 
         with self.subTest('test interaction with DeviceChecksumView caching'):

--- a/openwisp_controller/config/tests/test_template.py
+++ b/openwisp_controller/config/tests/test_template.py
@@ -356,7 +356,8 @@ class TestTemplate(CreateConfigTemplateMixin, TestVpnX509Mixin, TestCase):
             template_qs = Template.objects.filter(type='vpn')
             self.assertEqual(template_qs.count(), 1)
             t = template_qs.first()
-            self.assertDictContainsSubset(_original_context, t.get_context())
+            for key, value in _original_context.items():
+                self.assertEqual(t.get_context().get(key), value)
             self.assertEqual(app_settings.CONTEXT, _original_context)
 
         with self.subTest(


### PR DESCRIPTION
Tests are failing on Python 3.12 due to:
1. Removal of assertDictContainsSubset.
2. Deprecation of assertEquals (now replaced by assertEqual).

Fixes #953

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Reference to Existing Issue

Closes #953

## Description of Changes

Replaced assertEquals with assertEqual and assertDictContainsSubset with for loop to check all key-value pairs.
