### PR TITLE
[tests] Selenium test for Preview configuration with keyboard #868

### DIFF
--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -145,8 +145,8 @@ class TestDeviceAdmin(
             actions = ActionChains(self.web_driver)
             actions.key_down(Keys.ALT).send_keys('p').key_up(Keys.ALT).perform()
             try:
-                WebDriverWait(self.web_driver, 2).until(
-                    EC.invisibility_of_element_located(
+                WebDriverWait(self.web_driver, 1).until(
+                    EC.visibility_of_element_located(
                         (By.CSS_SELECTOR, '.djnjc-overlay:not(.loading)')
                     )
                 )
@@ -157,7 +157,7 @@ class TestDeviceAdmin(
             actions = ActionChains(self.web_driver)
             actions.send_keys(Keys.ESCAPE).perform()
             try:
-                WebDriverWait(self.web_driver, 2).until(
+                WebDriverWait(self.web_driver, 1).until(
                     EC.invisibility_of_element_located(
                         (By.CSS_SELECTOR, '.djnjc-overlay:not(.loading)')
                     )

--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -133,18 +133,11 @@ class TestDeviceAdmin(
         )
 
     def test_device_preview_keyboard_shortcuts(self):
-        self._create_config(device=self._create_device(name='Test'))
+        device = self._create_config(device=self._create_device(name='Test')).device
         self.login()
         self.open(reverse('admin:config_device_changelist'))
-
-        # open first device in the list
-        self.web_driver.find_element(
-            by=By.CSS_SELECTOR, value='tbody tr:nth-child(1) th a'
-        ).click()
         try:
-            WebDriverWait(self.web_driver, 2).until(
-                EC.presence_of_element_located((By.CSS_SELECTOR, '#content-main'))
-            )
+            self.open(reverse('admin:config_device_change', args=[device.id]))
         except TimeoutException:
             self.fail('Device detail page did not load in time')
 
@@ -153,10 +146,9 @@ class TestDeviceAdmin(
             actions.key_down(Keys.ALT).send_keys('p').key_up(Keys.ALT).perform()
             try:
                 WebDriverWait(self.web_driver, 2).until(
-                    lambda driver: driver.find_element(
-                        By.CSS_SELECTOR, '.djnjc-overlay:not(.loading)'
-                    ).value_of_css_property('display')
-                    != 'none'
+                    EC.invisibility_of_element_located(
+                        (By.CSS_SELECTOR, '.djnjc-overlay:not(.loading)')
+                    )
                 )
             except TimeoutException:
                 self.fail('The preview overlay is unexpectedly not visible')
@@ -166,10 +158,9 @@ class TestDeviceAdmin(
             actions.send_keys(Keys.ESCAPE).perform()
             try:
                 WebDriverWait(self.web_driver, 2).until(
-                    lambda driver: driver.find_element(
-                        By.CSS_SELECTOR, '.djnjc-overlay:not(.loading)'
-                    ).value_of_css_property('display')
-                    == 'none'
+                    EC.invisibility_of_element_located(
+                        (By.CSS_SELECTOR, '.djnjc-overlay:not(.loading)')
+                    )
                 )
             except TimeoutException:
                 self.fail('The preview overlay has not been closed as expected')


### PR DESCRIPTION
Added a Selenium test case to replicate the process by creating a device, clicking its anchor tag, pressing ALT+P to open the preview, and pressing ESC to close it.

Fixes #868

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Reference to Existing Issue

Closes #868

### Description of Changes:

- Creates and saves a device configuration.
- Navigate to the device detail page.
- Simulates pressing `Alt + P` to open the preview configuration overlay.
- Verifies that the overlay becomes visible.
- Simulates pressing `Escape` to close the overlay.
- Confirms that the overlay disappears.