### PR TITLE
[feature] Add API endpoint for indoor map coordinates #828

### DIFF
--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -961,9 +961,10 @@ List Indoor Coordinates of a Location
 
 .. note::
 
-    this endpoint returns device coordinates from the lowest positive
-    floor by default. If no positive floor exists, it returns coordinates
-    from the highest negative floor instead.
+    this endpoint returns device coordinates from the first floor above
+    ground (lowest non-negative floors) by default. If a location only has
+    negative floors (e.g. underground parking lot), then it will return
+    the closest floor to the ground (maximum negative floor).
 
 .. code-block:: text
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -956,6 +956,28 @@ Delete Floor Plan
 
     DELETE /api/v1/controller/floorplan/{pk}/
 
+List Indoor Coordinates of a Location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    this endpoint returns device coordinates from the lowest positive
+    floor by default. If no positive floor exists, it returns coordinates
+    from the highest negative floor instead.
+
+.. code-block:: text
+
+    GET /api/v1/controller/location/{id}/indoor-coordinates/
+
+**Available filters**
+
+You can filter using ``floor`` to get list of devices and their indoor
+coodinates for that floor.
+
+.. code-block:: text
+
+    GET /api/v1/controller/location/{id}/indoor-coordinates/?floor={floor}
+
 List Templates
 ~~~~~~~~~~~~~~
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -961,7 +961,7 @@ List Indoor Coordinates of a Location
 
 .. note::
 
-    this endpoint returns device coordinates from the first floor above
+    This endpoint returns device coordinates from the first floor above
     ground (lowest non-negative floors) by default. If a location only has
     negative floors (e.g. underground parking lot), then it will return
     the closest floor to the ground (maximum negative floor).

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -964,7 +964,7 @@ List Indoor Coordinates of a Location
     This endpoint returns device coordinates from the first floor above
     ground (lowest non-negative floors) by default. If a location only has
     negative floors (e.g. underground parking lot), then it will return
-    the closest floor to the ground (maximum negative floor).
+    the closest floor to the ground (greatest negative floor).
 
 .. code-block:: text
 

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -363,7 +363,7 @@ class FloorplanCoordinatesSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = DeviceLocation
-        fields = (
+        fields = [
             "name",
             "mac_address",
             "is_deactivated",
@@ -373,7 +373,7 @@ class FloorplanCoordinatesSerializer(serializers.ModelSerializer):
             "floor",
             "image",
             "location",
-        )
+        ]
 
     def get_floor_name(self, obj):
         loc_name = obj.floorplan.location.name
@@ -389,5 +389,5 @@ class FloorplanCoordinatesSerializer(serializers.ModelSerializer):
                 detail={"indoor": _("Floorplan indoor cordinates is null")}
             )
 
-        x, y = obj.indoor.split(",", 1)
+        y, x = obj.indoor.split(",", 1)
         return {"lat": float(y), "lng": float(x)}

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -385,10 +385,5 @@ class IndoorCoordinatesSerializer(serializers.ModelSerializer):
         """
         NetJsonGraph expects indoor coordinates in {'lat': y, 'lng': x}.
         """
-        if not obj.indoor:
-            raise serializers.ValidationError(
-                detail={"indoor": _("Floorplan indoor cordinates is null")}
-            )
-
         y, x = obj.indoor.split(",", 1)
         return {"lat": float(y), "lng": float(x)}

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -351,11 +351,12 @@ class DeviceLocationSerializer(serializers.ModelSerializer):
 
 
 class IndoorCoordinatesSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source="content_object.name")
+    content_object_id = serializers.UUIDField(
+        source="content_object.id", read_only=True
+    )
+    floorplan_id = serializers.UUIDField(source="floorplan.id", read_only=True)
+    device_name = serializers.CharField(source="content_object.name")
     mac_address = serializers.CharField(source="content_object.mac_address")
-    is_deactivated = serializers.BooleanField(source="content_object.is_deactivated")
-    model = serializers.CharField(source="content_object.model")
-    os = serializers.CharField(source="content_object.os")
     floor_name = serializers.SerializerMethodField()
     floor = serializers.IntegerField(source="floorplan.floor")
     image = serializers.ImageField(source="floorplan.image", read_only=True)
@@ -364,11 +365,11 @@ class IndoorCoordinatesSerializer(serializers.ModelSerializer):
     class Meta:
         model = DeviceLocation
         fields = [
-            "name",
+            "id",
+            "content_object_id",
+            "floorplan_id",
+            "device_name",
             "mac_address",
-            "is_deactivated",
-            "model",
-            "os",
             "floor_name",
             "floor",
             "image",

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -352,9 +352,7 @@ class DeviceLocationSerializer(serializers.ModelSerializer):
 
 class IndoorCoordinatesSerializer(serializers.ModelSerializer):
     admin_edit_url = SerializerMethodField("get_admin_edit_url")
-    content_object_id = serializers.UUIDField(
-        source="content_object.id", read_only=True
-    )
+    device_id = serializers.UUIDField(source="content_object.id", read_only=True)
     floorplan_id = serializers.UUIDField(source="floorplan.id", read_only=True)
     device_name = serializers.CharField(source="content_object.name")
     mac_address = serializers.CharField(source="content_object.mac_address")
@@ -368,7 +366,7 @@ class IndoorCoordinatesSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "admin_edit_url",
-            "content_object_id",
+            "device_id",
             "floorplan_id",
             "device_name",
             "mac_address",
@@ -387,9 +385,7 @@ class IndoorCoordinatesSerializer(serializers.ModelSerializer):
         )
 
     def get_floor_name(self, obj):
-        loc_name = obj.floorplan.location.name
-        floor_no = obj.floorplan.floor
-        return f"{loc_name} {ordinal(floor_no)} Floor"
+        return str(obj.floorplan)
 
     def get_coordinates(self, obj):
         """

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -350,7 +350,7 @@ class DeviceLocationSerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class FloorplanCoordinatesSerializer(serializers.ModelSerializer):
+class IndoorCoordinatesSerializer(serializers.ModelSerializer):
     name = serializers.CharField(source="content_object.name")
     mac_address = serializers.CharField(source="content_object.mac_address")
     is_deactivated = serializers.BooleanField(source="content_object.is_deactivated")

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -257,12 +257,8 @@ class IndoorCoordinatesList(
         return qs
 
     def list(self, request, *args, **kwargs):
-        qs = self.get_queryset()
-        floors = self.get_available_floors(qs)
-        filtered_qs = self.filter_queryset(qs)
-        page = self.paginate_queryset(filtered_qs)
-        serializer = self.get_serializer(page, many=True)
-        response = self.get_paginated_response(serializer.data)
+        floors = self.get_available_floors(self.get_queryset())
+        response = super().list(request, *args, **kwargs)
         if response.status_code == 200:
             response.data["floors"] = floors
         return response

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -200,6 +200,7 @@ class FloorplanCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
     serializer_class = FloorplanCoordinatesSerializer
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = FloorplanCoordinatesFilter
+    pagination_class = ListViewPagination
     queryset = (
         DeviceLocation.objects.filter(
             location__type="indoor",

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -230,31 +230,44 @@ class IndoorCoordinatesList(
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = IndoorCoordinatesFilter
     pagination_class = IndoorCoodinatesViewPagination
-    organization_field = "content_object__organization"
-
     queryset = (
         DeviceLocation.objects.filter(
             location__type="indoor",
             floorplan__isnull=False,
         )
         .select_related(
-            "content_object", "location", "floorplan", "content_object__organization"
+            "content_object", "location", "floorplan", "location__organization"
         )
         .order_by("floorplan__floor")
     )
 
     def get_parent_queryset(self):
-        return DeviceLocation.objects.filter(location__pk=self.kwargs.get("pk"))
+        qs = Location.objects.filter(pk=self.kwargs["pk"])
+        return qs
+
+    def get_queryset(self):
+        return super().get_queryset().filter(location_id=self.kwargs["pk"])
+
+    def get_organization_queryset(self, qs):
+        """
+        Perform organization lookup based on the model.
+
+        We need to filter the DeviceLocation queryset based on the related
+        Location.organization because the DeviceLocation object does not have
+        a direct relation to Organization.
+
+        TODO: Remove this working when the issue is fixed in openwisp-users.
+        https://github.com/openwisp/openwisp-users/issues/455
+        """
+        lookup_value = getattr(self.request.user, self._user_attr)
+        lookup_key = (
+            "organization__in" if qs.model == Location else "location__organization__in"
+        )
+        return qs.filter(**{lookup_key: lookup_value})
 
     def get_available_floors(self, qs):
         floors = list(qs.values_list("floorplan__floor", flat=True).distinct())
         return floors
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        location_id = self.kwargs.get("pk")
-        qs = qs.filter(location__id=location_id)
-        return qs
 
     def list(self, request, *args, **kwargs):
         floors = self.get_available_floors(self.get_queryset())

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -217,10 +217,6 @@ class FloorplanCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
         qs = qs.filter(location__id=location_id)
         return qs
 
-    def list(self, request, *args, **kwargs):
-        serializer = self.get_serializer(self.get_queryset(), many=True)
-        return Response({"nodes": serializer.data, "links": []})
-
 
 class LocationDeviceList(
     FilterByParentManaged, ProtectedAPIMixin, generics.ListAPIView

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -52,15 +52,6 @@ class FloorPlanOrganizationFilter(OrganizationManagedFilter):
         model = FloorPlan
 
 
-class IndoorCoordinatesFilter(OrganizationManagedFilter):
-    floor = filters.NumberFilter(field_name="floorplan__floor")
-    organization = filters.UUIDFilter(field_name="content_object__organization")
-
-    class Meta(OrganizationManagedFilter.Meta):
-        model = DeviceLocation
-        fields = OrganizationManagedFilter.Meta.fields + ["floor"]
-
-
 class ListViewPagination(pagination.PageNumberPagination):
     page_size = 10
     page_size_query_param = "page_size"
@@ -197,14 +188,12 @@ class GeoJsonLocationList(
 
 
 class IndoorCoodinatesViewPagination(ListViewPagination):
-    # Todo: Make it 50
-    page_size = 5
+    page_size = 50
 
 
 class IndoorCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
     serializer_class = IndoorCoordinatesSerializer
     filter_backends = [filters.DjangoFilterBackend]
-    filterset_class = IndoorCoordinatesFilter
     pagination_class = IndoorCoodinatesViewPagination
     queryset = (
         DeviceLocation.objects.filter(
@@ -227,9 +216,8 @@ class IndoorCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
         return floors
 
     def get_floor_from_query_or_default(self, qs, floor_param):
-        # Todo: Make better comment
         """
-        Returns first positive floor if no param is provieded if provived show for that perticular floor
+        Returns the requested floor if valid, else the first positive floor.
         """
         floors = self.get_available_floors()
         if floor_param is None:

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -200,7 +200,6 @@ class IndoorCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
     serializer_class = IndoorCoordinatesSerializer
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = IndoorCoordinatesFilter
-    pagination_class = ListViewPagination
     queryset = (
         DeviceLocation.objects.filter(
             location__type="indoor",

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -218,12 +218,15 @@ class IndoorCoodinatesViewPagination(ListViewPagination):
     page_size = 50
 
 
-class IndoorCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
+class IndoorCoordinatesList(
+    RelatedDeviceProtectedAPIMixin, FilterByParentManaged, generics.ListAPIView
+):
     serializer_class = IndoorCoordinatesSerializer
     filter_backends = [filters.DjangoFilterBackend]
     filterset_class = IndoorCoordinatesFilter
     pagination_class = IndoorCoodinatesViewPagination
     organization_field = "content_object__organization"
+
     queryset = (
         DeviceLocation.objects.filter(
             location__type="indoor",
@@ -234,6 +237,9 @@ class IndoorCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
         )
         .order_by("floorplan__floor")
     )
+
+    def get_parent_queryset(self):
+        return DeviceLocation.objects.filter(location__pk=self.kwargs.get("pk"))
 
     def get_available_floors(self, qs):
         floors = list(qs.values_list("floorplan__floor", flat=True).distinct())

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -219,7 +219,7 @@ class IndoorCoodinatesViewPagination(ListViewPagination):
 
 
 class IndoorCoordinatesList(
-    RelatedDeviceProtectedAPIMixin, FilterByParentManaged, generics.ListAPIView
+    FilterByParentManaged, ProtectedAPIMixin, generics.ListAPIView
 ):
     serializer_class = IndoorCoordinatesSerializer
     filter_backends = [filters.DjangoFilterBackend]

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -19,9 +19,9 @@ from .filters import DeviceListFilter
 from .serializers import (
     DeviceCoordinatesSerializer,
     DeviceLocationSerializer,
-    FloorplanCoordinatesSerializer,
     FloorPlanSerializer,
     GeoJsonLocationSerializer,
+    IndoorCoordinatesSerializer,
     LocationDeviceSerializer,
     LocationSerializer,
 )
@@ -52,7 +52,7 @@ class FloorPlanOrganizationFilter(OrganizationManagedFilter):
         model = FloorPlan
 
 
-class FloorplanCoordinatesFilter(OrganizationManagedFilter):
+class IndoorCoordinatesFilter(OrganizationManagedFilter):
     floor = filters.NumberFilter(field_name="floorplan__floor")
     organization = filters.UUIDFilter(field_name="content_object__organization")
 
@@ -196,10 +196,10 @@ class GeoJsonLocationList(
     filterset_class = LocationOrganizationFilter
 
 
-class FloorplanCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
-    serializer_class = FloorplanCoordinatesSerializer
+class IndoorCoordinatesList(ProtectedAPIMixin, generics.ListAPIView):
+    serializer_class = IndoorCoordinatesSerializer
     filter_backends = [filters.DjangoFilterBackend]
-    filterset_class = FloorplanCoordinatesFilter
+    filterset_class = IndoorCoordinatesFilter
     pagination_class = ListViewPagination
     queryset = (
         DeviceLocation.objects.filter(
@@ -277,6 +277,6 @@ geojson = GeoJsonLocationList.as_view()
 location_device_list = LocationDeviceList.as_view()
 list_floorplan = FloorPlanListCreateView.as_view()
 detail_floorplan = FloorPlanDetailView.as_view()
-floorplan_coordinates_list = FloorplanCoordinatesList.as_view()
+indoor_coordinates_list = IndoorCoordinatesList.as_view()
 list_location = LocationListCreateView.as_view()
 detail_location = LocationDetailView.as_view()

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1036,3 +1036,30 @@ class TestGeoApi(
         with self.subTest("Test deleting DeviceLocation"):
             response = self.client.delete(url)
             self.assertEqual(response.status_code, 403)
+
+    def test_floorplan_coordinates(self):
+        org = self._create_org()
+        location = self._create_location(type="indoor", organization=org)
+        floor1 = self._create_floorplan(floor=1, location=location)
+        floor2 = self._create_floorplan(floor=2, location=location)
+        device1 = self._create_device(
+            name="device1", mac_address="00:00:00:00:00:01", organization=org
+        )
+        device2 = self._create_device(
+            name="device2", mac_address="00:00:00:00:00:02", organization=org
+        )
+        self._create_object_location(
+            content_object=device1,
+            location=location,
+            floorplan=floor1,
+            organization=org,
+        )
+        self._create_object_location(
+            content_object=device2,
+            location=location,
+            floorplan=floor2,
+            organization=org,
+        )
+        path = reverse("geo_api:device_floorplan_coordinates", args=[location.id])
+        response = self.client.get(path)
+        print(response.__dict__)

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1037,7 +1037,7 @@ class TestGeoApi(
             response = self.client.delete(url)
             self.assertEqual(response.status_code, 403)
 
-    def test_floorplan_coordinates(self):
+    def test_indoor_coordinates_list_api(self):
         org = self._get_org()
         location = self._create_location(type="indoor", organization=org)
         f1 = self._create_floorplan(floor=1, location=location)
@@ -1063,11 +1063,11 @@ class TestGeoApi(
         path = reverse("geo_api:indoor_coordinates_list", args=[location.id])
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["name"], "device1")
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertEqual(response.data["results"][0]["device_name"], "device1")
 
         with self.subTest("Test filter by floor"):
             response = self.client.get(f"{path}?floor=2")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.data), 1)
-            self.assertEqual(response.data[0]["name"], "device2")
+            self.assertEqual(len(response.data["results"]), 1)
+            self.assertEqual(response.data["results"][0]["device_name"], "device2")

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1060,7 +1060,7 @@ class TestGeoApi(
             floorplan=f2,
             organization=org,
         )
-        path = reverse("geo_api:floorplan_coordinates_list", args=[location.id])
+        path = reverse("geo_api:indoor_coordinates_list", args=[location.id])
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1063,11 +1063,13 @@ class TestGeoApi(
         path = reverse("geo_api:indoor_coordinates_list", args=[location.id])
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]["device_name"], "device1")
+        self.assertEqual(len(response.data["results"]), 1)
+        self.assertEqual(response.data["results"][0]["device_name"], "device1")
+        self.assertEqual(response.data["results"][0]["floor"], 1)
 
         with self.subTest("Test filter by floor"):
             response = self.client.get(f"{path}?floor=2")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.data), 1)
-            self.assertEqual(response.data[0]["device_name"], "device2")
+            self.assertEqual(len(response.data["results"]), 1)
+            self.assertEqual(response.data["results"][0]["device_name"], "device2")
+            self.assertEqual(response.data["results"][0]["floor"], 2)

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1060,6 +1060,7 @@ class TestGeoApi(
             floorplan=floor2,
             organization=org,
         )
-        path = reverse("geo_api:device_floorplan_coordinates", args=[location.id])
+        path = reverse("geo_api:floorplan_coordinates_list", args=[location.id])
         response = self.client.get(path)
-        print(response.__dict__)
+        response = response.json()
+        print(response)

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1075,6 +1075,123 @@ class TestGeoApi(
             self.assertEqual(response.data["results"][0]["device_name"], "device2")
             self.assertEqual(response.data["results"][0]["floor"], 2)
 
+        with self.subTest("Test default floor with all positve floor"):
+            location2 = self._create_location(type="indoor", organization=org)
+            f0 = self._create_floorplan(floor=0, location=location2)
+            f5 = self._create_floorplan(floor=5, location=location2)
+            f9 = self._create_floorplan(floor=9, location=location2)
+            d0 = self._create_device(
+                name="device", mac_address="00:00:00:00:00:00", organization=org
+            )
+            d5 = self._create_device(
+                name="device5", mac_address="00:00:00:00:00:05", organization=org
+            )
+            d9 = self._create_device(
+                name="device9", mac_address="00:00:00:00:00:09", organization=org
+            )
+            self._create_object_location(
+                content_object=d0,
+                location=location2,
+                floorplan=f0,
+                organization=org,
+            )
+            self._create_object_location(
+                content_object=d5,
+                location=location2,
+                floorplan=f5,
+                organization=org,
+            )
+            self._create_object_location(
+                content_object=d9,
+                location=location2,
+                floorplan=f9,
+                organization=org,
+            )
+            path = reverse("geo_api:indoor_coordinates_list", args=[location2.id])
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.data["results"]), 1)
+            self.assertEqual(response.data["results"][0]["device_name"], "device")
+            self.assertEqual(response.data["results"][0]["floor"], 0)
+
+        with self.subTest("Test default floor with all negative floor"):
+            location3 = self._create_location(type="indoor", organization=org)
+            f_1 = self._create_floorplan(floor=-1, location=location3)
+            f_2 = self._create_floorplan(floor=-2, location=location3)
+            f_3 = self._create_floorplan(floor=-3, location=location3)
+            d_1 = self._create_device(
+                name="device-1", mac_address="00:00:00:00:10:01", organization=org
+            )
+            d_2 = self._create_device(
+                name="device-2", mac_address="00:00:00:00:10:02", organization=org
+            )
+            d_3 = self._create_device(
+                name="device-3", mac_address="00:00:00:00:10:03", organization=org
+            )
+            self._create_object_location(
+                content_object=d_1,
+                location=location3,
+                floorplan=f_1,
+                organization=org,
+            )
+            self._create_object_location(
+                content_object=d_2,
+                location=location3,
+                floorplan=f_2,
+                organization=org,
+            )
+            self._create_object_location(
+                content_object=d_3,
+                location=location3,
+                floorplan=f_3,
+                organization=org,
+            )
+            path = reverse("geo_api:indoor_coordinates_list", args=[location3.id])
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.data["results"]), 1)
+            self.assertEqual(response.data["results"][0]["device_name"], "device-1")
+            self.assertEqual(response.data["results"][0]["floor"], -1)
+
+        with self.subTest("Test default floor with positive and negative floor"):
+            location4 = self._create_location(type="indoor", organization=org)
+            f_4 = self._create_floorplan(floor=-4, location=location4)
+            f0 = self._create_floorplan(floor=0, location=location4)
+            f22 = self._create_floorplan(floor=22, location=location4)
+            d_3 = self._create_device(
+                name="device-4", mac_address="00:00:00:10:10:03", organization=org
+            )
+            d0 = self._create_device(
+                name="device-0", mac_address="00:00:00:00:10:00", organization=org
+            )
+            d22 = self._create_device(
+                name="device22", mac_address="00:00:00:00:10:22", organization=org
+            )
+            self._create_object_location(
+                content_object=d_3,
+                location=location4,
+                floorplan=f_4,
+                organization=org,
+            )
+            self._create_object_location(
+                content_object=d0,
+                location=location4,
+                floorplan=f0,
+                organization=org,
+            )
+            self._create_object_location(
+                content_object=d22,
+                location=location4,
+                floorplan=f22,
+                organization=org,
+            )
+            path = reverse("geo_api:indoor_coordinates_list", args=[location4.id])
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.data["results"]), 1)
+            self.assertEqual(response.data["results"][0]["device_name"], "device-0")
+            self.assertEqual(response.data["results"][0]["floor"], 0)
+
         with self.subTest("Test user without explicit view permission"):
             user = self._create_user(username="org_admin", email="admin@org1.com")
             self._create_org_user(organization=org, user=user, is_admin=True)
@@ -1091,18 +1208,18 @@ class TestGeoApi(
             self.assertEqual(response.status_code, 404)
 
         with self.subTest("Test user of org2 try to access its data and of org"):
-            location2 = self._create_location(type="indoor", organization=org2)
-            f3 = self._create_floorplan(floor=1, location=location2)
+            location5 = self._create_location(type="indoor", organization=org2)
+            f3 = self._create_floorplan(floor=1, location=location5)
             d3 = self._create_device(
                 name="device3", mac_address="00:00:00:00:00:03", organization=org2
             )
             self._create_object_location(
                 content_object=d3,
-                location=location2,
+                location=location5,
                 floorplan=f3,
                 organization=org2,
             )
-            path2 = reverse("geo_api:indoor_coordinates_list", args=[location2.id])
+            path2 = reverse("geo_api:indoor_coordinates_list", args=[location5.id])
             view_perm = Permission.objects.filter(codename="view_devicelocation")
             user.user_permissions.add(*view_perm)
             self.client.force_login(user)

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1038,29 +1038,36 @@ class TestGeoApi(
             self.assertEqual(response.status_code, 403)
 
     def test_floorplan_coordinates(self):
-        org = self._create_org()
+        org = self._get_org()
         location = self._create_location(type="indoor", organization=org)
-        floor1 = self._create_floorplan(floor=1, location=location)
-        floor2 = self._create_floorplan(floor=2, location=location)
-        device1 = self._create_device(
+        f1 = self._create_floorplan(floor=1, location=location)
+        f2 = self._create_floorplan(floor=2, location=location)
+        d1 = self._create_device(
             name="device1", mac_address="00:00:00:00:00:01", organization=org
         )
-        device2 = self._create_device(
+        d2 = self._create_device(
             name="device2", mac_address="00:00:00:00:00:02", organization=org
         )
         self._create_object_location(
-            content_object=device1,
+            content_object=d1,
             location=location,
-            floorplan=floor1,
+            floorplan=f1,
             organization=org,
         )
         self._create_object_location(
-            content_object=device2,
+            content_object=d2,
             location=location,
-            floorplan=floor2,
+            floorplan=f2,
             organization=org,
         )
         path = reverse("geo_api:floorplan_coordinates_list", args=[location.id])
         response = self.client.get(path)
-        response = response.json()
-        print(response)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["name"], "device1")
+
+        with self.subTest("Test filter by floor"):
+            response = self.client.get(f"{path}?floor=2")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.data), 1)
+            self.assertEqual(response.data[0]["name"], "device2")

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -1063,11 +1063,11 @@ class TestGeoApi(
         path = reverse("geo_api:indoor_coordinates_list", args=[location.id])
         response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["results"]), 2)
-        self.assertEqual(response.data["results"][0]["device_name"], "device1")
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["device_name"], "device1")
 
         with self.subTest("Test filter by floor"):
             response = self.client.get(f"{path}?floor=2")
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.data["results"]), 1)
-            self.assertEqual(response.data["results"][0]["device_name"], "device2")
+            self.assertEqual(len(response.data), 1)
+            self.assertEqual(response.data[0]["device_name"], "device2")

--- a/openwisp_controller/geo/utils.py
+++ b/openwisp_controller/geo/utils.py
@@ -42,8 +42,8 @@ def get_geo_urls(geo_views):
             name="detail_location",
         ),
         path(
-            "api/v1/controller/location/<str:pk>/floorplan/devices/",
-            geo_views.device_floorplan_coordinates,
-            name="device_floorplan_coordinates",
+            "api/v1/controller/location/<str:pk>/floorplan_coordinates/",
+            geo_views.floorplan_coordinates_list,
+            name="floorplan_coordinates_list",
         ),
     ]

--- a/openwisp_controller/geo/utils.py
+++ b/openwisp_controller/geo/utils.py
@@ -42,8 +42,8 @@ def get_geo_urls(geo_views):
             name="detail_location",
         ),
         path(
-            "api/v1/controller/location/<str:pk>/floorplan_coordinates/",
-            geo_views.floorplan_coordinates_list,
-            name="floorplan_coordinates_list",
+            "api/v1/controller/location/<str:pk>/indoor_coordinates/",
+            geo_views.indoor_coordinates_list,
+            name="indoor_coordinates_list",
         ),
     ]

--- a/openwisp_controller/geo/utils.py
+++ b/openwisp_controller/geo/utils.py
@@ -42,7 +42,7 @@ def get_geo_urls(geo_views):
             name="detail_location",
         ),
         path(
-            "api/v1/controller/location/<str:pk>/indoor_coordinates/",
+            "api/v1/controller/location/<str:pk>/indoor-coordinates/",
             geo_views.indoor_coordinates_list,
             name="indoor_coordinates_list",
         ),

--- a/openwisp_controller/geo/utils.py
+++ b/openwisp_controller/geo/utils.py
@@ -41,4 +41,9 @@ def get_geo_urls(geo_views):
             geo_views.detail_location,
             name="detail_location",
         ),
+        path(
+            "api/v1/controller/location/<str:pk>/floorplan/devices/",
+            geo_views.device_floorplan_coordinates,
+            name="device_floorplan_coordinates",
+        ),
     ]

--- a/openwisp_controller/geo/utils.py
+++ b/openwisp_controller/geo/utils.py
@@ -42,7 +42,7 @@ def get_geo_urls(geo_views):
             name="detail_location",
         ),
         path(
-            "api/v1/controller/location/<str:pk>/indoor-coordinates/",
+            "api/v1/controller/location/<uuid:pk>/indoor-coordinates/",
             geo_views.indoor_coordinates_list,
             name="indoor_coordinates_list",
         ),

--- a/tests/openwisp2/sample_geo/views.py
+++ b/tests/openwisp2/sample_geo/views.py
@@ -2,10 +2,10 @@ from openwisp_controller.geo.api.views import (
     DeviceCoordinatesView as BaseDeviceCoordinatesView,
 )
 from openwisp_controller.geo.api.views import (
-    DeviceFloorplanCoordinatesList as BaseDeviceFloorplanCoordinatesList,
+    DeviceLocationView as BaseDeviceLocationView,
 )
 from openwisp_controller.geo.api.views import (
-    DeviceLocationView as BaseDeviceLocationView,
+    FloorplanCoordinatesList as BaseFloorplanCoordinatesList,
 )
 from openwisp_controller.geo.api.views import (
     FloorPlanDetailView as BaseFloorPlanDetailView,
@@ -59,16 +59,16 @@ class LocationDetailView(BaseLocationDetailView):
     pass
 
 
-class DeviceFloorplanCoordinatesList(BaseDeviceFloorplanCoordinatesList):
+class FloorplanCoordinatesList(BaseFloorplanCoordinatesList):
     pass
 
 
-device_floorplan_coordinates = DeviceFloorplanCoordinatesList.as_view()
 device_coordinates = DeviceCoordinatesView.as_view()
 device_location = DeviceLocationView.as_view()
 geojson = GeoJsonLocationList.as_view()
 location_device_list = LocationDeviceList.as_view()
 list_floorplan = FloorPlanListCreateView.as_view()
+floorplan_coordinates_list = FloorplanCoordinatesList.as_view()
 detail_floorplan = FloorPlanDetailView.as_view()
 list_location = LocationListCreateView.as_view()
 detail_location = LocationDetailView.as_view()

--- a/tests/openwisp2/sample_geo/views.py
+++ b/tests/openwisp2/sample_geo/views.py
@@ -5,9 +5,6 @@ from openwisp_controller.geo.api.views import (
     DeviceLocationView as BaseDeviceLocationView,
 )
 from openwisp_controller.geo.api.views import (
-    FloorplanCoordinatesList as BaseFloorplanCoordinatesList,
-)
-from openwisp_controller.geo.api.views import (
     FloorPlanDetailView as BaseFloorPlanDetailView,
 )
 from openwisp_controller.geo.api.views import (
@@ -15,6 +12,9 @@ from openwisp_controller.geo.api.views import (
 )
 from openwisp_controller.geo.api.views import (
     GeoJsonLocationList as BaseGeoJsonLocationList,
+)
+from openwisp_controller.geo.api.views import (
+    IndoorCoordinatesList as BaseIndoorCoordinatesList,
 )
 from openwisp_controller.geo.api.views import (
     LocationDetailView as BaseLocationDetailView,
@@ -59,7 +59,7 @@ class LocationDetailView(BaseLocationDetailView):
     pass
 
 
-class FloorplanCoordinatesList(BaseFloorplanCoordinatesList):
+class IndoorCoordinatesList(BaseIndoorCoordinatesList):
     pass
 
 
@@ -68,7 +68,7 @@ device_location = DeviceLocationView.as_view()
 geojson = GeoJsonLocationList.as_view()
 location_device_list = LocationDeviceList.as_view()
 list_floorplan = FloorPlanListCreateView.as_view()
-floorplan_coordinates_list = FloorplanCoordinatesList.as_view()
+indoor_coordinates_list = IndoorCoordinatesList.as_view()
 detail_floorplan = FloorPlanDetailView.as_view()
 list_location = LocationListCreateView.as_view()
 detail_location = LocationDetailView.as_view()

--- a/tests/openwisp2/sample_geo/views.py
+++ b/tests/openwisp2/sample_geo/views.py
@@ -2,6 +2,9 @@ from openwisp_controller.geo.api.views import (
     DeviceCoordinatesView as BaseDeviceCoordinatesView,
 )
 from openwisp_controller.geo.api.views import (
+    DeviceFloorplanCoordinatesList as BaseDeviceFloorplanCoordinatesList,
+)
+from openwisp_controller.geo.api.views import (
     DeviceLocationView as BaseDeviceLocationView,
 )
 from openwisp_controller.geo.api.views import (
@@ -56,6 +59,11 @@ class LocationDetailView(BaseLocationDetailView):
     pass
 
 
+class DeviceFloorplanCoordinatesList(BaseDeviceFloorplanCoordinatesList):
+    pass
+
+
+device_floorplan_coordinates = DeviceFloorplanCoordinatesList.as_view()
 device_coordinates = DeviceCoordinatesView.as_view()
 device_location = DeviceLocationView.as_view()
 geojson = GeoJsonLocationList.as_view()


### PR DESCRIPTION
Implemented API to return device coordinates for a given location ID.

Fixes #828 

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #828 

## Description of Changes
- Added endpoint `floorplan_coordinates_list` to list coordinates
- Created a new serializer to add this below fields
```
fields = [
    "name", 
    "mac_address",
     "is_deactivated",
     "model",
     "os",
     "floor_name",
     "floor",
     "image",
     "location",
]
```
- Added filter by floor
- Added pagination class
- Added test