### PR TITLE
#982 Issue: Changed the network name for ow_zt to global for updated ZeroTier version

### DIFF
--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -634,7 +634,7 @@ class AbstractVpn(ShareableOrgMixinUniqueName, BaseConfig):
             # call auto_client and update the config
             elif self._is_backend_type('zerotier') and template_backend_class:
                 auto = getattr(template_backend_class, 'zerotier_auto_client')(
-                    name='ow_zt',
+                    name='global',
                     networks=[
                         {'id': self.network_id, 'ifname': f'owzt{self.network_id[-6:]}'}
                     ],

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -1210,7 +1210,7 @@ class TestZeroTier(BaseTestVpn, TestZeroTierVpnMixin, TestCase):
         for key in context_keys.keys():
             context_keys[key] = '{{%s}}' % context_keys[key]
         expected = template.backend_class.zerotier_auto_client(
-            name='ow_zt',
+            name='global',
             networks=[{'id': vpn.network_id, 'ifname': f'owzt{vpn.network_id[-6:]}'}],
             identity_secret=context_keys['secret'],
         )


### PR DESCRIPTION
[vpn] Update ZeroTier service name to 'global' #982 

Since ZeroTier 1.14.0 on OpenWrt now supports only a single controller service, this commit updates the Vpn.auto_client method to use '**global**' instead of '**ow_zt**'.

Fixes #982 
