### PR TITLE
[feature] Add support to reversion to the REST API #894

### DIFF
--- a/openwisp_controller/config/api/filters.py
+++ b/openwisp_controller/config/api/filters.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
+from reversion.models import Version
 from swapper import load_model
 
 from openwisp_users.api.filters import OrganizationManagedFilter
@@ -142,3 +143,18 @@ class DeviceGroupListFilter(BaseConfigAPIFilter):
 
     class Meta(BaseConfigAPIFilter.Meta):
         model = DeviceGroup
+
+
+class ReversionFilter(BaseConfigAPIFilter):
+    model = filters.CharFilter(field_name="content_type__model", lookup_expr="iexact")
+
+    def _set_valid_filterform_labels(self):
+        self.filters["model"].label = _("Model")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._set_valid_filterform_labels()
+
+    class Meta:
+        model = Version
+        fields = ["model"]

--- a/openwisp_controller/config/api/filters.py
+++ b/openwisp_controller/config/api/filters.py
@@ -4,7 +4,6 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
-from reversion.models import Version
 from swapper import load_model
 
 from openwisp_users.api.filters import OrganizationManagedFilter
@@ -143,18 +142,3 @@ class DeviceGroupListFilter(BaseConfigAPIFilter):
 
     class Meta(BaseConfigAPIFilter.Meta):
         model = DeviceGroup
-
-
-class ReversionFilter(BaseConfigAPIFilter):
-    model = filters.CharFilter(field_name="content_type__model", lookup_expr="iexact")
-
-    def _set_valid_filterform_labels(self):
-        self.filters["model"].label = _("Model")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._set_valid_filterform_labels()
-
-    class Meta:
-        model = Version
-        fields = ["model"]

--- a/openwisp_controller/config/api/filters.py
+++ b/openwisp_controller/config/api/filters.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.exceptions import ValidationError
+from reversion.models import Version
 from swapper import load_model
 
 from openwisp_users.api.filters import OrganizationManagedFilter
@@ -142,3 +143,47 @@ class DeviceGroupListFilter(BaseConfigAPIFilter):
 
     class Meta(BaseConfigAPIFilter.Meta):
         model = DeviceGroup
+
+
+class ReversionListFilter(filters.FilterSet):
+    revision_id = filters.NumberFilter(field_name="revision_id")
+    object_id = filters.CharFilter(
+        field_name="object_id",
+        lookup_expr="icontains",
+    )
+    user_id = filters.CharFilter(field_name="revision__user_id")
+    comment = filters.CharFilter(
+        field_name="revision__comment",
+        lookup_expr="icontains",
+    )
+    date_created__gte = filters.DateTimeFilter(
+        field_name="revision__date_created",
+        lookup_expr="gte",
+    )
+    date_created__lt = filters.DateTimeFilter(
+        field_name="revision__date_created",
+        lookup_expr="lt",
+    )
+
+    def _set_valid_filter_form_lables(self):
+        self.filters["revision_id"].label = _("Revision ID")
+        self.filters["object_id"].label = _("Object ID")
+        self.filters["user_id"].label = _("User ID")
+        self.filters["comment"].label = _("Comment")
+        self.filters["date_created__gte"].label = _("Created after")
+        self.filters["date_created__lt"].label = _("Created before")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._set_valid_filter_form_lables()
+
+    class Meta:
+        model = Version
+        fields = [
+            "revision_id",
+            "object_id",
+            "user_id",
+            "comment",
+            "date_created__gte",
+            "date_created__lt",
+        ]

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -380,13 +380,13 @@ class DeviceGroupSerializer(BaseSerializer):
         return instance
 
 
-class ReversionSerializer(BaseSerializer):
-    user_id = serializers.SerializerMethodField()
+class VersionSerializer(BaseSerializer):
+    user_id = serializers.CharField(source="revision.user_id", read_only=True)
     date_created = serializers.DateTimeField(
         source="revision.date_created", read_only=True
     )
     comment = serializers.CharField(source="revision.comment", read_only=True)
-    content_type = serializers.SerializerMethodField()
+    content_type = serializers.CharField(source="revision.content_type", read_only=True)
 
     class Meta:
         model = Version
@@ -403,9 +403,3 @@ class ReversionSerializer(BaseSerializer):
             "date_created",
             "comment",
         ]
-
-    def get_user_id(self, obj):
-        return getattr(obj.revision, "user_id", None)
-
-    def get_content_type(self, obj):
-        return getattr(obj.content_type, "model", None)

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -3,6 +3,7 @@ from django.db import transaction
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
+from reversion.models import Version
 from swapper import load_model
 
 from openwisp_utils.api.serializers import ValidatedModelSerializer
@@ -377,3 +378,34 @@ class DeviceGroupSerializer(BaseSerializer):
         instance = super().update(instance, validated_data)
         self._save_m2m_templates(instance)
         return instance
+
+
+class ReversionSerializer(BaseSerializer):
+    user_id = serializers.SerializerMethodField()
+    date_created = serializers.DateTimeField(
+        source="revision.date_created", read_only=True
+    )
+    comment = serializers.CharField(source="revision.comment", read_only=True)
+    content_type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Version
+        fields = [
+            "id",
+            "revision_id",
+            "object_id",
+            "content_type",
+            "db",
+            "format",
+            "serialized_data",
+            "object_repr",
+            "user_id",
+            "date_created",
+            "comment",
+        ]
+
+    def get_user_id(self, obj):
+        return getattr(obj.revision, "user_id", None)
+
+    def get_content_type(self, obj):
+        return getattr(obj.content_type, "model", None)

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -380,13 +380,13 @@ class DeviceGroupSerializer(BaseSerializer):
         return instance
 
 
-class VersionSerializer(BaseSerializer):
+class ReversionSerializer(BaseSerializer):
     user_id = serializers.CharField(source="revision.user_id", read_only=True)
     date_created = serializers.DateTimeField(
         source="revision.date_created", read_only=True
     )
     comment = serializers.CharField(source="revision.comment", read_only=True)
-    content_type = serializers.CharField(source="revision.content_type", read_only=True)
+    content_type = serializers.CharField(source="content_type.model", read_only=True)
 
     class Meta:
         model = Version

--- a/openwisp_controller/config/api/urls.py
+++ b/openwisp_controller/config/api/urls.py
@@ -83,6 +83,21 @@ def get_api_urls(api_views):
                 api_download_views.download_device_config,
                 name="download_device_config",
             ),
+            path(
+                'controller/reversion/',
+                api_views.reversion_list,
+                name='reversion_list',
+            ),
+            path(
+                'controller/reversion/<str:pk>/',
+                api_views.reversion_detail,
+                name='reversion_detail',
+            ),
+            path(
+                'controller/reversion/<str:pk>/restore/',
+                api_views.reversion_restore,
+                name='reversion_restore',
+            ),
         ]
     else:
         return []

--- a/openwisp_controller/config/api/urls.py
+++ b/openwisp_controller/config/api/urls.py
@@ -14,6 +14,21 @@ def get_api_urls(api_views):
     if getattr(settings, "OPENWISP_CONTROLLER_API", True):
         return [
             path(
+                "controller/<str:model>/revision/",
+                api_views.revision_list,
+                name="revision_list",
+            ),
+            path(
+                "controller/<str:model>/revision/<str:pk>/",
+                api_views.version_detail,
+                name="version_detail",
+            ),
+            path(
+                "controller/<str:model>/revision/<str:pk>/restore/",
+                api_views.revision_restore,
+                name="revision_restore",
+            ),
+            path(
                 "controller/template/",
                 api_views.template_list,
                 name="template_list",
@@ -82,21 +97,6 @@ def get_api_urls(api_views):
                 "controller/device/<uuid:pk>/configuration/",
                 api_download_views.download_device_config,
                 name="download_device_config",
-            ),
-            path(
-                'controller/reversion/',
-                api_views.reversion_list,
-                name='reversion_list',
-            ),
-            path(
-                'controller/reversion/<str:pk>/',
-                api_views.reversion_detail,
-                name='reversion_detail',
-            ),
-            path(
-                'controller/reversion/<str:pk>/restore/',
-                api_views.reversion_restore,
-                name='reversion_restore',
             ),
         ]
     else:

--- a/openwisp_controller/config/api/urls.py
+++ b/openwisp_controller/config/api/urls.py
@@ -14,21 +14,6 @@ def get_api_urls(api_views):
     if getattr(settings, "OPENWISP_CONTROLLER_API", True):
         return [
             path(
-                "controller/<str:model>/revision/",
-                api_views.revision_list,
-                name="revision_list",
-            ),
-            path(
-                "controller/<str:model>/revision/<str:pk>/",
-                api_views.version_detail,
-                name="version_detail",
-            ),
-            path(
-                "controller/<str:model>/revision/<str:pk>/restore/",
-                api_views.revision_restore,
-                name="revision_restore",
-            ),
-            path(
                 "controller/template/",
                 api_views.template_list,
                 name="template_list",
@@ -97,6 +82,21 @@ def get_api_urls(api_views):
                 "controller/device/<uuid:pk>/configuration/",
                 api_download_views.download_device_config,
                 name="download_device_config",
+            ),
+            path(
+                "controller/<str:model>/reversion/",
+                api_views.reversion_list,
+                name="reversion_list",
+            ),
+            path(
+                "controller/<str:model>/reversion/<int:pk>/",
+                api_views.reversion_detail,
+                name="reversion_detail",
+            ),
+            path(
+                "controller/<str:model>/reversion/<int:pk>/restore/",
+                api_views.reversion_restore,
+                name="reversion_restore",
             ),
         ]
     else:

--- a/openwisp_controller/config/api/views.py
+++ b/openwisp_controller/config/api/views.py
@@ -17,7 +17,7 @@ from rest_framework.generics import (
     get_object_or_404,
 )
 from rest_framework.response import Response
-from reversion.models import Revision, Version
+from reversion.models import Version
 from swapper import load_model
 
 from openwisp_users.api.permissions import DjangoModelPermissions

--- a/openwisp_controller/config/api/views.py
+++ b/openwisp_controller/config/api/views.py
@@ -1,10 +1,10 @@
 import reversion
 from cache_memoize import cache_memoize
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import F, Q
 from django.http import Http404
-from django.shortcuts import get_list_or_404
 from django.urls.base import reverse
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import pagination, serializers, status
@@ -14,9 +14,10 @@ from rest_framework.generics import (
     ListCreateAPIView,
     RetrieveAPIView,
     RetrieveUpdateDestroyAPIView,
+    get_object_or_404,
 )
 from rest_framework.response import Response
-from reversion.models import Version
+from reversion.models import Revision, Version
 from swapper import load_model
 
 from openwisp_users.api.permissions import DjangoModelPermissions
@@ -26,6 +27,7 @@ from .filters import (
     DeviceGroupListFilter,
     DeviceListFilter,
     DeviceListFilterBackend,
+    ReversionListFilter,
     TemplateListFilter,
     VPNListFilter,
 )
@@ -33,8 +35,8 @@ from .serializers import (
     DeviceDetailSerializer,
     DeviceGroupSerializer,
     DeviceListSerializer,
+    ReversionSerializer,
     TemplateSerializer,
-    VersionSerializer,
     VpnSerializer,
 )
 
@@ -303,55 +305,45 @@ class DeviceGroupCommonName(ProtectedAPIMixin, AutoRevisionMixin, RetrieveAPIVie
         cls.get_device_group.invalidate(cls, org_slug, common_name)
 
 
-class RevisionListView(ProtectedAPIMixin, ListAPIView):
-    serializer_class = VersionSerializer
+class BaseReversionView:
+    def get_queryset(self):
+        model = self.kwargs.get("model").lower()
+        content_type = get_object_or_404(ContentType, model=model)
+        return super().get_queryset().filter(content_type=content_type)
+
+
+class ReversionListView(BaseReversionView, ProtectedAPIMixin, ListAPIView):
+    serializer_class = ReversionSerializer
     queryset = Version.objects.select_related("revision").order_by(
         "-revision__date_created"
     )
-
-    def get_queryset(self):
-        model = self.kwargs.get("model").lower()
-        queryset = self.queryset.filter(content_type__model=model)
-        revision_id = self.request.query_params.get("revision_id")
-        if revision_id:
-            queryset = queryset.filter(revision_id=revision_id)
-        return self.queryset.filter(content_type__model=model)
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = ReversionListFilter
+    pagination_class = ListViewPagination
 
 
-class VersionDetailView(ProtectedAPIMixin, RetrieveAPIView):
-    serializer_class = VersionSerializer
-    queryset = Version.objects.select_related("revision").order_by(
-        "-revision__date_created"
-    )
-
-    def get_queryset(self):
-        model = self.kwargs.get("model").lower()
-        return self.queryset.filter(content_type__model=model)
+class ReversionDetailView(BaseReversionView, ProtectedAPIMixin, RetrieveAPIView):
+    serializer_class = ReversionSerializer
+    queryset = Version.objects.select_related("revision")
 
 
-class RevisionRestoreView(ProtectedAPIMixin, GenericAPIView):
+class ReversionRestoreView(BaseReversionView, ProtectedAPIMixin, GenericAPIView):
     serializer_class = serializers.Serializer
     queryset = Version.objects.select_related("revision").order_by(
         "-revision__date_created"
     )
 
-    def get_queryset(self):
-        model = self.kwargs.get("model").lower()
-        return self.queryset.filter(content_type__model=model)
-
     def post(self, request, *args, **kwargs):
         qs = self.get_queryset()
-        versions = get_list_or_404(qs, revision_id=kwargs["pk"])
+        version = get_object_or_404(qs, revision_id=kwargs["pk"])
+        revision = version.revision
         with transaction.atomic():
             with reversion.create_revision():
-                for version in versions:
-                    version.revert()
+                revision.revert()
                 reversion.set_user(request.user)
-                reversion.set_comment(
-                    f"Restored to previous revision: {self.kwargs.get('pk')}"
-                )
-
-        serializer = VersionSerializer(
+                reversion.set_comment(f"Restored to previous revision: {revision.id}")
+        versions = qs.filter(revision=revision)
+        serializer = ReversionSerializer(
             versions, many=True, context=self.get_serializer_context()
         )
         return Response(serializer.data, status=status.HTTP_200_OK)
@@ -368,6 +360,6 @@ device_deactivate = DeviceDeactivateView.as_view()
 devicegroup_list = DeviceGroupListCreateView.as_view()
 devicegroup_detail = DeviceGroupDetailView.as_view()
 devicegroup_commonname = DeviceGroupCommonName.as_view()
-revision_list = RevisionListView.as_view()
-version_detail = VersionDetailView.as_view()
-revision_restore = RevisionRestoreView.as_view()
+reversion_list = ReversionListView.as_view()
+reversion_detail = ReversionDetailView.as_view()
+reversion_restore = ReversionRestoreView.as_view()

--- a/openwisp_controller/config/api/views.py
+++ b/openwisp_controller/config/api/views.py
@@ -17,7 +17,7 @@ from rest_framework.generics import (
     get_object_or_404,
 )
 from rest_framework.response import Response
-from reversion.models import Version
+from reversion.models import Revision, Version
 from swapper import load_model
 
 from openwisp_users.api.permissions import DjangoModelPermissions
@@ -309,10 +309,18 @@ class BaseReversionView:
     def get_queryset(self):
         model = self.kwargs.get("model").lower()
         content_type = get_object_or_404(ContentType, model=model)
-        return super().get_queryset().filter(content_type=content_type)
+        qs = super().get_queryset().filter(content_type=content_type)
+        user = self.request.user
+        if user.is_superuser:
+            return qs
+        model_class = content_type.model_class()
+        allowed_object_ids = model_class.objects.filter(
+            organization__in=user.organizations_managed
+        ).values_list("pk", flat=True)
+        return qs.filter(object_id__in=allowed_object_ids)
 
 
-class ReversionListView(BaseReversionView, ProtectedAPIMixin, ListAPIView):
+class ReversionListView(BaseReversionView, ListAPIView):
     serializer_class = ReversionSerializer
     queryset = Version.objects.select_related("revision").order_by(
         "-revision__date_created"
@@ -322,12 +330,12 @@ class ReversionListView(BaseReversionView, ProtectedAPIMixin, ListAPIView):
     pagination_class = ListViewPagination
 
 
-class ReversionDetailView(BaseReversionView, ProtectedAPIMixin, RetrieveAPIView):
+class ReversionDetailView(BaseReversionView, RetrieveAPIView):
     serializer_class = ReversionSerializer
     queryset = Version.objects.select_related("revision")
 
 
-class ReversionRestoreView(BaseReversionView, ProtectedAPIMixin, GenericAPIView):
+class ReversionRestoreView(BaseReversionView, GenericAPIView):
     serializer_class = serializers.Serializer
     queryset = Version.objects.select_related("revision").order_by(
         "-revision__date_created"
@@ -335,14 +343,23 @@ class ReversionRestoreView(BaseReversionView, ProtectedAPIMixin, GenericAPIView)
 
     def post(self, request, *args, **kwargs):
         qs = self.get_queryset()
-        version = get_object_or_404(qs, revision_id=kwargs["pk"])
-        revision = version.revision
+        revision = get_object_or_404(Revision, pk=kwargs["pk"])
+        if not qs.filter(revision=revision).exists():
+            raise Http404
+        comment = f"Restored to previous revision: {revision.id}"
         with transaction.atomic():
             with reversion.create_revision():
                 revision.revert()
                 reversion.set_user(request.user)
-                reversion.set_comment(f"Restored to previous revision: {revision.id}")
-        versions = qs.filter(revision=revision)
+                reversion.set_comment(comment)
+        restored_revision = get_object_or_404(
+            Revision.objects.order_by(
+                "-date_created"
+            ),
+            user=request.user,
+            comment=comment,
+        )
+        versions = qs.filter(revision=restored_revision)
         serializer = ReversionSerializer(
             versions, many=True, context=self.get_serializer_context()
         )

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -1,3 +1,4 @@
+import reversion
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -1777,3 +1778,42 @@ class TestConfigApiTransaction(
                 template2.refresh_from_db()
                 self.assertEqual(template2.default_values["ifname"], "eth3")
                 mocked_signal.assert_called_once()
+
+    def test_reversion_list_and_restore_api(self):
+        org = self._get_org()
+        with reversion.create_revision():
+            device = self._create_device(
+                organization=org, name="test", _is_deactivated=True
+            )
+        path = reverse("config_api:device_detail", args=[device.pk])
+        response = self.client.delete(path)
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(Device.objects.count(), 0)
+
+        path = reverse("config_api:reversion_list")
+        response = self.client.get(path)
+        response_json = response.json()
+        version_id = response_json[0]["id"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response_json), 1)
+
+        with self.subTest("Test filter reversion list with model name"):
+            params = {"id": 1, "model": "Device"}
+            response = self.client.get(path, params)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response.json()), 1)
+            self.assertEqual(response.json()[0]["object_id"], str(device.pk))
+
+        with self.subTest("Test reversion detail"):
+            path = reverse("config_api:reversion_detail", args=[version_id])
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["id"], version_id)
+            self.assertEqual(response.json()["object_id"], str(device.pk))
+
+        with self.subTest("Test reversion restore view"):
+            path = reverse("config_api:reversion_restore", args=[version_id])
+            response = self.client.post(path)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(Device.objects.count(), 1)
+            self.assertEqual(Device.objects.first().id, device.pk)

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -1781,39 +1781,46 @@ class TestConfigApiTransaction(
 
     def test_reversion_list_and_restore_api(self):
         org = self._get_org()
+        model_slug = "device"
         with reversion.create_revision():
             device = self._create_device(
-                organization=org, name="test", _is_deactivated=True
+                organization=org,
+                name="test",
             )
         path = reverse("config_api:device_detail", args=[device.pk])
-        response = self.client.delete(path)
-        self.assertEqual(response.status_code, 204)
-        self.assertEqual(Device.objects.count(), 0)
-
-        path = reverse("config_api:reversion_list")
-        response = self.client.get(path)
-        response_json = response.json()
-        version_id = response_json[0]["id"]
+        data = dict(name="change-test-device")
+        response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response_json), 1)
+        self.assertEqual(response.data["name"], "change-test-device")
 
-        with self.subTest("Test filter reversion list with model name"):
-            params = {"id": 1, "model": "Device"}
-            response = self.client.get(path, params)
+        with self.subTest("Test revision list"):
+            path = reverse("config_api:revision_list", args=[model_slug])
+            response = self.client.get(path)
+            response_json = response.json()
+            version_id = response_json[1]["id"]
+            revision_id = response_json[1]["revision_id"]
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response.json()), 1)
-            self.assertEqual(response.json()[0]["object_id"], str(device.pk))
+            self.assertEqual(len(response_json), 2)
 
-        with self.subTest("Test reversion detail"):
-            path = reverse("config_api:reversion_detail", args=[version_id])
+        with self.subTest("Test revision list filter by revision id"):
+            path = reverse("config_api:revision_list", args=[model_slug])
+            response = self.client.get(f"{path}?revision_id={revision_id}")
+            response_json = response.json()
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(len(response_json), 2)
+
+        with self.subTest("Test version detail"):
+            path = reverse("config_api:version_detail", args=[model_slug, version_id])
             response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json()["id"], version_id)
             self.assertEqual(response.json()["object_id"], str(device.pk))
 
-        with self.subTest("Test reversion restore view"):
-            path = reverse("config_api:reversion_restore", args=[version_id])
+        with self.subTest("Test revision restore view"):
+            revision_id = response_json[1]["revision_id"]
+            path = reverse(
+                "config_api:revision_restore", args=[model_slug, revision_id]
+            )
             response = self.client.post(path)
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(Device.objects.count(), 1)
-            self.assertEqual(Device.objects.first().id, device.pk)
+            self.assertEqual(Device.objects.get(name="test").pk, device.pk)

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -1779,6 +1779,7 @@ class TestConfigApiTransaction(
                 self.assertEqual(template2.default_values["ifname"], "eth3")
                 mocked_signal.assert_called_once()
 
+    # Todo: create sperate test for each endpoint
     def test_reversion_list_and_restore_api(self):
         org = self._get_org()
         model_slug = "device"

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -1,7 +1,7 @@
-import reversion
 from datetime import timedelta
 from unittest.mock import patch
 
+import reversion
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
@@ -1793,33 +1793,33 @@ class TestConfigApiTransaction(
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "change-test-device")
 
-        with self.subTest("Test revision list"):
-            path = reverse("config_api:revision_list", args=[model_slug])
+        with self.subTest("Test reversion list"):
+            path = reverse("config_api:reversion_list", args=[model_slug])
             response = self.client.get(path)
             response_json = response.json()
-            version_id = response_json[1]["id"]
-            revision_id = response_json[1]["revision_id"]
+            version_id = response_json["results"][1]["id"]
+            revision_id = response_json["results"][1]["revision_id"]
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response_json), 2)
+            self.assertEqual(len(response_json["results"]), 2)
 
         with self.subTest("Test revision list filter by revision id"):
-            path = reverse("config_api:revision_list", args=[model_slug])
+            path = reverse("config_api:reversion_list", args=[model_slug])
             response = self.client.get(f"{path}?revision_id={revision_id}")
             response_json = response.json()
             self.assertEqual(response.status_code, 200)
-            self.assertEqual(len(response_json), 2)
+            self.assertEqual(len(response_json["results"]), 1)
 
-        with self.subTest("Test version detail"):
-            path = reverse("config_api:version_detail", args=[model_slug, version_id])
+        with self.subTest("Test reversion detail"):
+            path = reverse("config_api:reversion_detail", args=[model_slug, version_id])
             response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json()["id"], version_id)
             self.assertEqual(response.json()["object_id"], str(device.pk))
 
-        with self.subTest("Test revision restore view"):
-            revision_id = response_json[1]["revision_id"]
+        with self.subTest("Test reversion restore view"):
+            revision_id = response_json["results"][0]["revision_id"]
             path = reverse(
-                "config_api:revision_restore", args=[model_slug, revision_id]
+                "config_api:reversion_restore", args=[model_slug, revision_id]
             )
             response = self.client.post(path)
             self.assertEqual(response.status_code, 200)

--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -119,6 +119,7 @@ class BaseDeviceConnection(
     organization_lookup = "organization__in"
     model = DeviceConnection
     serializer_class = DeviceConnectionSerializer
+    queryset = DeviceConnection.objects.prefetch_related("device")
 
     def get_queryset(self):
         return (
@@ -133,17 +134,6 @@ class BaseDeviceConnection(
         context["device_id"] = self.kwargs["device_id"]
         return context
 
-    def initial(self, *args, **kwargs):
-        super().initial(*args, **kwargs)
-        self.assert_parent_exists()
-
-    def assert_parent_exists(self):
-        try:
-            assert self.get_parent_queryset().exists()
-        except (AssertionError, ValidationError):
-            device_id = self.kwargs["device_id"]
-            raise NotFound(detail=f'Device with ID "{device_id}" not found.')
-
     def get_parent_queryset(self):
         return Device.objects.filter(pk=self.kwargs["device_id"])
 
@@ -152,14 +142,6 @@ class DeviceConnenctionListCreateView(
     BaseDeviceConnection, AutoRevisionMixin, ListCreateAPIView
 ):
     pagination_class = ListViewPagination
-
-    def get_queryset(self):
-        return (
-            super()
-            .get_queryset()
-            .filter(device_id=self.kwargs["device_id"])
-            .order_by("-created")
-        )
 
 
 class DeviceConnectionDetailView(

--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -160,7 +160,7 @@ class DeviceConnenctionListCreateView(
             .filter(device_id=self.kwargs["device_id"])
             .order_by("-created")
         )
-    
+
 
 class DeviceConnectionDetailView(
     BaseDeviceConnection, AutoRevisionMixin, RetrieveUpdateDestroyAPIView

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -561,7 +561,7 @@ class TestConnectionApi(
             "enabled": True,
             "failure_reason": "",
         }
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(23):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 
@@ -606,7 +606,7 @@ class TestConnectionApi(
             "enabled": False,
             "failure_reason": "",
         }
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(23):
             response = self.client.put(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -620,7 +620,7 @@ class TestConnectionApi(
         path = reverse("connection_api:deviceconnection_detail", args=(d1, dc.pk))
         self.assertEqual(dc.update_strategy, app_settings.UPDATE_STRATEGIES[0][0])
         data = {"update_strategy": app_settings.UPDATE_STRATEGIES[1][0]}
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(22):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -561,7 +561,7 @@ class TestConnectionApi(
             "enabled": True,
             "failure_reason": "",
         }
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(22):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -18,8 +18,8 @@ from openwisp_users.api.filters import OrganizationManagedFilter
 from openwisp_users.api.mixins import FilterByOrganizationManaged, FilterByParentManaged
 
 from ...mixins import (
-    BaseProtectedAPIMixin,
     AutoRevisionMixin,
+    BaseProtectedAPIMixin,
     ProtectedAPIMixin,
     RelatedDeviceProtectedAPIMixin,
 )
@@ -312,6 +312,7 @@ class LocationDeviceList(
         if response.status_code == 200:
             response.data["has_floorplan"] = has_floorplan
         return response
+
 
 class FloorPlanListCreateView(
     ProtectedAPIMixin, AutoRevisionMixin, generics.ListCreateAPIView

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -19,6 +19,7 @@ from openwisp_users.api.mixins import FilterByOrganizationManaged, FilterByParen
 
 from ...mixins import (
     BaseProtectedAPIMixin,
+    AutoRevisionMixin,
     ProtectedAPIMixin,
     RelatedDeviceProtectedAPIMixin,
 )
@@ -109,7 +110,9 @@ class ListViewPagination(pagination.PageNumberPagination):
     max_page_size = 100
 
 
-class DeviceCoordinatesView(ProtectedAPIMixin, generics.RetrieveUpdateAPIView):
+class DeviceCoordinatesView(
+    ProtectedAPIMixin, AutoRevisionMixin, generics.RetrieveUpdateAPIView
+):
     serializer_class = DeviceCoordinatesSerializer
     permission_classes = (DevicePermission,)
     queryset = Device.objects.select_related(
@@ -157,6 +160,7 @@ class DeviceCoordinatesView(ProtectedAPIMixin, generics.RetrieveUpdateAPIView):
 
 class DeviceLocationView(
     RelatedDeviceProtectedAPIMixin,
+    AutoRevisionMixin,
     FilterByParentManaged,
     generics.RetrieveUpdateDestroyAPIView,
 ):
@@ -309,8 +313,9 @@ class LocationDeviceList(
             response.data["has_floorplan"] = has_floorplan
         return response
 
-
-class FloorPlanListCreateView(ProtectedAPIMixin, generics.ListCreateAPIView):
+class FloorPlanListCreateView(
+    ProtectedAPIMixin, AutoRevisionMixin, generics.ListCreateAPIView
+):
     serializer_class = FloorPlanSerializer
     queryset = FloorPlan.objects.select_related().order_by("-created")
     pagination_class = ListViewPagination
@@ -320,13 +325,16 @@ class FloorPlanListCreateView(ProtectedAPIMixin, generics.ListCreateAPIView):
 
 class FloorPlanDetailView(
     ProtectedAPIMixin,
+    AutoRevisionMixin,
     generics.RetrieveUpdateDestroyAPIView,
 ):
     serializer_class = FloorPlanSerializer
     queryset = FloorPlan.objects.select_related()
 
 
-class LocationListCreateView(ProtectedAPIMixin, generics.ListCreateAPIView):
+class LocationListCreateView(
+    ProtectedAPIMixin, AutoRevisionMixin, generics.ListCreateAPIView
+):
     serializer_class = LocationSerializer
     queryset = Location.objects.prefetch_related(
         Prefetch(
@@ -341,6 +349,7 @@ class LocationListCreateView(ProtectedAPIMixin, generics.ListCreateAPIView):
 
 class LocationDetailView(
     ProtectedAPIMixin,
+    AutoRevisionMixin,
     generics.RetrieveUpdateDestroyAPIView,
 ):
     serializer_class = LocationSerializer

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -404,6 +404,7 @@ class TestGeoApi(
     def setUp(self):
         admin = self._create_admin()
         self.client.force_login(admin)
+        ContentType.objects.clear_cache()
 
     def _create_device_location(self, **kwargs):
         options = dict()
@@ -599,7 +600,7 @@ class TestGeoApi(
             "address": "Via del Corso, Roma, Italia",
             "geometry": coords,
         }
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(13):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 
@@ -633,7 +634,7 @@ class TestGeoApi(
             "address": "Via del Corso, Roma, Italia",
             "geometry": coords,
         }
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(10):
             response = self.client.put(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["organization"], org1.pk)
@@ -644,7 +645,7 @@ class TestGeoApi(
         self.assertEqual(l1.name, "test-location")
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"name": "change-test-location"}
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(9):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "change-test-location")
@@ -674,7 +675,7 @@ class TestGeoApi(
         fl = self._create_floorplan(location=l1)
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"floorplan": {"floor": 13}}
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(17):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         fl.refresh_from_db()
@@ -685,7 +686,7 @@ class TestGeoApi(
         self._create_floorplan(location=l1)
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"type": "outdoor"}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(13):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["floorplan"], [])
@@ -712,7 +713,7 @@ class TestGeoApi(
             "floorplan.floor": ["23"],
             "floorplan.image": [fl_image],
         }
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(20):
             response = self.client.post(path, data, format="multipart")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -736,7 +737,7 @@ class TestGeoApi(
             "floorplan.floor": "23",
             "floorplan.image": fl_image,
         }
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(20):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -831,7 +832,7 @@ class TestGeoApi(
         floorplan = self._create_floorplan()
         location = floorplan.location
         url = reverse("geo_api:device_location", args=[device.id])
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(29):
             response = self.client.put(
                 url,
                 data={
@@ -869,7 +870,7 @@ class TestGeoApi(
             "floorplan.image": self._get_simpleuploadedfile(),
             "indoor": ["12.342,23.541"],
         }
-        with self.assertNumQueries(31):
+        with self.assertNumQueries(43):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -936,7 +937,7 @@ class TestGeoApi(
                 "type": "indoor",
             }
         }
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(32):
             response = self.client.put(url, data=data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.location_model.objects.count(), 1)
@@ -976,7 +977,7 @@ class TestGeoApi(
             "floorplan.image": self._get_simpleuploadedfile(),
             "indoor": ["12.342,23.541"],
         }
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(37):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -999,7 +1000,7 @@ class TestGeoApi(
         }
         self.assertEqual(device_location.location.type, "outdoor")
         self.assertEqual(device_location.floorplan, None)
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(33):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -1018,7 +1019,7 @@ class TestGeoApi(
             "indoor": "0,0",
         }
         self.assertEqual(device_location.indoor, "-140.38620,40.369227")
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(20):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()
@@ -1035,7 +1036,7 @@ class TestGeoApi(
         data = {
             "floorplan": str(floor2.id),
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(22):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()
@@ -1049,7 +1050,7 @@ class TestGeoApi(
         data = {
             "location": str(location2.id),
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(21):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -600,7 +600,7 @@ class TestGeoApi(
             "address": "Via del Corso, Roma, Italia",
             "geometry": coords,
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 
@@ -634,7 +634,7 @@ class TestGeoApi(
             "address": "Via del Corso, Roma, Italia",
             "geometry": coords,
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.put(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["organization"], org1.pk)
@@ -645,7 +645,7 @@ class TestGeoApi(
         self.assertEqual(l1.name, "test-location")
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"name": "change-test-location"}
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "change-test-location")
@@ -675,7 +675,7 @@ class TestGeoApi(
         fl = self._create_floorplan(location=l1)
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"floorplan": {"floor": 13}}
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(16):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         fl.refresh_from_db()
@@ -686,7 +686,7 @@ class TestGeoApi(
         self._create_floorplan(location=l1)
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"type": "outdoor"}
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["floorplan"], [])
@@ -713,7 +713,7 @@ class TestGeoApi(
             "floorplan.floor": ["23"],
             "floorplan.image": [fl_image],
         }
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(19):
             response = self.client.post(path, data, format="multipart")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -737,7 +737,7 @@ class TestGeoApi(
             "floorplan.floor": "23",
             "floorplan.image": fl_image,
         }
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(19):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -832,7 +832,7 @@ class TestGeoApi(
         floorplan = self._create_floorplan()
         location = floorplan.location
         url = reverse("geo_api:device_location", args=[device.id])
-        with self.assertNumQueries(29):
+        with self.assertNumQueries(28):
             response = self.client.put(
                 url,
                 data={
@@ -870,7 +870,7 @@ class TestGeoApi(
             "floorplan.image": self._get_simpleuploadedfile(),
             "indoor": ["12.342,23.541"],
         }
-        with self.assertNumQueries(43):
+        with self.assertNumQueries(42):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -937,7 +937,7 @@ class TestGeoApi(
                 "type": "indoor",
             }
         }
-        with self.assertNumQueries(32):
+        with self.assertNumQueries(31):
             response = self.client.put(url, data=data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.location_model.objects.count(), 1)
@@ -977,7 +977,7 @@ class TestGeoApi(
             "floorplan.image": self._get_simpleuploadedfile(),
             "indoor": ["12.342,23.541"],
         }
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(36):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -1000,7 +1000,7 @@ class TestGeoApi(
         }
         self.assertEqual(device_location.location.type, "outdoor")
         self.assertEqual(device_location.floorplan, None)
-        with self.assertNumQueries(33):
+        with self.assertNumQueries(32):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -1019,7 +1019,7 @@ class TestGeoApi(
             "indoor": "0,0",
         }
         self.assertEqual(device_location.indoor, "-140.38620,40.369227")
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(19):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()
@@ -1036,7 +1036,7 @@ class TestGeoApi(
         data = {
             "floorplan": str(floor2.id),
         }
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(21):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()
@@ -1050,7 +1050,7 @@ class TestGeoApi(
         data = {
             "location": str(location2.id),
         }
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(20):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()

--- a/openwisp_controller/mixins.py
+++ b/openwisp_controller/mixins.py
@@ -1,3 +1,6 @@
+import reversion
+from reversion.views import RevisionMixin
+
 from openwisp_users.api.mixins import FilterByOrganizationManaged, FilterByParentManaged
 from openwisp_users.api.mixins import ProtectedAPIMixin as BaseProtectedAPIMixin
 from openwisp_users.api.permissions import DjangoModelPermissions, IsOrganizationManager
@@ -33,3 +36,25 @@ class RelatedDeviceProtectedAPIMixin(FilterByParentManaged, BaseProtectedAPIMixi
 
 class ProtectedAPIMixin(BaseProtectedAPIMixin, FilterByOrganizationManaged):
     pass
+
+
+class AutoRevisionMixin(RevisionMixin):
+    revision_atomic = False
+
+    def dispatch(self, request, *args, **kwargs):
+        qs = getattr(self, "queryset", None)
+        model = getattr(qs, "model", None)
+        if (
+            request.method in ("POST", "PUT", "PATCH")
+            and request.user.is_authenticated
+            and model
+            and reversion.is_registered(model)
+        ):
+            with reversion.create_revision(atomic=self.revision_atomic):
+                response = super().dispatch(request, *args, **kwargs)
+                reversion.set_user(request.user)
+                reversion.set_comment(
+                    f"API request: {request.method} {request.get_full_path()}"
+                )
+            return response
+        return super().dispatch(request, *args, **kwargs)

--- a/openwisp_controller/mixins.py
+++ b/openwisp_controller/mixins.py
@@ -1,5 +1,4 @@
 import reversion
-from reversion.views import RevisionMixin
 
 from openwisp_users.api.mixins import FilterByOrganizationManaged, FilterByParentManaged
 from openwisp_users.api.mixins import ProtectedAPIMixin as BaseProtectedAPIMixin
@@ -38,7 +37,7 @@ class ProtectedAPIMixin(BaseProtectedAPIMixin, FilterByOrganizationManaged):
     pass
 
 
-class AutoRevisionMixin(RevisionMixin):
+class AutoRevisionMixin:
     revision_atomic = False
 
     def dispatch(self, request, *args, **kwargs):
@@ -46,13 +45,13 @@ class AutoRevisionMixin(RevisionMixin):
         model = getattr(qs, "model", None)
         if (
             request.method in ("POST", "PUT", "PATCH")
-            and request.user.is_authenticated
             and model
             and reversion.is_registered(model)
         ):
             with reversion.create_revision(atomic=self.revision_atomic):
                 response = super().dispatch(request, *args, **kwargs)
-                reversion.set_user(request.user)
+                if self.request.user.is_authenticated:
+                    reversion.set_user(self.request.user)
                 reversion.set_comment(
                     f"API request: {request.method} {request.get_full_path()}"
                 )

--- a/openwisp_controller/pki/api/views.py
+++ b/openwisp_controller/pki/api/views.py
@@ -10,7 +10,7 @@ from rest_framework.generics import (
 from rest_framework.response import Response
 from swapper import load_model
 
-from ...mixins import ProtectedAPIMixin
+from ...mixins import AutoRevisionMixin, ProtectedAPIMixin
 from .serializers import (
     CaDetailSerializer,
     CaListSerializer,
@@ -30,18 +30,18 @@ class ListViewPagination(pagination.PageNumberPagination):
     max_page_size = 100
 
 
-class CaListCreateView(ProtectedAPIMixin, ListCreateAPIView):
+class CaListCreateView(ProtectedAPIMixin, AutoRevisionMixin, ListCreateAPIView):
     serializer_class = CaListSerializer
     queryset = Ca.objects.order_by("-created")
     pagination_class = ListViewPagination
 
 
-class CaDetailView(ProtectedAPIMixin, RetrieveUpdateDestroyAPIView):
+class CaDetailView(ProtectedAPIMixin, AutoRevisionMixin, RetrieveUpdateDestroyAPIView):
     serializer_class = CaDetailSerializer
     queryset = Ca.objects.all()
 
 
-class CaRenewView(ProtectedAPIMixin, GenericAPIView):
+class CaRenewView(ProtectedAPIMixin, AutoRevisionMixin, GenericAPIView):
     serializer_class = serializers.Serializer
     queryset = Ca.objects.all()
 
@@ -66,18 +66,20 @@ class CrlDownloadView(ProtectedAPIMixin, RetrieveAPIView):
         )
 
 
-class CertListCreateView(ProtectedAPIMixin, ListCreateAPIView):
+class CertListCreateView(ProtectedAPIMixin, AutoRevisionMixin, ListCreateAPIView):
     serializer_class = CertListSerializer
     queryset = Cert.objects.order_by("-created")
     pagination_class = ListViewPagination
 
 
-class CertDetailView(ProtectedAPIMixin, RetrieveUpdateDestroyAPIView):
+class CertDetailView(
+    ProtectedAPIMixin, AutoRevisionMixin, RetrieveUpdateDestroyAPIView
+):
     serializer_class = CertDetailSerializer
     queryset = Cert.objects.select_related("ca")
 
 
-class CertRevokeRenewBaseView(ProtectedAPIMixin, GenericAPIView):
+class CertRevokeRenewBaseView(ProtectedAPIMixin, AutoRevisionMixin, GenericAPIView):
     serializer_class = serializers.Serializer
     queryset = Cert.objects.select_related("ca")
 

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -51,7 +51,7 @@ class TestPkiApi(
         self.assertEqual(Ca.objects.count(), 0)
         path = reverse("pki_api:ca_list")
         data = self._ca_data
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -61,7 +61,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_list")
         data = self._ca_data
         data["extensions"] = []
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(r.data["extensions"], [])
@@ -77,7 +77,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            6 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 5
+            10 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -97,7 +97,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -124,7 +124,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
         org2 = self._create_org()
         data = {"name": "change-ca1", "organization": org2.pk, "notes": "change-notes"}
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(11):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -137,7 +137,7 @@ class TestPkiApi(
         data = {
             "name": "change-ca1",
         }
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(10):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -161,7 +161,7 @@ class TestPkiApi(
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         old_serial_num = ca1.serial_number
         path = reverse("pki_api:ca_renew", args=[ca1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(8):
             r = self.client.post(path)
         ca1.refresh_from_db()
         self.assertEqual(r.status_code, 200)
@@ -172,7 +172,7 @@ class TestPkiApi(
         path = reverse("pki_api:cert_list")
         data = self._cert_data
         data["ca"] = self._create_ca().pk
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(11):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -189,7 +189,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            10 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
+            14 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 13
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -205,7 +205,7 @@ class TestPkiApi(
         data = self._cert_data
         data["ca"] = self._create_ca().pk
         data["extensions"] = []
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(11):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -221,7 +221,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(11):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -253,7 +253,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(13):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -264,7 +264,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(12):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -289,7 +289,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(9):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -300,7 +300,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(8):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -51,7 +51,7 @@ class TestPkiApi(
         self.assertEqual(Ca.objects.count(), 0)
         path = reverse("pki_api:ca_list")
         data = self._ca_data
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -61,7 +61,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_list")
         data = self._ca_data
         data["extensions"] = []
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(r.data["extensions"], [])
@@ -77,7 +77,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            10 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
+            9 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 8
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -97,7 +97,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -124,7 +124,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
         org2 = self._create_org()
         data = {"name": "change-ca1", "organization": org2.pk, "notes": "change-notes"}
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -137,7 +137,7 @@ class TestPkiApi(
         data = {
             "name": "change-ca1",
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -161,7 +161,7 @@ class TestPkiApi(
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         old_serial_num = ca1.serial_number
         path = reverse("pki_api:ca_renew", args=[ca1.pk])
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path)
         ca1.refresh_from_db()
         self.assertEqual(r.status_code, 200)
@@ -172,7 +172,7 @@ class TestPkiApi(
         path = reverse("pki_api:cert_list")
         data = self._cert_data
         data["ca"] = self._create_ca().pk
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -189,7 +189,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            14 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 13
+            13 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 12
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -205,7 +205,7 @@ class TestPkiApi(
         data = self._cert_data
         data["ca"] = self._create_ca().pk
         data["extensions"] = []
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -221,7 +221,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -253,7 +253,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -264,7 +264,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -289,7 +289,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -300,7 +300,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)

--- a/tests/openwisp2/sample_config/api/views.py
+++ b/tests/openwisp2/sample_config/api/views.py
@@ -29,6 +29,15 @@ from openwisp_controller.config.api.views import (
     DeviceListCreateView as BaseDeviceListCreateView,
 )
 from openwisp_controller.config.api.views import (
+    ReversionDetailView as BaseReversionDetailView,
+)
+from openwisp_controller.config.api.views import (
+    ReversionListView as BaseReversionListView,
+)
+from openwisp_controller.config.api.views import (
+    ReversionRestoreView as BaseReversionRestoreView,
+)
+from openwisp_controller.config.api.views import (
     TemplateDetailView as BaseTemplateDetailView,
 )
 from openwisp_controller.config.api.views import (
@@ -96,6 +105,18 @@ class DownloadDeviceView(BaseDownloadDeviceView):
     pass
 
 
+class ReversionListView(BaseReversionListView):
+    pass
+
+
+class ReversionDetailView(BaseReversionDetailView):
+    pass
+
+
+class ReversionRestoreView(BaseReversionRestoreView):
+    pass
+
+
 template_list = TemplateListCreateView.as_view()
 template_detail = TemplateDetailView.as_view()
 download_template_config = DownloadTemplateconfiguration.as_view()
@@ -110,3 +131,6 @@ download_device_config = DownloadDeviceView().as_view()
 devicegroup_list = DeviceGroupListCreateView.as_view()
 devicegroup_detail = DeviceGroupDetailView.as_view()
 devicegroup_commonname = DeviceGroupCommonName.as_view()
+reversion_list = ReversionListView.as_view()
+reversion_detail = ReversionDetailView.as_view()
+reversion_restore = ReversionRestoreView.as_view()

--- a/tests/openwisp2/sample_config/api/views.py
+++ b/tests/openwisp2/sample_config/api/views.py
@@ -29,19 +29,19 @@ from openwisp_controller.config.api.views import (
     DeviceListCreateView as BaseDeviceListCreateView,
 )
 from openwisp_controller.config.api.views import (
-    ReversionDetailView as BaseReversionDetailView,
+    RevisionListView as BaseRevisionListView,
 )
 from openwisp_controller.config.api.views import (
-    ReversionListView as BaseReversionListView,
-)
-from openwisp_controller.config.api.views import (
-    ReversionRestoreView as BaseReversionRestoreView,
+    RevisionRestoreView as BaseRevisionRestoreView,
 )
 from openwisp_controller.config.api.views import (
     TemplateDetailView as BaseTemplateDetailView,
 )
 from openwisp_controller.config.api.views import (
     TemplateListCreateView as BaseTemplateListCreateView,
+)
+from openwisp_controller.config.api.views import (
+    VersionDetailView as BaseVersionDetailView,
 )
 from openwisp_controller.config.api.views import VpnDetailView as BaseVpnDetailView
 from openwisp_controller.config.api.views import (
@@ -105,15 +105,15 @@ class DownloadDeviceView(BaseDownloadDeviceView):
     pass
 
 
-class ReversionListView(BaseReversionListView):
+class RevisionListView(BaseRevisionListView):
     pass
 
 
-class ReversionDetailView(BaseReversionDetailView):
+class VersionDetailView(BaseVersionDetailView):
     pass
 
 
-class ReversionRestoreView(BaseReversionRestoreView):
+class RevisionRestoreView(BaseRevisionRestoreView):
     pass
 
 
@@ -131,6 +131,6 @@ download_device_config = DownloadDeviceView().as_view()
 devicegroup_list = DeviceGroupListCreateView.as_view()
 devicegroup_detail = DeviceGroupDetailView.as_view()
 devicegroup_commonname = DeviceGroupCommonName.as_view()
-reversion_list = ReversionListView.as_view()
-reversion_detail = ReversionDetailView.as_view()
-reversion_restore = ReversionRestoreView.as_view()
+revision_list = RevisionListView.as_view()
+version_detail = VersionDetailView.as_view()
+revision_restore = RevisionRestoreView.as_view()

--- a/tests/openwisp2/sample_config/api/views.py
+++ b/tests/openwisp2/sample_config/api/views.py
@@ -29,19 +29,19 @@ from openwisp_controller.config.api.views import (
     DeviceListCreateView as BaseDeviceListCreateView,
 )
 from openwisp_controller.config.api.views import (
-    RevisionListView as BaseRevisionListView,
+    ReversionDetailView as BaseReversionDetailView,
 )
 from openwisp_controller.config.api.views import (
-    RevisionRestoreView as BaseRevisionRestoreView,
+    ReversionListView as BaseReversionListView,
+)
+from openwisp_controller.config.api.views import (
+    ReversionRestoreView as BaseReversionRestoreView,
 )
 from openwisp_controller.config.api.views import (
     TemplateDetailView as BaseTemplateDetailView,
 )
 from openwisp_controller.config.api.views import (
     TemplateListCreateView as BaseTemplateListCreateView,
-)
-from openwisp_controller.config.api.views import (
-    VersionDetailView as BaseVersionDetailView,
 )
 from openwisp_controller.config.api.views import VpnDetailView as BaseVpnDetailView
 from openwisp_controller.config.api.views import (
@@ -105,15 +105,15 @@ class DownloadDeviceView(BaseDownloadDeviceView):
     pass
 
 
-class RevisionListView(BaseRevisionListView):
+class ReversionListView(BaseReversionListView):
     pass
 
 
-class VersionDetailView(BaseVersionDetailView):
+class ReversionDetailView(BaseReversionDetailView):
     pass
 
 
-class RevisionRestoreView(BaseRevisionRestoreView):
+class ReversionRestoreView(BaseReversionRestoreView):
     pass
 
 
@@ -131,6 +131,6 @@ download_device_config = DownloadDeviceView().as_view()
 devicegroup_list = DeviceGroupListCreateView.as_view()
 devicegroup_detail = DeviceGroupDetailView.as_view()
 devicegroup_commonname = DeviceGroupCommonName.as_view()
-revision_list = RevisionListView.as_view()
-version_detail = VersionDetailView.as_view()
-revision_restore = RevisionRestoreView.as_view()
+reversion_list = ReversionListView.as_view()
+reversion_detail = ReversionDetailView.as_view()
+reversion_restore = ReversionRestoreView.as_view()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #894.

## Description of Changes

Introduces three new REST API endpoints for managing revisions:

- **List all revisions** with optional filtering by model:  
`GET /controller/reversion/?model=<model_name>`


- **Inspect a specific revision using its ID**:  
`GET /controller/reversion/<revision_id>/`


- **Restore a revision based on its ID**:  
`POST /controller/reversion/<revision_id>/restore/`

Let me know if any changes are needed in the response data whether anything should be included, excluded, or modified. Also, please share any suggestions for adding more filters or adjusting the response format for the restore endpoint