### PR TITLE
[tests] Add missing sample_config admin tests on 1.1

### DIFF
--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2116,7 +2116,7 @@ class TestTransactionAdmin(
         self.assertContains(
             response,
             '<div class="readonly">',
-            22,
+            23,
         )
         # Save buttons are absent on deactivated device
         self.assertNotContains(response, self._save_btn_html)
@@ -2199,9 +2199,9 @@ class TestTransactionAdmin(
         )
         multiple_success_message_html = (
             f'<li class="success">The following devices were {html_method}ed'
-            f' successfully: <a href="/admin/config/device/{device1.id}/change/">'
-            f'{device1.name}</a>, <a href="/admin/config/device/{device2.id}/change/">'
-            f'{device2.name}</a> and <a href="/admin/config/device/{device3.id}/'
+            f' successfully: <a href="/admin/{self.app_label}/device/{device1.id}/change/">'
+            f'{device1.name}</a>, <a href="/admin/{self.app_label}/device/{device2.id}/change/">'
+            f'{device2.name}</a> and <a href="/admin/{self.app_label}/device/{device3.id}/'
             f'change/">{device3.name}</a>.</li>'
         )
         single_error_message_html = (

--- a/tests/openwisp2/sample_config/tests.py
+++ b/tests/openwisp2/sample_config/tests.py
@@ -119,7 +119,9 @@ class TestVxlan(BaseTestVxlan):
 
 
 del BaseTestAdmin
+del BaseTestTransactionAdmin
 del BaseTestDeviceGroupAdmin
+del BaseTestDeviceGroupAdminTransaction
 del BaseTestConfig
 del BaseTestTransactionConfig
 del BaseTestController

--- a/tests/openwisp2/sample_config/tests.py
+++ b/tests/openwisp2/sample_config/tests.py
@@ -1,6 +1,10 @@
-from openwisp_controller.config.tests.test_admin import TestAdmin as BaseTestAdmin
+from openwisp_controller.config.tests.test_admin import (
+        TestAdmin as BaseTestAdmin,
+        TestTransactionAdmin as BaseTestTransactionAdmin,
+)
 from openwisp_controller.config.tests.test_admin import (
     TestDeviceGroupAdmin as BaseTestDeviceGroupAdmin,
+    TestDeviceGroupAdminTransaction as BaseTestDeviceGroupAdminTransaction,
 )
 from openwisp_controller.config.tests.test_api import TestConfigApi as BaseTestConfigApi
 from openwisp_controller.config.tests.test_apps import TestApps as BaseTestApps
@@ -38,7 +42,15 @@ class TestAdmin(BaseTestAdmin):
     app_label = 'sample_config'
 
 
+class TestTransactionAdmin(BaseTestTransactionAdmin):
+    app_label = 'sample_config'
+
+
 class TestDeviceGroupAdmin(BaseTestDeviceGroupAdmin):
+    app_label = 'sample_config'
+
+
+class TestDeviceGroupAdminTransaction(BaseTestDeviceGroupAdminTransaction):
     app_label = 'sample_config'
 
 


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

This PR adds tests that seemed to be missing among the sample_config tests

This is currently a draft to check tests behaviour in the pipeline, using 1.1 as my current setup.
I plan to rebase on master later on.