### PR TITLE
[tests] Add missing sample_config admin tests on master

### DIFF
--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2229,7 +2229,7 @@ class TestTransactionAdmin(
         self.assertContains(
             response,
             '<div class="readonly">',
-            22,
+            23,
         )
         # Save buttons are absent on deactivated device
         self.assertNotContains(response, self._save_btn_html)
@@ -2312,9 +2312,9 @@ class TestTransactionAdmin(
         )
         multiple_success_message_html = (
             f'<li class="success">The following devices were {html_method}ed'
-            f' successfully: <a href="/admin/config/device/{device1.id}/change/">'
-            f'{device1.name}</a>, <a href="/admin/config/device/{device2.id}/change/">'
-            f'{device2.name}</a> and <a href="/admin/config/device/{device3.id}/'
+            f' successfully: <a href="/admin/{self.app_label}/device/{device1.id}/change/">'
+            f'{device1.name}</a>, <a href="/admin/{self.app_label}/device/{device2.id}/change/">'
+            f'{device2.name}</a> and <a href="/admin/{self.app_label}/device/{device3.id}/'
             f'change/">{device3.name}</a>.</li>'
         )
         single_error_message_html = (

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2229,7 +2229,7 @@ class TestTransactionAdmin(
         self.assertContains(
             response,
             '<div class="readonly">',
-            23,
+            22,
         )
         # Save buttons are absent on deactivated device
         self.assertNotContains(response, self._save_btn_html)

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2190,6 +2190,8 @@ class TestTransactionAdmin(
             'Delete</a></p>'
         )
 
+    _deactivated_device_expected_readonly_fields = 22
+
     def test_device_with_config_change_deactivate_deactivate(self):
         """
         This test checks the following things
@@ -2229,7 +2231,7 @@ class TestTransactionAdmin(
         self.assertContains(
             response,
             '<div class="readonly">',
-            22,
+            self._deactivated_device_expected_readonly_fields,
         )
         # Save buttons are absent on deactivated device
         self.assertNotContains(response, self._save_btn_html)
@@ -2311,10 +2313,13 @@ class TestTransactionAdmin(
             f' was {html_method}ed successfully.</li>'
         )
         multiple_success_message_html = (
-            f'<li class="success">The following devices were {html_method}ed'
-            f' successfully: <a href="/admin/{self.app_label}/device/{device1.id}/change/">'
-            f'{device1.name}</a>, <a href="/admin/{self.app_label}/device/{device2.id}/change/">'
-            f'{device2.name}</a> and <a href="/admin/{self.app_label}/device/{device3.id}/'
+            f'<li class="success">The following devices were {html_method}ed '
+            'successfully: '
+            f'<a href="/admin/{self.app_label}/device/{device1.id}/change/">'
+            f'{device1.name}</a>, '
+            f'<a href="/admin/{self.app_label}/device/{device2.id}/change/">'
+            f'{device2.name}</a> and '
+            f'<a href="/admin/{self.app_label}/device/{device3.id}/'
             f'change/">{device3.name}</a>.</li>'
         )
         single_error_message_html = (

--- a/tests/openwisp2/sample_config/tests.py
+++ b/tests/openwisp2/sample_config/tests.py
@@ -1,10 +1,12 @@
-from openwisp_controller.config.tests.test_admin import (
-        TestAdmin as BaseTestAdmin,
-        TestTransactionAdmin as BaseTestTransactionAdmin,
-)
+from openwisp_controller.config.tests.test_admin import TestAdmin as BaseTestAdmin
 from openwisp_controller.config.tests.test_admin import (
     TestDeviceGroupAdmin as BaseTestDeviceGroupAdmin,
+)
+from openwisp_controller.config.tests.test_admin import (
     TestDeviceGroupAdminTransaction as BaseTestDeviceGroupAdminTransaction,
+)
+from openwisp_controller.config.tests.test_admin import (
+    TestTransactionAdmin as BaseTestTransactionAdmin,
 )
 from openwisp_controller.config.tests.test_api import TestConfigApi as BaseTestConfigApi
 from openwisp_controller.config.tests.test_apps import TestApps as BaseTestApps
@@ -44,6 +46,7 @@ class TestAdmin(BaseTestAdmin):
 
 class TestTransactionAdmin(BaseTestTransactionAdmin):
     app_label = 'sample_config'
+    _deactivated_device_expected_readonly_fields = 23
 
 
 class TestDeviceGroupAdmin(BaseTestDeviceGroupAdmin):

--- a/tests/openwisp2/sample_config/tests.py
+++ b/tests/openwisp2/sample_config/tests.py
@@ -119,7 +119,9 @@ class TestVxlan(BaseTestVxlan):
 
 
 del BaseTestAdmin
+del BaseTestTransactionAdmin
 del BaseTestDeviceGroupAdmin
+del BaseTestDeviceGroupAdminTransaction
 del BaseTestConfig
 del BaseTestTransactionConfig
 del BaseTestController

--- a/tests/openwisp2/sample_config/tests.py
+++ b/tests/openwisp2/sample_config/tests.py
@@ -1,6 +1,10 @@
-from openwisp_controller.config.tests.test_admin import TestAdmin as BaseTestAdmin
+from openwisp_controller.config.tests.test_admin import (
+        TestAdmin as BaseTestAdmin,
+        TestTransactionAdmin as BaseTestTransactionAdmin,
+)
 from openwisp_controller.config.tests.test_admin import (
     TestDeviceGroupAdmin as BaseTestDeviceGroupAdmin,
+    TestDeviceGroupAdminTransaction as BaseTestDeviceGroupAdminTransaction,
 )
 from openwisp_controller.config.tests.test_api import TestConfigApi as BaseTestConfigApi
 from openwisp_controller.config.tests.test_apps import TestApps as BaseTestApps
@@ -38,7 +42,15 @@ class TestAdmin(BaseTestAdmin):
     app_label = 'sample_config'
 
 
+class TestTransactionAdmin(BaseTestTransactionAdmin):
+    app_label = 'sample_config'
+
+
 class TestDeviceGroupAdmin(BaseTestDeviceGroupAdmin):
+    app_label = 'sample_config'
+
+
+class TestDeviceGroupAdminTransaction(BaseTestDeviceGroupAdminTransaction):
     app_label = 'sample_config'
 
 


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

This PR adds tests that seemed to be missing among the sample_config tests
