### PR TITLE
Added 'subnet' and 'ip' in the VpnSerializer

### DIFF
--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -85,6 +85,8 @@ class VpnSerializer(BaseSerializer):
             'name',
             'host',
             'organization',
+            'subnet',
+            'ip',
             'key',
             'ca',
             'cert',


### PR DESCRIPTION
Added the 'subnet' and 'ip' fields in the VpnSerializer in order to have them in the /controller/vpn/ APIs

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1003 


## Description of Changes

Added the relevant fields in the VpnSerializer
