### PR TITLE
Added Subnet and IP in the Vpn list and Vpn detail APIs

### DIFF
--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -77,6 +77,7 @@ class TemplateSerializer(BaseSerializer):
 class VpnSerializer(BaseSerializer):
     config = serializers.JSONField(initial={})
     include_shared = True
+    ip = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta(BaseMeta):
         model = Vpn
@@ -85,6 +86,8 @@ class VpnSerializer(BaseSerializer):
             'name',
             'host',
             'organization',
+            'subnet',
+            'ip',
             'key',
             'ca',
             'cert',

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -9,6 +9,7 @@ from swapper import load_model
 
 from openwisp_users.api.mixins import FilterSerializerByOrgManaged
 from openwisp_utils.api.serializers import ValidatedModelSerializer
+from openwisp_ipam.models import IpAddress
 
 from .. import settings as app_settings
 
@@ -108,8 +109,10 @@ class VpnClientSerializer(serializers.ModelSerializer):
         fields = ['id', 'vpn', 'ip_address']
 
     def get_ip_address(self, obj):
-        return obj.ip.ip_address if obj.ip else None
-
+        try:
+            return obj.ip.ip_address if obj.ip else None
+        except IpAddress.DoesNotExist:
+            return None
 
 class FilterTemplatesByOrganization(serializers.PrimaryKeyRelatedField):
     def get_queryset(self):

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -14,6 +14,7 @@ from .. import settings as app_settings
 
 Template = load_model('config', 'Template')
 Vpn = load_model('config', 'Vpn')
+VpnClient = load_model('config', 'VpnClient')
 Device = load_model('config', 'Device')
 DeviceGroup = load_model('config', 'DeviceGroup')
 Config = load_model('config', 'Config')
@@ -98,6 +99,16 @@ class VpnSerializer(BaseSerializer):
             'created',
             'modified',
         ]
+
+class VpnClientSerializer(serializers.ModelSerializer):
+    vpn = serializers.PrimaryKeyRelatedField(read_only=True)
+    ip_address = serializers.SerializerMethodField()
+    class Meta:
+        model = VpnClient
+        fields = ['id', 'vpn', 'ip_address']
+
+    def get_ip_address(self, obj):
+        return obj.ip.ip_address if obj.ip else None
 
 
 class FilterTemplatesByOrganization(serializers.PrimaryKeyRelatedField):
@@ -248,6 +259,10 @@ class DeviceDetailConfigSerializer(BaseConfigSerializer):
         initial={}, help_text=_('Configuration variables in JSON format')
     )
     templates = FilterTemplatesByOrganization(many=True)
+    vpnclient_config = VpnClientSerializer(many=True, read_only=True, source='vpnclient_set')
+
+    class Meta(BaseConfigSerializer.Meta):
+        fields = BaseConfigSerializer.Meta.fields + ['vpnclient_config']
 
 
 class DeviceDetailSerializer(DeviceConfigMixin, BaseSerializer):

--- a/openwisp_controller/config/api/views.py
+++ b/openwisp_controller/config/api/views.py
@@ -104,7 +104,10 @@ class DeviceDetailView(ProtectedAPIMixin, RetrieveUpdateDestroyAPIView):
     """
 
     serializer_class = DeviceDetailSerializer
-    queryset = Device.objects.select_related('config', 'group', 'organization')
+    queryset = Device.objects.select_related('config', 'group', 'organization').prefetch_related(
+        'config__vpnclient_set'
+    )
+
     permission_classes = ProtectedAPIMixin.permission_classes + (DevicePermission,)
 
     def perform_destroy(self, instance):


### PR DESCRIPTION
Added 'subnet' and 'ip' fields in the /controller/vpn/ and /controller/vpn/${id} get requests

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1003 

## Description of Changes

Changed the Meta calss inside the VpnSerializer class in order to add 'subnet' and 'ip' fields