### PR TITLE
[fix] Fixed bug in preview when device has no name

### DIFF
--- a/openwisp_controller/config/base/base.py
+++ b/openwisp_controller/config/base/base.py
@@ -89,7 +89,7 @@ class BaseConfig(BaseModel):
             return config
         c = deepcopy(config)
         is_config = not any([self.__template__, self.__vpn__])
-        if 'hostname' not in c.get('general', {}) and is_config:
+        if all(('hostname' not in c.get('general', {}), is_config, self.name)):
             c.setdefault('general', {})
             c['general']['hostname'] = self.name.replace(':', '-')
         return c

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -423,7 +423,7 @@ class AbstractConfig(BaseConfig):
 
         # Check if the device is using stock OpenWrt.
         openwrt_match = re.search(
-            '[oO][pP][eE][nN][wW][rR][tT]\s*([\d.]+)', self.device.os
+            r'[oO][pP][eE][nN][wW][rR][tT]\s*([\d.]+)', self.device.os
         )
         if openwrt_match:
             if version.parse(openwrt_match.group(1)) >= version.parse('21'):

--- a/openwisp_controller/config/tests/test_config.py
+++ b/openwisp_controller/config/tests/test_config.py
@@ -333,6 +333,11 @@ class TestConfig(
         c.refresh_from_db()
         self.assertDictEqual(c.config, {'general': {}})
 
+        with self.subTest('missing name shall not raise exception'):
+            c.device.name = None
+            del c.backend_instance
+            self.assertDictEqual(c.backend_instance.config, {'general': {}})
+
     def test_config_context(self):
         config = {
             'general': {

--- a/openwisp_controller/config/validators.py
+++ b/openwisp_controller/config/validators.py
@@ -2,7 +2,7 @@ from django.core.validators import RegexValidator, _lazy_re_compile
 from django.utils.translation import gettext_lazy as _
 
 key_validator = RegexValidator(
-    _lazy_re_compile('^[^\s/\.]+$'),
+    _lazy_re_compile(r'^[^\s/\.]+$'),
     message=_('Key must not contain spaces, dots or slashes.'),
     code='invalid',
 )
@@ -16,9 +16,9 @@ mac_address_validator = RegexValidator(
 
 # device name must either be a hostname or a valid mac address
 hostname_regex = (
-    '^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}'
-    '[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9]'
-    '[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$'
+    r'^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}'
+    r'[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9]'
+    r'[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$'
 )
 device_name_validator = RegexValidator(
     _lazy_re_compile('{0}|{1}'.format(hostname_regex, mac_address_regex)),

--- a/openwisp_controller/connection/commands.py
+++ b/openwisp_controller/connection/commands.py
@@ -65,7 +65,7 @@ DEFAULT_COMMANDS = OrderedDict(
                             'type': 'string',
                             'minLength': 6,
                             'maxLength': 30,
-                            'pattern': '[\S]',
+                            'pattern': r'[\S]',
                         }
                     },
                 },


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

The `get_config` method wasn't checking  if `self.name` is defined before using it.