### PR TITLE
[tests] Import django_loci selenium tests, fix failing readonly tests

### DIFF
--- a/openwisp_controller/geo/tests/test_selenium.py
+++ b/openwisp_controller/geo/tests/test_selenium.py
@@ -4,13 +4,17 @@ from django_loci.tests.base.test_selenium import BaseTestDeviceAdminSelenium
 from selenium.webdriver.common.by import By
 from swapper import load_model
 
+from openwisp_users.tests.utils import TestOrganizationMixin
+
 Device = load_model('config', 'Device')
 Location = load_model('geo', 'Location')
 FloorPlan = load_model('geo', 'FloorPlan')
 DeviceLocation = load_model('geo', 'DeviceLocation')
 
 
-class TestDeviceAdminSelenium(BaseTestDeviceAdminSelenium, StaticLiveServerTestCase):
+class TestDeviceAdminSelenium(
+    BaseTestDeviceAdminSelenium, TestOrganizationMixin, StaticLiveServerTestCase
+):
     app_label = 'geo'
     object_model = Device
     location_model = Location
@@ -23,8 +27,22 @@ class TestDeviceAdminSelenium(BaseTestDeviceAdminSelenium, StaticLiveServerTestC
     def _get_prefix(cls):
         return cls.inline_field_prefix
 
-    def _create_device(self):
+    def _fill_device_form(self):
+        org = self._get_org()
         self.find_element(by=By.NAME, value='mac_address').send_keys(
             '11:22:33:44:55:66'
         )
-        super()._create_device()
+        self.find_element(
+            by=By.CSS_SELECTOR, value='#select2-id_organization-container'
+        ).click()
+        self.wait_for_invisibility(
+            By.CSS_SELECTOR, '.select2-results__option.loading-results'
+        )
+        self.find_element(by=By.CLASS_NAME, value='select2-search__field').send_keys(
+            org.name
+        )
+        self.wait_for_invisibility(
+            By.CSS_SELECTOR, '.select2-results__option.loading-results'
+        )
+        self.find_element(by=By.CLASS_NAME, value='select2-results__option').click()
+        super()._fill_device_form()

--- a/openwisp_controller/geo/tests/test_selenium.py
+++ b/openwisp_controller/geo/tests/test_selenium.py
@@ -1,0 +1,30 @@
+from django.contrib.auth import get_user_model
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django_loci.tests.base.test_selenium import BaseTestDeviceAdminSelenium
+from selenium.webdriver.common.by import By
+from swapper import load_model
+
+Device = load_model('config', 'Device')
+Location = load_model('geo', 'Location')
+FloorPlan = load_model('geo', 'FloorPlan')
+DeviceLocation = load_model('geo', 'DeviceLocation')
+
+
+class TestDeviceAdminSelenium(BaseTestDeviceAdminSelenium, StaticLiveServerTestCase):
+    app_label = 'geo'
+    object_model = Device
+    location_model = Location
+    object_location_model = DeviceLocation
+    user_model = get_user_model()
+
+    inline_field_prefix = 'devicelocation'
+
+    @classmethod
+    def _get_prefix(cls):
+        return cls.inline_field_prefix
+
+    def _create_device(self):
+        self.find_element(by=By.NAME, value='mac_address').send_keys(
+            '11:22:33:44:55:66'
+        )
+        super()._create_device()

--- a/openwisp_controller/geo/tests/utils.py
+++ b/openwisp_controller/geo/tests/utils.py
@@ -3,6 +3,7 @@ from django_loci.tests import TestLociMixin
 from swapper import load_model
 
 Organization = load_model('openwisp_users', 'Organization')
+OrganizationUser = load_model('openwisp_users', 'OrganizationUser')
 
 
 class TestGeoMixin(TestLociMixin):
@@ -56,3 +57,9 @@ class TestGeoMixin(TestLociMixin):
         ol.full_clean()
         ol.save()
         return ol
+
+    def _create_readonly_admin(self, **kwargs):
+        user = super()._create_readonly_admin(**kwargs)
+        org1 = self._create_organization()
+        OrganizationUser.objects.create(user=user, organization=org1, is_admin=True)
+        return user

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-taggit~=6.0.0
 netjsonconfig @ https://github.com/openwisp/netjsonconfig/tarball/1.2
 django-x509 @ https://github.com/openwisp/django-x509/tarball/1.3
 # temp for passing tests
-django-loci @ https://github.com/DragnEmperor/django-loci/tarball/chores/migrate-formset-function
+django-loci @ https://github.com/DragnEmperor/django-loci/tarball/1.2
 django-flat-json-widget~=0.3.1
 openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/1.2
 openwisp-utils[celery,channels] @ https://github.com/openwisp/openwisp-utils/tarball/1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,8 @@ django-reversion~=5.1.0
 django-taggit~=6.0.0
 netjsonconfig @ https://github.com/openwisp/netjsonconfig/tarball/1.2
 django-x509 @ https://github.com/openwisp/django-x509/tarball/1.3
-django-loci @ https://github.com/openwisp/django-loci/tarball/1.2
+# temp for passing tests
+django-loci @ https://github.com/DragnEmperor/django-loci/tarball/chores/migrate-formset-function
 django-flat-json-widget~=0.3.1
 openwisp-users @ https://github.com/openwisp/openwisp-users/tarball/1.2
 openwisp-utils[celery,channels] @ https://github.com/openwisp/openwisp-utils/tarball/1.2


### PR DESCRIPTION
Imported selenium test cases for device admin from `django_loci`. The readonly tests were failing due to user not belonging to the same organization of instances.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Description of Changes

Imported selenium test cases for device admin from `django_loci`. 
The readonly tests were failing due to user not belonging to the same organization of instances.
