### PR TITLE
[change] Change relevant templates logic to facilitate changing organization +optimizations

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -463,6 +463,13 @@ class ConfigInline(
         fields = super().get_fields(request, obj)
         return self._error_reason_field_conditional(obj, fields)
 
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        # setting queryset none for all requests except POST as queryset
+        # is required for the form to be valid
+        if db_field.name == 'templates' and request.method != 'POST':
+            kwargs['queryset'] = Template.objects.none()
+        return super().formfield_for_manytomany(db_field, request, **kwargs)
+
 
 class ChangeDeviceGroupForm(forms.Form):
     device_group = forms.ModelChoiceField(
@@ -1318,6 +1325,13 @@ class DeviceGroupAdmin(MultitenantAdminMixin, BaseAdmin):
             ),
         }
         return ctx
+
+    def formfield_for_manytomany(self, db_field, request, **kwargs):
+        # setting queryset none for all requests except POST as queryset
+        # is required for the form to be valid
+        if db_field.name == 'templates' and request.method != 'POST':
+            kwargs['queryset'] = Template.objects.none()
+        return super().formfield_for_manytomany(db_field, request, **kwargs)
 
 
 admin.site.register(Device, DeviceAdminExportable)

--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -466,8 +466,8 @@ class ConfigInline(
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         # setting queryset none for all requests except POST as queryset
         # is required for the form to be valid
-        if db_field.name == 'templates' and request.method != 'POST':
-            kwargs['queryset'] = Template.objects.none()
+        if db_field.name == "templates" and request.method != "POST":
+            kwargs["queryset"] = Template.objects.none()
         return super().formfield_for_manytomany(db_field, request, **kwargs)
 
 
@@ -1329,8 +1329,8 @@ class DeviceGroupAdmin(MultitenantAdminMixin, BaseAdmin):
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         # setting queryset none for all requests except POST as queryset
         # is required for the form to be valid
-        if db_field.name == 'templates' and request.method != 'POST':
-            kwargs['queryset'] = Template.objects.none()
+        if db_field.name == "templates" and request.method != "POST":
+            kwargs["queryset"] = Template.objects.none()
         return super().formfield_for_manytomany(db_field, request, **kwargs)
 
 

--- a/openwisp_controller/config/static/config/js/relevant_templates.js
+++ b/openwisp_controller/config/static/config/js/relevant_templates.js
@@ -71,12 +71,23 @@ django.jQuery(function ($) {
     },
     updateConfigTemplateField = function (templates) {
       var value = templates.join(","),
-        templateField = templatesFieldName();
+        templateField = templatesFieldName(),
+        updateInitialValue = false;
       $(`input[name="${templateField}"]`).attr("value", value);
-      if (pageLoading) {
+      if (
+        pageLoading ||
+        // Handle cases where the AJAX request finishes after initial page load.
+        // If we're editing an existing object and the initial value hasn't been set,
+        // assign it now to avoid false positives in the unsaved changes warning.
+        (!isAddingNewObject() &&
+          django._owcInitialValues[templateField] === undefined)
+      ) {
         django._owcInitialValues[templateField] = value;
+        updateInitialValue = true;
       }
-      $("input.sortedm2m:first").trigger("change");
+      $("input.sortedm2m:first").trigger("change", {
+        updateInitialValue: updateInitialValue,
+      });
     },
     getSelectedTemplates = function () {
       // Returns the selected templates from the sortedm2m input

--- a/openwisp_controller/config/static/config/js/relevant_templates.js
+++ b/openwisp_controller/config/static/config/js/relevant_templates.js
@@ -95,7 +95,10 @@ django.jQuery(function ($) {
         selectedTemplates;
 
       // Hide templates if no organization or backend is selected
-      if (orgID.length === 0 || (!isDeviceGroup() && backend.length === 0)) {
+      if (
+        (orgID && orgID.length === 0) ||
+        (!isDeviceGroup() && backend.length === 0)
+      ) {
         resetTemplateOptions();
         updateTemplateHelpText();
         return;
@@ -212,8 +215,10 @@ django.jQuery(function ($) {
         if (selectedTemplates === undefined) {
           if (!isDeviceGroup()) {
             $(
-              `.has_original .field-templates .sortedm2m-container input[type="hidden"]`,
-            ).attr("name", templatesFieldName());
+              `#config-0 .field-templates .sortedm2m-container input[type="hidden"]`,
+            )
+              .first()
+              .attr("name", templatesFieldName());
             // set the initial value of the hidden input field
             // to the selected templates
             django._owcInitialValues[templatesFieldName()] =

--- a/openwisp_controller/config/static/config/js/relevant_templates.js
+++ b/openwisp_controller/config/static/config/js/relevant_templates.js
@@ -4,7 +4,7 @@ django.jQuery(function ($) {
     backendFieldSelector = "#id_config-0-backend",
     orgFieldSelector = "#id_organization",
     isDeviceGroup = function () {
-      return window._deviceGroup;
+      return window._deviceGroupId !== undefined;
     },
     templatesFieldName = function () {
       return isDeviceGroup() ? "templates" : "config-0-templates";

--- a/openwisp_controller/config/static/config/js/relevant_templates.js
+++ b/openwisp_controller/config/static/config/js/relevant_templates.js
@@ -105,10 +105,7 @@ django.jQuery(function ($) {
         url.searchParams.set("backend", backend);
       }
       if (isDeviceGroup() && !$(".add-form").length) {
-        // Get the group id from the URL
-        // TODO: This is fragile, consider using a more robust way to get the group id.
-        var pathParts = window.location.pathname.split("/");
-        url.searchParams.set("group_id", pathParts[pathParts.length - 3]);
+        url.searchParams.set("group_id", window._deviceGroupId);
       } else if ($('input[name="config-0-id"]').length) {
         url.searchParams.set("config_id", $('input[name="config-0-id"]').val());
       }

--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -326,13 +326,7 @@
         }
         alert(message);
       }
-      var contextField = $("#id_config-0-context");
-      if (contextField.length) {
-        var contextValue = JSON.parse(contextField.val());
-        contextField.val(
-          JSON.stringify(removeUnchangedDefaultValues(contextValue)),
-        );
-      }
+
       if ($advancedEl.is(":hidden")) {
         return;
       }
@@ -494,8 +488,8 @@
         getDefaultValues(true);
       });
     }
-    $(".sortedm2m-items").on("change", function () {
-      getDefaultValues();
+    $(".sortedm2m-items").on("change", function (event) {
+      getDefaultValues(event.updateInitialValue === true);
     });
     $(".sortedm2m-items").on("sortstop", function () {
       getDefaultValues();

--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -326,7 +326,13 @@
         }
         alert(message);
       }
-
+      var contextField = $("#id_config-0-context");
+      if (contextField.length) {
+        var contextValue = JSON.parse(contextField.val());
+        contextField.val(
+          JSON.stringify(removeUnchangedDefaultValues(contextValue)),
+        );
+      }
       if ($advancedEl.is(":hidden")) {
         return;
       }

--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -488,8 +488,8 @@
         getDefaultValues(true);
       });
     }
-    $(".sortedm2m-items").on("change", function (event) {
-      getDefaultValues(event.updateInitialValue === true);
+    $(".sortedm2m-items").on("change", function (event, data) {
+      getDefaultValues(data && data.updateInitialValue === true);
     });
     $(".sortedm2m-items").on("sortstop", function () {
       getDefaultValues();

--- a/openwisp_controller/config/templates/admin/device_group/change_form.html
+++ b/openwisp_controller/config/templates/admin/device_group/change_form.html
@@ -12,7 +12,6 @@
         (function ($) {
             $(document).ready( function () {
                 window._relevantTemplateUrl = "{{ relevant_template_url | safe }}";
-                window._deviceGroup = true;
                 window._deviceGroupId = "{{ original.pk }}";
                 window.bindDefaultTemplateLoading();
             })

--- a/openwisp_controller/config/templates/admin/device_group/change_form.html
+++ b/openwisp_controller/config/templates/admin/device_group/change_form.html
@@ -13,6 +13,7 @@
             $(document).ready( function () {
                 window._relevantTemplateUrl = "{{ relevant_template_url | safe }}";
                 window._deviceGroup = true;
+                window._deviceGroupId = "{{ original.pk }}";
                 window.bindDefaultTemplateLoading();
             })
         }) (django.jQuery);

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1572,7 +1572,7 @@ class TestAdmin(
         def _update_template(templates):
             params.update(
                 {
-                    'config-0-templates': ','.join(
+                    "config-0-templates": ",".join(
                         [str(template.pk) for template in templates]
                     )
                 }
@@ -1584,8 +1584,8 @@ class TestAdmin(
         vpn = self._create_vpn()
         template = self._create_template()
         vpn_template = self._create_template(
-            name='vpn-test',
-            type='vpn',
+            name="vpn-test",
+            type="vpn",
             vpn=vpn,
             auto_cert=True,
         )
@@ -1594,26 +1594,26 @@ class TestAdmin(
         revoked_cert_query = cert_query.filter(revoked=True)
 
         # Add a new device
-        path = reverse(f'admin:{self.app_label}_device_add')
+        path = reverse(f"admin:{self.app_label}_device_add")
         params = self._get_device_params(org=self._get_org())
         response = self.client.post(path, data=params, follow=True)
         self.assertEqual(response.status_code, 200)
 
-        config = Device.objects.get(name=params['name']).config
+        config = Device.objects.get(name=params["name"]).config
         self.assertEqual(config.vpnclient_set.count(), 0)
         self.assertEqual(config.templates.count(), 0)
 
-        path = reverse(f'admin:{self.app_label}_device_change', args=[config.device_id])
+        path = reverse(f"admin:{self.app_label}_device_change", args=[config.device_id])
         params.update(
             {
-                'config-0-id': str(config.pk),
-                'config-0-device': str(config.device_id),
-                'config-INITIAL_FORMS': 1,
-                '_continue': True,
+                "config-0-id": str(config.pk),
+                "config-0-device": str(config.device_id),
+                "config-INITIAL_FORMS": 1,
+                "_continue": True,
             }
         )
 
-        with self.subTest('Adding only VpnClient template'):
+        with self.subTest("Adding only VpnClient template"):
             # Adding VpnClient template to the device
             _update_template(templates=[vpn_template])
 
@@ -1631,7 +1631,7 @@ class TestAdmin(
             self.assertEqual(revoked_cert_query.count(), 1)
             self.assertEqual(valid_cert_query.count(), 0)
 
-        with self.subTest('Add VpnClient template along with another template'):
+        with self.subTest("Add VpnClient template along with another template"):
             # Adding templates to the device
             _update_template(templates=[template, vpn_template])
 
@@ -2100,9 +2100,9 @@ class TestAdmin(
 
     # helper for asserting queries executed during template fetch for a device
     def _verify_template_queries(self, config, count):
-        path = reverse(f'admin:{self.app_label}_device_change', args=[config.device.pk])
+        path = reverse(f"admin:{self.app_label}_device_change", args=[config.device.pk])
         for i in range(count):
-            self._create_template(name=f'template-{i}')
+            self._create_template(name=f"template-{i}")
         expected_count = 24
         if django.VERSION < (5, 2):
             # In django version < 5.2, there is an extra SAVEPOINT query
@@ -2115,7 +2115,7 @@ class TestAdmin(
             # and 1 for fetching templates
             response = self.client.get(
                 reverse(
-                    'admin:get_relevant_templates', args=[config.device.organization.pk]
+                    "admin:get_relevant_templates", args=[config.device.organization.pk]
                 )
             )
             self.assertEqual(response.status_code, 200)
@@ -2127,11 +2127,11 @@ class TestAdmin(
 
     def test_templates_fetch_queries_5(self):
         config = self._create_config(organization=self._get_org())
-        self._verify_template_queries(config, 1)
+        self._verify_template_queries(config, 5)
 
     def test_templates_fetch_queries_10(self):
         config = self._create_config(organization=self._get_org())
-        self._verify_template_queries(config, 1)
+        self._verify_template_queries(config, 10)
 
 
 class TestTransactionAdmin(

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1568,6 +1568,85 @@ class TestAdmin(
             response, 'value="openwisp_controller.vpn_backends.OpenVpn" selected'
         )
 
+    def test_vpn_clients_deleted(self):
+        def _update_template(templates):
+            params.update(
+                {
+                    'config-0-templates': ','.join(
+                        [str(template.pk) for template in templates]
+                    )
+                }
+            )
+            response = self.client.post(path, data=params, follow=True)
+            self.assertEqual(response.status_code, 200)
+            return response
+
+        vpn = self._create_vpn()
+        template = self._create_template()
+        vpn_template = self._create_template(
+            name='vpn-test',
+            type='vpn',
+            vpn=vpn,
+            auto_cert=True,
+        )
+        cert_query = Cert.objects.exclude(pk=vpn.cert_id)
+        valid_cert_query = cert_query.filter(revoked=False)
+        revoked_cert_query = cert_query.filter(revoked=True)
+
+        # Add a new device
+        path = reverse(f'admin:{self.app_label}_device_add')
+        params = self._get_device_params(org=self._get_org())
+        response = self.client.post(path, data=params, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        config = Device.objects.get(name=params['name']).config
+        self.assertEqual(config.vpnclient_set.count(), 0)
+        self.assertEqual(config.templates.count(), 0)
+
+        path = reverse(f'admin:{self.app_label}_device_change', args=[config.device_id])
+        params.update(
+            {
+                'config-0-id': str(config.pk),
+                'config-0-device': str(config.device_id),
+                'config-INITIAL_FORMS': 1,
+                '_continue': True,
+            }
+        )
+
+        with self.subTest('Adding only VpnClient template'):
+            # Adding VpnClient template to the device
+            _update_template(templates=[vpn_template])
+
+            self.assertEqual(config.templates.count(), 1)
+            self.assertEqual(config.vpnclient_set.count(), 1)
+            self.assertEqual(cert_query.count(), 1)
+            self.assertEqual(valid_cert_query.count(), 1)
+
+            # Remove VpnClient template from the device
+            _update_template(templates=[])
+
+            self.assertEqual(config.templates.count(), 0)
+            self.assertEqual(config.vpnclient_set.count(), 0)
+            # Removing VPN template marks the related certificate as revoked
+            self.assertEqual(revoked_cert_query.count(), 1)
+            self.assertEqual(valid_cert_query.count(), 0)
+
+        with self.subTest('Add VpnClient template along with another template'):
+            # Adding templates to the device
+            _update_template(templates=[template, vpn_template])
+
+            self.assertEqual(config.templates.count(), 2)
+            self.assertEqual(config.vpnclient_set.count(), 1)
+            self.assertEqual(valid_cert_query.count(), 1)
+
+            # Remove VpnClient template from the device
+            _update_template(templates=[template])
+
+            self.assertEqual(config.templates.count(), 1)
+            self.assertEqual(config.vpnclient_set.count(), 0)
+            self.assertEqual(valid_cert_query.count(), 0)
+            self.assertEqual(revoked_cert_query.count(), 2)
+
     def test_ip_not_in_add_device(self):
         path = reverse(f"admin:{self.app_label}_device_add")
         response = self.client.get(path)

--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -12,8 +12,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
 from swapper import load_model
 
-from openwisp_controller.config.base import device
-from openwisp_users.tests.utils import TestOrganizationMixin
 from openwisp_utils.tests import SeleniumTestMixin as BaseSeleniumTestMixin
 
 from .utils import CreateConfigTemplateMixin, TestVpnX509Mixin, TestWireguardVpnMixin
@@ -26,18 +24,18 @@ Cert = load_model("django_x509", "Cert")
 class SeleniumTestMixin(BaseSeleniumTestMixin):
     def _select_organization(self, org):
         self.find_element(
-            by=By.CSS_SELECTOR, value='#select2-id_organization-container'
+            by=By.CSS_SELECTOR, value="#select2-id_organization-container"
         ).click()
         self.wait_for_invisibility(
-            By.CSS_SELECTOR, '.select2-results__option.loading-results'
+            By.CSS_SELECTOR, ".select2-results__option.loading-results"
         )
-        self.find_element(by=By.CLASS_NAME, value='select2-search__field').send_keys(
+        self.find_element(by=By.CLASS_NAME, value="select2-search__field").send_keys(
             org.name
         )
         self.wait_for_invisibility(
-            By.CSS_SELECTOR, '.select2-results__option.loading-results'
+            By.CSS_SELECTOR, ".select2-results__option.loading-results"
         )
-        self.find_element(by=By.CLASS_NAME, value='select2-results__option').click()
+        self.find_element(by=By.CLASS_NAME, value="select2-results__option").click()
 
     def _verify_templates_visibility(self, hidden=None, visible=None):
         hidden = hidden or []
@@ -48,7 +46,7 @@ class SeleniumTestMixin(BaseSeleniumTestMixin):
             self.wait_for_visibility(By.XPATH, f'//*[@value="{template.id}"]')
 
 
-@tag('selenium_tests')
+@tag("selenium_tests")
 class TestDeviceAdmin(
     SeleniumTestMixin,
     CreateConfigTemplateMixin,
@@ -58,7 +56,7 @@ class TestDeviceAdmin(
     # helper function for adding/removing templates
     def _update_template(self, device_id, templates, is_enabled=False):
         self.open(
-            reverse('admin:config_device_change', args=[device_id]) + '#config-group'
+            reverse("admin:config_device_change", args=[device_id]) + "#config-group"
         )
         self.wait_for_presence(By.CSS_SELECTOR, 'input[name="config-0-templates"]')
 
@@ -79,8 +77,8 @@ class TestDeviceAdmin(
         self.web_driver.execute_script(
             'document.querySelector("#ow-user-tools").style.display="none"'
         )
-        self.find_element(by=By.NAME, value='_save').click()
-        self.wait_for_presence(By.CSS_SELECTOR, '.messagelist .success', timeout=5)
+        self.find_element(by=By.NAME, value="_save").click()
+        self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success", timeout=5)
 
     def test_create_new_device(self):
         required_template = self._create_template(name="Required", required=True)
@@ -200,7 +198,7 @@ class TestDeviceAdmin(
         )
         self.hide_loading_overlay()
 
-        with self.subTest('only org1 and shared templates should be visible'):
+        with self.subTest("only org1 and shared templates should be visible"):
             self._verify_templates_visibility(
                 hidden=[org2_required_template, org2_default_template],
                 visible=[
@@ -210,7 +208,7 @@ class TestDeviceAdmin(
                 ],
             )
 
-        with self.subTest('changing org should update templates'):
+        with self.subTest("changing org should update templates"):
             self.find_element(
                 By.CSS_SELECTOR, value='a[href="#overview-group"]'
             ).click()
@@ -387,56 +385,56 @@ class TestDeviceAdmin(
         # so we add a wait to allow login to complete
         time.sleep(2)
 
-        with self.subTest('Template should be added'):
+        with self.subTest("Template should be added"):
             self._update_template(device.id, templates=[template])
             config.refresh_from_db()
             self.assertEqual(config.templates.count(), 1)
-            self.assertEqual(config.status, 'modified')
+            self.assertEqual(config.status, "modified")
             config.set_status_applied()
-            self.assertEqual(config.status, 'applied')
+            self.assertEqual(config.status, "applied")
 
-        with self.subTest('Template should be removed'):
+        with self.subTest("Template should be removed"):
             self._update_template(device.id, templates=[template], is_enabled=True)
             config.refresh_from_db()
             self.assertEqual(config.templates.count(), 0)
-            self.assertEqual(config.status, 'modified')
+            self.assertEqual(config.status, "modified")
 
 
-@tag('selenium_tests')
+@tag("selenium_tests")
 class TestDeviceGroupAdmin(
     SeleniumTestMixin,
     CreateConfigTemplateMixin,
     StaticLiveServerTestCase,
 ):
     def test_show_relevant_templates(self):
-        org1 = self._create_org(name='org1', slug='org1')
-        org2 = self._create_org(name='org2', slug='org2')
-        shared_template = self._create_template(name='shared template')
-        org1_template = self._create_template(name='org1 template', organization=org1)
+        org1 = self._create_org(name="org1", slug="org1")
+        org2 = self._create_org(name="org2", slug="org2")
+        shared_template = self._create_template(name="shared template")
+        org1_template = self._create_template(name="org1 template", organization=org1)
         org1_required_template = self._create_template(
-            name='org1 required', organization=org1, required=True
+            name="org1 required", organization=org1, required=True
         )
         org1_default_template = self._create_template(
-            name='org1 default', organization=org1, default=True
+            name="org1 default", organization=org1, default=True
         )
-        org2_template = self._create_template(name='org2 template', organization=org2)
+        org2_template = self._create_template(name="org2 template", organization=org2)
         org2_required_template = self._create_template(
-            name='org2 required', organization=org2, required=True
+            name="org2 required", organization=org2, required=True
         )
         org2_default_template = self._create_template(
-            name='org2 default', organization=org2, default=True
+            name="org2 default", organization=org2, default=True
         )
 
         self.login()
-        self.open(reverse('admin:config_devicegroup_add'))
+        self.open(reverse("admin:config_devicegroup_add"))
         self.assertEqual(
             self.wait_for_visibility(
-                By.CSS_SELECTOR, '.sortedm2m-container .help'
+                By.CSS_SELECTOR, ".sortedm2m-container .help"
             ).text,
-            'No Template available',
+            "No Template available",
         )
         self.find_element(by=By.CSS_SELECTOR, value='input[name="name"]').send_keys(
-            'Test Device Group'
+            "Test Device Group"
         )
         self._select_organization(org1)
         self._verify_templates_visibility(
@@ -459,7 +457,7 @@ class TestDeviceGroupAdmin(
         self.find_element(by=By.CSS_SELECTOR, value='input[name="_continue"]').click()
         self._wait_until_page_ready()
         device_group = DeviceGroup.objects.first()
-        self.assertEqual(device_group.name, 'Test Device Group')
+        self.assertEqual(device_group.name, "Test Device Group")
         self.assertIn(org1_template, device_group.templates.all())
         self.assertEqual(
             self.find_element(
@@ -469,7 +467,7 @@ class TestDeviceGroupAdmin(
             True,
         )
 
-        with self.subTest('Change organization to org2'):
+        with self.subTest("Change organization to org2"):
             self._select_organization(org2)
             self._verify_templates_visibility(
                 hidden=[

--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -168,9 +168,7 @@ class TestDeviceAdmin(
             self.wait_for_invisibility(By.CSS_SELECTOR, ".djnjc-overlay:not(.loading)")
 
     def test_multiple_organization_templates(self):
-        shared_template = self._create_template(
-            name="shared", organization=None
-        )
+        shared_template = self._create_template(name="shared", organization=None)
 
         org1 = self._create_org(name="org1", slug="org1")
         org1_required_template = self._create_template(

--- a/openwisp_controller/config/tests/test_views.py
+++ b/openwisp_controller/config/tests/test_views.py
@@ -107,6 +107,7 @@ class TestViews(
                     "required": t4.required,
                     "default": t4.default,
                     "name": t4.name,
+                    "selected": False,
                 }
             },
         )
@@ -144,6 +145,7 @@ class TestViews(
                     "required": t1.required,
                     "default": t1.default,
                     "name": t1.name,
+                    "selected": False,
                 }
             },
         )
@@ -163,6 +165,7 @@ class TestViews(
                     "required": t2.required,
                     "default": t2.default,
                     "name": t2.name,
+                    "selected": False,
                 }
             },
         )

--- a/openwisp_controller/config/tests/test_views.py
+++ b/openwisp_controller/config/tests/test_views.py
@@ -243,7 +243,7 @@ class TestViews(
         response = self.client.get(
             reverse("admin:get_relevant_templates", args=["wrong"])
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 400)
 
     def test_get_default_values_authorization(self):
         org1 = self._get_org()

--- a/openwisp_controller/config/views.py
+++ b/openwisp_controller/config/views.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from copy import deepcopy
 from uuid import UUID
 
-import ipdb
 from django.db.models import Q
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.utils import timezone
@@ -29,7 +28,7 @@ def _get_relevant_templates_dict(queryset, selected=False):
             backend=template.get_backend_display(),
             default=template.default,
             required=template.required,
-            selected=True,
+            selected=selected,
         )
     return relevant_templates
 

--- a/openwisp_controller/config/views.py
+++ b/openwisp_controller/config/views.py
@@ -2,7 +2,9 @@ import json
 from copy import deepcopy
 from uuid import UUID
 
+from django.db import models as django_models
 from django.db.models import Q
+from django.db.models.functions import Coalesce
 from django.http import HttpResponse, JsonResponse
 from django.utils import timezone
 from django.utils.module_loading import import_string
@@ -31,26 +33,50 @@ def get_relevant_templates(request, organization_id):
     if not user.is_superuser and not user.is_manager(organization_id):
         return HttpResponse(status=403)
     org = get_object_or_404(Organization, pk=organization_id, is_active=True)
+    org_filters = Q(organization_id=org.pk) | Q(organization_id=None)
     filter_options = {}
     if backend:
         filter_options.update(backend=backend)
     else:
         filter_options.update(required=False, default=False)
+    sort_value_subquery = None
+    # fetch the selected templates for the device or group by creating a subquery.
+    # through_model and lookup_field are set based on the presence of device_id or
+    # group_id. we need through_model as `sort_value` is a field of the through model.
+    # the subquery will be used to annotate the queryset with the sort_value
+    # of the selected templates.
+    if device_id and (lookup := Config.objects.filter(device_id=device_id).first()):
+        through_model = Config.templates.through
+        lookup_field = "config_id"
+    if group_id and (
+        lookup := DeviceGroup.objects.filter(Q(pk=group_id) & (org_filters)).first()
+    ):
+        through_model = DeviceGroup.templates.through
+        lookup_field = "devicegroup_id"
+    if device_id or group_id:
+        sort_value_subquery = django_models.Subquery(
+            through_model.objects.filter(
+                **{lookup_field: lookup.id}, template_id=django_models.OuterRef('pk')
+            ).values('sort_value')[:1],
+            output_field=django_models.IntegerField(),
+        )
+    # annotated a selected field which is True based on sort_value
+    # if sort_value is 9999 then selected is False else True
     queryset = (
         Template.objects.filter(**filter_options)
-        .filter(Q(organization_id=org.pk) | Q(organization_id=None))
+        .filter(org_filters)
+        .annotate(
+            sort_value=Coalesce(sort_value_subquery, django_models.Value(9999)),
+            selected=django_models.Case(
+                django_models.When(sort_value=9999, then=django_models.Value(False)),
+                default=django_models.Value(True),
+                output_field=django_models.BooleanField(),
+            ),
+        )
+        .order_by("sort_value")
         .only("id", "name", "backend", "default", "required")
     )
-    # for checking which templates are enabled for given device or group
-    selected_templates = []
-    if device_id:
-        selected_templates = Config.objects.filter(device_id=device_id).values_list(
-            'templates__id', flat=True
-        )
-    if group_id:
-        selected_templates = DeviceGroup.objects.filter(
-            pk=group_id, organization_id=organization_id
-        ).values_list('templates__id', flat=True)
+
     relevant_templates = {}
     for template in queryset:
         relevant_templates[str(template.pk)] = dict(
@@ -58,7 +84,7 @@ def get_relevant_templates(request, organization_id):
             backend=template.get_backend_display(),
             default=template.default,
             required=template.required,
-            selected=template.pk in selected_templates,
+            selected=template.selected,
         )
     return JsonResponse(relevant_templates)
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #204
Closes #1050

## Description of Changes

To remove queries generated by sortedm2m, 'formfield_for_manytomany' is overridden such that on page load, we can get templates using 'get_relevant_templates'. 
Added device/group id in 'get_relevant_templates' to identify selected templates. Changes are made in 'relevantTemplates.js' to ensure templates are viewed and changes are saved as per initial behavior.

As now we are fetching  templates via js only, I have done some modifications for the failing test cases.
- for test case `test_device_templates_m2m_queryset` there is a similar selenium test case `test_multiple_organization_templates`
- for test cases `test_configuration_templates_removed` , `test_vpn_clients_deleted`, have added new selenium test cases `test_add_remove_templates`, `test_vpn_clients_deleted`.