### PR TITLE
[fix] Fixed live updates for "Send commands"

### DIFF
--- a/openwisp_controller/connection/channels/consumers.py
+++ b/openwisp_controller/connection/channels/consumers.py
@@ -1,4 +1,5 @@
 import json
+from copy import deepcopy
 
 from swapper import load_model
 
@@ -9,5 +10,6 @@ Device = load_model('config', 'Device')
 
 class CommandConsumer(BaseDeviceConsumer):
     def send_update(self, event):
-        event.pop('type')
-        self.send(json.dumps(event))
+        data = deepcopy(event)
+        data.pop('type')
+        self.send(json.dumps(data))


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Bug:
When multiple connections are made to the websocket command endpoint of the same device (e.g. when multiple browser tabs are open for the same device), the UI does not receive updates from the websocket and keeps showing a loader in the command output field, even when the command has completed execution.

Fix:
The issue was caused by mutating the shared `event` dictionary in the `send_update` method of `CommandConsumer`. Specifically, calling `event.pop('type')` removed the `'type'` key from the event. Since the same event object is dispatched to all consumer instances (one for each websocket connection), removing `'type'` in one instance caused the others to raise:

    ValueError: Incoming message has no 'type' attribute

This broke message dispatch for the remaining connections. The fix is to avoid modifying the original `event` dictionary.
This preserves the `'type'` key, ensuring all consumer instances continue to receive well-formed events and function correctly.

