### PR TITLE
[feature] Add support for inherited variables in DeviceDetialView #818

### DIFF
--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -326,6 +326,18 @@ class DeviceDetailSerializer(DeviceConfigSerializer):
                 )
         return super().update(instance, validated_data)
 
+    def get_inherited_variables(self, device):
+        return {
+            'global': getattr(app_settings, 'CONTEXT', {}),
+            'group': DeviceGroupSerializer(device.group, context=self.context).data,
+            'config': DeviceDetailConfigSerializer(
+                device.config, context=self.context
+            ).data,
+            'templates': TemplateSerializer(
+                device.config.templates, many=True, context=self.context
+            ).data,
+        }
+
 
 class FilterGroupTemplates(FilterTemplatesByOrganization):
     def get_queryset(self):

--- a/openwisp_controller/config/api/views.py
+++ b/openwisp_controller/config/api/views.py
@@ -111,6 +111,14 @@ class DeviceDetailView(ProtectedAPIMixin, RetrieveUpdateDestroyAPIView):
         force_deletion = self.request.query_params.get('force', None) == 'true'
         instance.delete(check_deactivated=(not force_deletion))
 
+    def retrieve(self, request, *args, **kwargs):
+        device = self.get_object()
+        serializer = self.get_serializer(device)
+        data = serializer.data
+        if request.query_params.get('inherited_variables') == 'True':
+            data['inherited_variables'] = serializer.get_inherited_variables(device)
+        return Response(data)
+
     def get_object(self):
         """Set device property for serializer context."""
         obj = super().get_object()


### PR DESCRIPTION
Expose inherited variables (from templates, groups, and global) in API response via optional query param.

Fixes #818

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #818.

## Description of Changes

- Added a parameter `inherited_variables` to the DeviceDetailView to optionally include the inherited variables field from related objects.
   1. Config
   2. Group
   3. Templates
   4. Global (not sure the added one is correct)
- Not sure if the add way of serializing the object is the correct way.

####  Sample response

```
{
  'id': '8237003b-ecb9-46f0-80cf-bb3f5c407afb',
  'name': 'default.test.device',
  'organization': 'f5e0b4e0-629f-47c8-8115-6ffaf89cd54c',
  'group': '2132c6b5-e85d-4d6a-bb3e-a9c6ba744dc3',
  'mac_address': '00:11:22:33:44:55',
  'key': 'XxtYUJsxaGAZAl7KuIE7lnFnKluUzshG',
  'last_ip': None,
  'management_ip': None,
  'is_deactivated': False,
  'model': 'TP-Link TL-WDR4300 v1',
  'os': 'LEDE Reboot 17.01-SNAPSHOT r3313-c2999ef',
  'system': '',
  'notes': '',
  'config': {
    'status': 'modified',
    'error_reason': '',
    'backend': 'netjsonconfig.OpenWrt',
    'templates': ['9ad08f5e-ca41-4f84-be38-523bca731989'],
    'context': {},
    'config': {
      'general': {}
    }
  },
  'created': '2025-05-07T13:31:03.711252+02:00',
  'modified': '2025-05-07T13:31:03.711252+02:00',
  
  // Newly added field
  
  'inherited_variables': {
    'global': {
      'vpnserver1': 'vpn.testdomain.com'
    },
    'group': {
      'id': '2132c6b5-e85d-4d6a-bb3e-a9c6ba744dc3',
      'name': 'Routers',
      'organization': 'f5e0b4e0-629f-47c8-8115-6ffaf89cd54c',
      'description': 'Group for all routers',
      'templates': [],
      'context': {},
      'meta_data': {},
      'created': '2025-05-07T13:31:03.708412+02:00',
      'modified': '2025-05-07T13:31:03.708412+02:00'
    },
    'config': {
      'status': 'modified',
      'error_reason': '',
      'backend': 'netjsonconfig.OpenWrt',
      'templates': ['9ad08f5e-ca41-4f84-be38-523bca731989'],
      'context': {},
      'config': {
        'general': {}
      }
    },
    'templates': [
      {
        'id': '9ad08f5e-ca41-4f84-be38-523bca731989',
        'name': 'test-template',
        'organization': 'f5e0b4e0-629f-47c8-8115-6ffaf89cd54c',
        'type': 'generic',
        'backend': 'netjsonconfig.OpenWrt',
        'vpn': None,
        'tags': [],
        'default': False,
        'required': False,
        'default_values': {},
        'config': {
          'interfaces': [
            {
              'name': 'eth0',
              'type': 'ethernet'
            }
          ]
        },
        'created': '2025-05-07T13:31:03.736374+02:00',
        'modified': '2025-05-07T13:31:03.736374+02:00'
      }
    ]
  }
}

```  
