### PR TITLE
[fix] Fixed target URL in "config_error" notification type

### DIFF
--- a/openwisp_controller/config/utils.py
+++ b/openwisp_controller/config/utils.py
@@ -203,5 +203,5 @@ def get_default_templates_queryset(
 
 
 def get_config_error_notification_target_url(obj, field, absolute_url=True):
-    url = _get_object_link(obj, field, absolute_url)
+    url = _get_object_link(obj._related_object(field), absolute_url)
     return f'{url}#config-group'


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

Bug:
The target_link callable was not returning the correct URL due to changes in openwisp-notifications.

Fix:
Updated the target_link callable for "config_error" notification type and improved test for better E2E testing.

