### PR TITLE
[Fix] Update to show most recent commands first

### DIFF
--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -53,7 +53,7 @@ class BaseCommandView(
         )
 
     def get_queryset(self):
-        return super().get_queryset().filter(device_id=self.kwargs['device_pk'])
+        return super().get_queryset().filter(device_id=self.kwargs['device_pk']).order_by('-created')
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -125,6 +125,13 @@ class TestCommandsAPI(TestCase, AuthenticationMixin, CreateCommandMixin):
             self.assertIn('device', command_obj)
             self.assertIn('connection', command_obj)
 
+        with self.subTest('Test results ordering, recent first'):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            created_list = [cmd['created'] for cmd in response.data['results']]
+            sorted_created_list = sorted(created_list, reverse=True)
+            self.assertEqual(created_list, sorted_created_list)
+
     def test_command_create_api(self):
         def test_command_attributes(self, payload):
             self.assertEqual(command_qs.count(), 1)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #1040.

## Description of Changes

Added ordering by creation date (descending) to the Base command view to ensure consistent and expected command ordering.
Subtest added under the command list test function.

