### PR TITLE
[fix] Ensure recent items are shown first in the REST API 

### DIFF
--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -56,7 +56,7 @@ class BaseCommandView(
         return (
             super()
             .get_queryset()
-            .filter(device_id=self.kwargs["device_pk"])
+            .filter(device_id=self.kwargs["device_id"])
             .order_by("-created")
         )
 

--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -53,7 +53,12 @@ class BaseCommandView(
         )
 
     def get_queryset(self):
-        return super().get_queryset().filter(device_id=self.kwargs["device_id"])
+        return (
+            super()
+            .get_queryset()
+            .filter(device_id=self.kwargs["device_pk"])
+            .order_by("-created")
+        )
 
     def get_serializer_context(self):
         context = super().get_serializer_context()

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -125,6 +125,13 @@ class TestCommandsAPI(TestCase, AuthenticationMixin, CreateCommandMixin):
             self.assertIn("device", command_obj)
             self.assertIn("connection", command_obj)
 
+        with self.subTest("Test results ordering, recent first"):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            created_list = [cmd["created"] for cmd in response.data["results"]]
+            sorted_created_list = sorted(created_list, reverse=True)
+            self.assertEqual(created_list, sorted_created_list)
+
     def test_command_create_api(self):
         def test_command_attributes(self, payload):
             self.assertEqual(command_qs.count(), 1)

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.timezone import now, timedelta
 from packaging.version import parse as parse_version
 from rest_framework import VERSION as REST_FRAMEWORK_VERSION
 from rest_framework.exceptions import ErrorDetail
@@ -399,6 +400,16 @@ class TestConnectionApi(
         with self.assertNumQueries(4):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
+        with self.subTest("Check ordering of credentials"):
+            cred_old = self._create_credentials(name="Old Credential")
+            cred_old.created = now() - timedelta(days=1)
+            cred_old.save()
+            self._create_credentials(name="Newest Credential")
+            response = self.client.get(path)
+            self.assertEqual(response.status_code, 200)
+            created_list = [cred["created"] for cred in response.data["results"]]
+            sorted_created = sorted(created_list, reverse=True)
+            self.assertEqual(created_list, sorted_created)
 
     def test_filter_credentials_list(self):
         cred_1 = self._create_credentials(name="Credential One")
@@ -416,18 +427,6 @@ class TestConnectionApi(
         self.assertEqual(response.data["count"], 1)
         self.assertContains(response, cred_2.id)
         self.assertNotContains(response, cred_1.id)
-
-    @patch.object(ListViewPagination, "page_size", 3)
-    def test_credential_list_ordering(self):
-        number_of_credentials = 6
-        url = reverse("connection_api:credential_list")
-        for i in range(number_of_credentials):
-            self._create_credentials(name=f"Test Credential {i}")
-        response = self.client.get(url)
-        self.assertEqual(response.data["count"], number_of_credentials)
-        created_list = [cred["created"] for cred in response.data["results"]]
-        sorted_created_list = sorted(created_list, reverse=True)
-        self.assertEqual(created_list, sorted_created_list)
 
     def test_post_credential_list(self):
         path = reverse("connection_api:credential_list")
@@ -502,25 +501,19 @@ class TestConnectionApi(
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 0)
-
-    @patch.object(ListViewPagination, "page_size", 3)
-    def test_deviceconnection_list_ordering(self):
-        device = self._create_device()
-        self._create_config(device=device)
-        credentials_list = [
-            self._create_credentials(name=f"Credential {i}") for i in range(3)
-        ]
-        for cred in credentials_list:
-            DeviceConnection.objects.create(
-                device=device,
-                credentials=cred,
-            )
-        path = reverse("connection_api:deviceconnection_list", args=(device.pk,))
-        response = self.client.get(path)
-        self.assertEqual(response.status_code, 200)
-        created_list = [item["created"] for item in response.data["results"]]
-        sorted_created_list = sorted(created_list, reverse=True)
-        self.assertEqual(created_list, sorted_created_list)
+        with self.subTest("Check ordering of device connections"):
+            self._create_config(device=d1)
+            creds = [self._create_credentials(name=f"Cred {i}") for i in range(3)]
+            creds[0].created = now() - timedelta(days=1)
+            creds[0].save()
+            for cred in creds:
+                DeviceConnection.objects.create(device=d1, credentials=cred)
+            response = self.client.get(path)
+            print(response.data)
+            self.assertEqual(response.status_code, 200)
+            created_list = [conn["created"] for conn in response.data["results"]]
+            sorted_created = sorted(created_list, reverse=True)
+            self.assertEqual(created_list, sorted_created)
 
     def test_post_deviceconnection_list(self):
         d1 = self._create_device()

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -428,7 +428,7 @@ class TestConnectionApi(
         created_list = [cred["created"] for cred in response.data["results"]]
         sorted_created_list = sorted(created_list, reverse=True)
         self.assertEqual(created_list, sorted_created_list)
-    
+
     def test_post_credential_list(self):
         path = reverse("connection_api:credential_list")
         data = {

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -417,6 +417,18 @@ class TestConnectionApi(
         self.assertContains(response, cred_2.id)
         self.assertNotContains(response, cred_1.id)
 
+    @patch.object(ListViewPagination, "page_size", 3)
+    def test_credential_list_ordering(self):
+        number_of_credentials = 6
+        url = reverse("connection_api:credential_list")
+        for i in range(number_of_credentials):
+            self._create_credentials(name=f"Test Credential {i}")
+        response = self.client.get(url)
+        self.assertEqual(response.data["count"], number_of_credentials)
+        created_list = [cred["created"] for cred in response.data["results"]]
+        sorted_created_list = sorted(created_list, reverse=True)
+        self.assertEqual(created_list, sorted_created_list)
+    
     def test_post_credential_list(self):
         path = reverse("connection_api:credential_list")
         data = {
@@ -490,6 +502,25 @@ class TestConnectionApi(
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 0)
+
+    @patch.object(ListViewPagination, "page_size", 3)
+    def test_deviceconnection_list_ordering(self):
+        device = self._create_device()
+        self._create_config(device=device)
+        credentials_list = [
+            self._create_credentials(name=f"Credential {i}") for i in range(3)
+        ]
+        for cred in credentials_list:
+            DeviceConnection.objects.create(
+                device=device,
+                credentials=cred,
+            )
+        path = reverse("connection_api:deviceconnection_list", args=(device.pk,))
+        response = self.client.get(path)
+        self.assertEqual(response.status_code, 200)
+        created_list = [item["created"] for item in response.data["results"]]
+        sorted_created_list = sorted(created_list, reverse=True)
+        self.assertEqual(created_list, sorted_created_list)
 
     def test_post_deviceconnection_list(self):
         d1 = self._create_device()


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #1040.

## Description of Changes

Added ordering by creation date (descending) to the Base command view to ensure consistent and expected command ordering and checked all other list apis to ensure recency.
Tests to supported the same added.