### PR TITLE
[chores] Add gsoc25-map and gsoc25-whois in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - master
       - "1.1"
+      - gsoc25-map
+      - gsoc25-whois
 
 jobs:
   build:


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes
- Add `gosc25-map` and `gsoc25-whois` to get the CI builds