### PR TITLE
[tests] Sessions now cached in redis

### DIFF
--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2103,13 +2103,13 @@ class TestAdmin(
         path = reverse(f"admin:{self.app_label}_device_change", args=[config.device.pk])
         for i in range(count):
             self._create_template(name=f"template-{i}")
-        expected_count = 24
+        expected_count = 22
         if django.VERSION < (5, 2):
             # In django version < 5.2, there is an extra SAVEPOINT query
             # leading to extra RELEASE SAVEPOINT query, thus 2 extra queries
             expected_count += 2
         with self.assertNumQueries(expected_count):
-            # contains 22 queries for fetching normal device data
+            # contains 20 queries for fetching normal device data
             response = self.client.get(path)
             # contains 2 queries, 1 for fetching organization
             # and 1 for fetching templates

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1776,7 +1776,7 @@ class TestAdmin(
         path = reverse("admin:get_default_values")
 
         with self.subTest("get default values for one template"):
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(2):
                 r = self.client.get(path, {"pks": f"{t1.pk}"})
                 self.assertEqual(r.status_code, 200)
                 expected = {"default_values": {"name1": "test1"}}
@@ -1784,14 +1784,14 @@ class TestAdmin(
 
         with self.subTest("get default values for multiple templates"):
             t2 = self._create_template(name="t2", default_values={"name2": "test2"})
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(2):
                 r = self.client.get(path, {"pks": f"{t1.pk},{t2.pk}"})
                 self.assertEqual(r.status_code, 200)
                 expected = {"default_values": {"name1": "test1", "name2": "test2"}}
                 self.assertEqual(r.json(), expected)
 
         with self.subTest("get default values conflicting with device group"):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(
                     path, {"pks": f"{t1.pk}", "group": str(group.pk)}
                 )
@@ -1803,7 +1803,7 @@ class TestAdmin(
                 self.assertNotIn("name4", response_data)
 
         with self.subTest("get default values conflicting with organization"):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(
                     path, {"pks": f"{t1.pk}", "organization": str(org.pk)}
                 )
@@ -1814,7 +1814,7 @@ class TestAdmin(
                 self.assertNotIn("name3", response_data)
 
         with self.subTest("get default values conflicting with organization and group"):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get(
                     path,
                     {

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -249,7 +249,7 @@ class TestConfigApi(
     def test_device_list_api(self):
         device = self._create_device()
         path = reverse("config_api:device_list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         with self.subTest("device list should show most recent first"):
@@ -395,7 +395,7 @@ class TestConfigApi(
     def test_device_detail_api(self):
         d1 = self._create_device()
         path = reverse("config_api:device_detail", args=[d1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["config"], None)
@@ -405,7 +405,7 @@ class TestConfigApi(
         d1 = self._create_device()
         self._create_config(device=d1)
         path = reverse("config_api:device_detail", args=[d1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertNotEqual(r.data["config"], None)
@@ -547,7 +547,7 @@ class TestConfigApi(
         d1 = self._create_device()
         self._create_config(device=d1)
         path = reverse("config_api:download_device_config", args=[d1.pk])
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
 
@@ -708,7 +708,7 @@ class TestConfigApi(
         org1 = self._get_org()
         self._create_template(name="t1", organization=org1)
         path = reverse("config_api:template_list")
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(Template.objects.count(), 1)
@@ -801,7 +801,7 @@ class TestConfigApi(
     def test_template_detail_api(self):
         t1 = self._create_template(name="t1")
         path = reverse("config_api:template_detail", args=[t1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["organization"], None)
@@ -834,7 +834,7 @@ class TestConfigApi(
     def test_template_download_api(self):
         t1 = self._create_template(name="t1")
         path = reverse("config_api:download_template_config", args=[t1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
 
@@ -873,7 +873,7 @@ class TestConfigApi(
         org = self._get_org()
         self._create_vpn(organization=org)
         path = reverse("config_api:vpn_list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
 
@@ -935,7 +935,7 @@ class TestConfigApi(
     def test_vpn_detail_no_org_api(self):
         vpn1 = self._create_vpn(name="test-vpn")
         path = reverse("config_api:vpn_detail", args=[vpn1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["organization"], None)
@@ -945,7 +945,7 @@ class TestConfigApi(
         org = self._get_org()
         vpn1 = self._create_vpn(name="test-vpn", organization=org)
         path = reverse("config_api:vpn_detail", args=[vpn1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["organization"], org.pk)
@@ -980,7 +980,7 @@ class TestConfigApi(
     def test_vpn_download_api(self):
         vpn1 = self._create_vpn(name="test-vpn")
         path = reverse("config_api:download_vpn_config", args=[vpn1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
 
@@ -1054,7 +1054,7 @@ class TestConfigApi(
         dg = self._create_device_group()
         path = reverse("config_api:devicegroup_list")
         with self.subTest("assert number of queries"):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 r = self.client.get(path)
             self.assertEqual(r.status_code, 200)
         with self.subTest("should not contain default or required templates"):
@@ -1123,7 +1123,7 @@ class TestConfigApi(
         path = reverse("config_api:devicegroup_detail", args=[device_group.pk])
 
         with self.subTest("Test GET"):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["name"], device_group.name)
@@ -1354,11 +1354,11 @@ class TestConfigApiTransaction(
             self.assertEqual(response.status_code, 200)
 
         def _assert_cache_invalidation(path, org_slug):
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(5):
                 response = self.client.get(path, data={"org": org_slug})
                 self.assertEqual(response.status_code, 200)
 
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(5):
                 response = self.client.get(path)
                 self.assertEqual(response.status_code, 200)
 
@@ -1369,11 +1369,11 @@ class TestConfigApiTransaction(
 
         with self.subTest("Test caching works"):
             _build_cache(path, org.slug)
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(2):
                 response = self.client.get(path, data={"org": org.slug})
                 self.assertEqual(response.status_code, 200)
 
-            with self.assertNumQueries(3):
+            with self.assertNumQueries(2):
                 response = self.client.get(path)
                 self.assertEqual(response.status_code, 200)
 
@@ -1415,11 +1415,11 @@ class TestConfigApiTransaction(
             "config_api:devicegroup_x509_commonname", args=[cert.common_name]
         )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(path, data={"org": org.slug})
             self.assertEqual(response.status_code, 200)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path, data={"org": org.slug})
             self.assertEqual(response.status_code, 200)
 
@@ -1433,11 +1433,11 @@ class TestConfigApiTransaction(
             "config_api:devicegroup_x509_commonname", args=[cert.common_name]
         )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(path, data={"org": org.slug})
             self.assertEqual(response.status_code, 200)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path, data={"org": org.slug})
             self.assertEqual(response.status_code, 200)
 
@@ -1451,11 +1451,11 @@ class TestConfigApiTransaction(
             "config_api:devicegroup_x509_commonname", args=[cert.common_name]
         )
 
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(path, data={"org": org.slug})
             self.assertEqual(response.status_code, 200)
 
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path, data={"org": org.slug})
             self.assertEqual(response.status_code, 200)
 

--- a/openwisp_controller/config/tests/test_views.py
+++ b/openwisp_controller/config/tests/test_views.py
@@ -70,7 +70,7 @@ class TestViews(
             inactive_t,
         ) = self._create_template_test_data()
         self._login()
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 reverse("admin:get_relevant_templates", args=[org1.pk])
             )
@@ -92,7 +92,7 @@ class TestViews(
             default=False,
             required=True,
         )
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 reverse("admin:get_relevant_templates", args=[org1.pk])
             )
@@ -130,7 +130,7 @@ class TestViews(
         )
         self._login()
 
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(
                 reverse("admin:get_relevant_templates", args=[org1.pk]),
                 {"backend": "netjsonconfig.OpenWrt"},

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -397,7 +397,7 @@ class TestConnectionApi(
     def test_get_credentials_list(self):
         self._create_credentials()
         path = reverse("connection_api:credential_list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         with self.subTest("Check ordering of credentials"):
@@ -421,7 +421,7 @@ class TestConnectionApi(
         OrganizationUser.objects.create(user=user, organization=org1, is_admin=True)
         self.client.force_login(user)
         path = reverse("connection_api:credential_list")
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 1)
@@ -437,14 +437,14 @@ class TestConnectionApi(
             "auto_add": False,
             "params": {"username": "roOT", "password": "Pa$$w0Rd", "port": 22},
         }
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 
     def test_get_credential_detail(self):
         cred = self._create_credentials()
         path = reverse("connection_api:credential_detail", args=(cred.pk,))
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
 
@@ -464,7 +464,7 @@ class TestConnectionApi(
             },
         }
         expected_queries = (
-            9 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 8
+            8 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 7
         )
         with self.assertNumQueries(expected_queries):
             response = self.client.put(path, data, content_type="application/json")
@@ -482,7 +482,7 @@ class TestConnectionApi(
         cred = self._create_credentials()
         path = reverse("connection_api:credential_detail", args=(cred.pk,))
         data = {"name": "Change Test credentials"}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "Change Test credentials")
@@ -490,14 +490,14 @@ class TestConnectionApi(
     def test_delete_credential_detail(self):
         cred = self._create_credentials()
         path = reverse("connection_api:credential_detail", args=(cred.pk,))
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.delete(path)
         self.assertEqual(response.status_code, 204)
 
     def test_get_deviceconnection_list(self):
         d1 = self._create_device()
         path = reverse("connection_api:deviceconnection_list", args=(d1.pk,))
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["count"], 0)
@@ -525,7 +525,7 @@ class TestConnectionApi(
             "enabled": True,
             "failure_reason": "",
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 
@@ -538,7 +538,7 @@ class TestConnectionApi(
             "enabled": True,
             "failure_reason": "",
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.post(path, data, content_type="application/json")
         error_msg = """
             the update strategy can be determined automatically only if
@@ -555,7 +555,7 @@ class TestConnectionApi(
         dc = self._create_device_connection()
         d1 = dc.device.id
         path = reverse("connection_api:deviceconnection_detail", args=(d1, dc.pk))
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
 
@@ -570,7 +570,7 @@ class TestConnectionApi(
             "enabled": False,
             "failure_reason": "",
         }
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(13):
             response = self.client.put(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -584,7 +584,7 @@ class TestConnectionApi(
         path = reverse("connection_api:deviceconnection_detail", args=(d1, dc.pk))
         self.assertEqual(dc.update_strategy, app_settings.UPDATE_STRATEGIES[0][0])
         data = {"update_strategy": app_settings.UPDATE_STRATEGIES[1][0]}
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
@@ -595,7 +595,7 @@ class TestConnectionApi(
         dc = self._create_device_connection()
         d1 = dc.device.id
         path = reverse("connection_api:deviceconnection_detail", args=(d1, dc.pk))
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.delete(path)
         self.assertEqual(response.status_code, 204)
 

--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -311,7 +311,7 @@ class TestGeoApi(
 
     def test_get_floorplan_list(self):
         path = reverse("geo_api:list_floorplan")
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
 
@@ -327,7 +327,7 @@ class TestGeoApi(
         path = reverse("geo_api:list_floorplan")
 
         with self.subTest("Test without organization filtering"):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 2)
@@ -335,7 +335,7 @@ class TestGeoApi(
             self.assertContains(response, org2_floorplan.id)
 
         with self.subTest("Test filtering with organization slug"):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(path, {"organization_slug": org1.slug})
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -343,7 +343,7 @@ class TestGeoApi(
             self.assertNotContains(response, org2_floorplan.id)
 
         with self.subTest("Test filtering with organization id"):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get(path, {"organization": org1.id})
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -354,7 +354,7 @@ class TestGeoApi(
             self.client.logout()
             user = self._create_administrator([org1])
             self.client.force_login(user)
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(5):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -370,7 +370,7 @@ class TestGeoApi(
             "location": location.pk,
         }
         self.assertEqual(self.floorplan_model.objects.count(), 0)
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.post(path, data, format="multipart")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.floorplan_model.objects.count(), 1)
@@ -380,7 +380,7 @@ class TestGeoApi(
     def test_get_floorplan_detail(self):
         f1 = self._create_floorplan()
         path = reverse("geo_api:detail_floorplan", args=[f1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
 
@@ -392,7 +392,7 @@ class TestGeoApi(
         image = Image.new("RGB", (100, 100))
         image.save(temporary_image.name)
         data = {"floor": 12, "image": temporary_image, "location": l1.pk}
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -405,7 +405,7 @@ class TestGeoApi(
         self.assertEqual(f1.floor, 1)
         path = reverse("geo_api:detail_floorplan", args=[f1.pk])
         data = {"floor": 12}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["floor"], 12)
@@ -413,13 +413,13 @@ class TestGeoApi(
     def test_delete_floorplan_detail(self):
         f1 = self._create_floorplan()
         path = reverse("geo_api:detail_floorplan", args=[f1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.delete(path)
         self.assertEqual(response.status_code, 204)
 
     def test_get_location_list(self):
         path = reverse("geo_api:list_location")
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.get(path)
         self.assertEqual(response.status_code, 200)
 
@@ -433,7 +433,7 @@ class TestGeoApi(
         path = reverse("geo_api:list_location")
 
         with self.subTest("Test without organization filtering"):
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(5):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 2)
@@ -441,7 +441,7 @@ class TestGeoApi(
             self.assertContains(response, org2_location.id)
 
         with self.subTest("Test filtering with organization slug"):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get(path, {"organization_slug": org1.slug})
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -449,7 +449,7 @@ class TestGeoApi(
             self.assertNotContains(response, org2_location.id)
 
         with self.subTest("Test filtering with organization id"):
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(5):
                 response = self.client.get(path, {"organization": org1.id})
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -457,7 +457,7 @@ class TestGeoApi(
             self.assertNotContains(response, org2_location.id)
 
         with self.subTest("Test filtering with location type"):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get(path, {"type": "indoor"})
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -465,7 +465,7 @@ class TestGeoApi(
             self.assertNotContains(response, org2_location.id)
 
         with self.subTest('Test filtering with "is_mobile"'):
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get(path, {"is_mobile": True})
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -476,7 +476,7 @@ class TestGeoApi(
             self.client.logout()
             user = self._create_administrator([org1])
             self.client.force_login(user)
-            with self.assertNumQueries(7):
+            with self.assertNumQueries(6):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 1)
@@ -494,21 +494,21 @@ class TestGeoApi(
             "address": "Via del Corso, Roma, Italia",
             "geometry": coords,
         }
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
 
     def test_get_location_detail(self):
         with self.subTest("Test with invalid pk"):
             path = reverse("geo_api:detail_location", args=["wrong-pk"])
-            with self.assertNumQueries(2):
+            with self.assertNumQueries(1):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 404)
 
         with self.subTest("Test with correct pk"):
             location = self._create_location()
             path = reverse("geo_api:detail_location", args=[location.pk])
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
 
@@ -525,7 +525,7 @@ class TestGeoApi(
             "address": "Via del Corso, Roma, Italia",
             "geometry": coords,
         }
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.put(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["organization"], org1.pk)
@@ -536,7 +536,7 @@ class TestGeoApi(
         self.assertEqual(l1.name, "test-location")
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"name": "change-test-location"}
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["name"], "change-test-location")
@@ -553,7 +553,7 @@ class TestGeoApi(
             "geometry": coords,
             "floorplan": {"floor": 12},
         }
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             response = self.client.post(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 400)
         self.assertIn(
@@ -566,7 +566,7 @@ class TestGeoApi(
         fl = self._create_floorplan(location=l1)
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"floorplan": {"floor": 13}}
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         fl.refresh_from_db()
@@ -577,7 +577,7 @@ class TestGeoApi(
         self._create_floorplan(location=l1)
         path = reverse("geo_api:detail_location", args=[l1.pk])
         data = {"type": "outdoor"}
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["floorplan"], [])
@@ -585,7 +585,7 @@ class TestGeoApi(
     def test_delete_location_detail(self):
         l1 = self._create_location()
         path = reverse("geo_api:detail_location", args=[l1.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             response = self.client.delete(path)
         self.assertEqual(response.status_code, 204)
 
@@ -603,7 +603,7 @@ class TestGeoApi(
             "floorplan.floor": ["23"],
             "floorplan.image": [fl_image],
         }
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             response = self.client.post(path, data, format="multipart")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
@@ -627,7 +627,7 @@ class TestGeoApi(
             "floorplan.floor": "23",
             "floorplan.image": fl_image,
         }
-        with self.assertNumQueries(16):
+        with self.assertNumQueries(15):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -722,7 +722,7 @@ class TestGeoApi(
         floorplan = self._create_floorplan()
         location = floorplan.location
         url = reverse("geo_api:device_location", args=[device.id])
-        with self.assertNumQueries(18):
+        with self.assertNumQueries(17):
             response = self.client.put(
                 url,
                 data={
@@ -760,7 +760,7 @@ class TestGeoApi(
             "floorplan.image": self._get_simpleuploadedfile(),
             "indoor": ["12.342,23.541"],
         }
-        with self.assertNumQueries(32):
+        with self.assertNumQueries(31):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -827,7 +827,7 @@ class TestGeoApi(
                 "type": "indoor",
             }
         }
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(20):
             response = self.client.put(url, data=data, content_type="application/json")
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.location_model.objects.count(), 1)
@@ -844,7 +844,7 @@ class TestGeoApi(
             "floorplan.floor": 1,
             "floorplan.image": self._get_simpleuploadedfile(),
         }
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -867,7 +867,7 @@ class TestGeoApi(
             "floorplan.image": self._get_simpleuploadedfile(),
             "indoor": ["12.342,23.541"],
         }
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(25):
             response = self.client.put(
                 url, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -890,7 +890,7 @@ class TestGeoApi(
         }
         self.assertEqual(device_location.location.type, "outdoor")
         self.assertEqual(device_location.floorplan, None)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(22):
             response = self.client.put(
                 path, encode_multipart(BOUNDARY, data), content_type=MULTIPART_CONTENT
             )
@@ -909,7 +909,7 @@ class TestGeoApi(
             "indoor": "0,0",
         }
         self.assertEqual(device_location.indoor, "-140.38620,40.369227")
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()
@@ -926,7 +926,7 @@ class TestGeoApi(
         data = {
             "floorplan": str(floor2.id),
         }
-        with self.assertNumQueries(14):
+        with self.assertNumQueries(13):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()
@@ -940,7 +940,7 @@ class TestGeoApi(
         data = {
             "location": str(location2.id),
         }
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             response = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(response.status_code, 200)
         device_location.refresh_from_db()

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -51,7 +51,7 @@ class TestPkiApi(
         self.assertEqual(Ca.objects.count(), 0)
         path = reverse("pki_api:ca_list")
         data = self._ca_data
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -61,7 +61,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_list")
         data = self._ca_data
         data["extensions"] = []
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(r.data["extensions"], [])
@@ -77,7 +77,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            7 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 6
+            6 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 5
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -97,7 +97,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -105,7 +105,7 @@ class TestPkiApi(
     def test_ca_list_api(self):
         self._create_ca()
         path = reverse("pki_api:ca_list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertNotIn("passphrase", r.content.decode("utf8"))
@@ -113,7 +113,7 @@ class TestPkiApi(
     def test_ca_detail_api(self):
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["id"], ca1.pk)
@@ -124,7 +124,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
         org2 = self._create_org()
         data = {"name": "change-ca1", "organization": org2.pk, "notes": "change-notes"}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -137,7 +137,7 @@ class TestPkiApi(
         data = {
             "name": "change-ca1",
         }
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -145,14 +145,14 @@ class TestPkiApi(
     def test_crl_download_api(self):
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         path = reverse("pki_api:crl_download", args=[ca1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
 
     def test_ca_delete_api(self):
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             r = self.client.delete(path)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Ca.objects.count(), 0)
@@ -161,7 +161,7 @@ class TestPkiApi(
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         old_serial_num = ca1.serial_number
         path = reverse("pki_api:ca_renew", args=[ca1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.post(path)
         ca1.refresh_from_db()
         self.assertEqual(r.status_code, 200)
@@ -172,7 +172,7 @@ class TestPkiApi(
         path = reverse("pki_api:cert_list")
         data = self._cert_data
         data["ca"] = self._create_ca().pk
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -189,7 +189,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            11 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 10
+            10 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -205,7 +205,7 @@ class TestPkiApi(
         data = self._cert_data
         data["ca"] = self._create_ca().pk
         data["extensions"] = []
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -221,7 +221,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -229,7 +229,7 @@ class TestPkiApi(
     def test_cert_list_api(self):
         self._create_cert(name="cert1")
         path = reverse("pki_api:cert_list")
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(Cert.objects.count(), 1)
@@ -238,7 +238,7 @@ class TestPkiApi(
     def test_cert_detail_api(self):
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["id"], cert1.pk)
@@ -253,7 +253,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -264,7 +264,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -272,7 +272,7 @@ class TestPkiApi(
     def test_cert_delete_api(self):
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.delete(path)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Cert.objects.count(), 0)
@@ -280,7 +280,7 @@ class TestPkiApi(
     def test_ca_in_cert_detail_fields(self):
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["ca"], cert1.ca.id)
@@ -289,7 +289,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -300,7 +300,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -149,16 +149,15 @@ OPENWISP_CONTROLLER_GROUP_PIE_CHART = True
 # during development only
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-if not TESTING:
-    CACHES = {
-        "default": {
-            "BACKEND": "django_redis.cache.RedisCache",
-            "LOCATION": f"{REDIS_URL}/6",
-            "OPTIONS": {
-                "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            },
-        }
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"{REDIS_URL}/6",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
     }
+}
 
 if not TESTING:
     CELERY_BROKER_URL = f"{REDIS_URL}/1"
@@ -166,6 +165,9 @@ else:
     CELERY_TASK_ALWAYS_EAGER = True
     CELERY_TASK_EAGER_PROPAGATES = True
     CELERY_BROKER_URL = "memory://"
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Set:
```
SESSION_ENGINE = "django.contrib.sessions.backends.cache"
SESSION_CACHE_ALIAS = "default"
```
to align with the test setup of other openwisp packages.

