### PR TITLE
[fix] Fixed visibility of "Recent Commands" tab on device page

### DIFF
--- a/openwisp_controller/connection/static/connection/css/command-inline.css
+++ b/openwisp_controller/connection/static/connection/css/command-inline.css
@@ -14,7 +14,7 @@ button[disabled] {
 #command_set-group .add-row,
 #command_set-group .advanced_editor,
 #command_set-group .form-row.field-type,
-li.commands {
+li.commands:not(.recent) {
   display: none !important;
 }
 

--- a/openwisp_controller/connection/tests/test_selenium.py
+++ b/openwisp_controller/connection/tests/test_selenium.py
@@ -55,3 +55,15 @@ class TestDeviceAdmin(
         self.find_element(by=By.CSS_SELECTOR, value="#ow-command-confirm-yes").click()
 
         self.assertEqual(Command.objects.count(), 1)
+        # TODO: Selenium tests does not support websocket connections.
+        # Thus, we need to refresh the page. Remove this when support for
+        # websockets is added.
+        self.open(path)
+        self.wait_for_visibility(
+            By.CSS_SELECTOR,
+            (  # selector for Django 5.2
+                "#tabs-container li.recent.commands,"
+                # selector for Django 4.2
+                " #tabs-container li.recent-commands"
+            ),
+        )


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


