### PR TITLE
[fix] Fixed DeviceConnection and Command API endpoints for non-superuser

### DIFF
--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -43,6 +43,8 @@ class BaseCommandView(
     BaseProtectedAPIMixin,
     FilterByParentManaged,
 ):
+    organization_field = "device__organization"
+    organization_lookup = "organization__in"
     model = Command
     queryset = Command.objects.prefetch_related("device")
     serializer_class = CommandSerializer

--- a/openwisp_controller/connection/api/views.py
+++ b/openwisp_controller/connection/api/views.py
@@ -1,20 +1,14 @@
-from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import pagination
-from rest_framework.exceptions import NotFound
 from rest_framework.generics import (
-    GenericAPIView,
     ListCreateAPIView,
     RetrieveAPIView,
     RetrieveUpdateDestroyAPIView,
     get_object_or_404,
 )
 from swapper import load_model
-
-from openwisp_users.api.mixins import FilterByParentManaged
-from openwisp_users.api.mixins import ProtectedAPIMixin as BaseProtectedAPIMixin
 
 from ...mixins import (
     ProtectedAPIMixin,

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -583,7 +583,7 @@ class TestConnectionApi(
             the update strategy manually.
         """
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
+        self.assertTrue(
             " ".join(error_msg.split()), response.data["update_strategy"][0].title()
         )
 
@@ -760,32 +760,32 @@ class TestConnectionApi(
 
             self.assertEqual(response.status_code, expected_status["create"])
 
-        # with self.subTest("Retrieve operation"):
-        #     response = self.client.get(detail_path)
-        #     self.assertEqual(response.status_code, expected_status["retrieve"])
+        with self.subTest("Retrieve operation"):
+            response = self.client.get(detail_path)
+            self.assertEqual(response.status_code, expected_status["retrieve"])
 
-        # with self.subTest("Update operation"):
-        #     response = self.client.put(
-        #         detail_path,
-        #         {
-        #             "credentials": self._get_credentials().pk,
-        #             "update_strategy": app_settings.UPDATE_STRATEGIES[1][0],
-        #             "enabled": False,
-        #             "failure_reason": "",
-        #         },
-        #         content_type="application/json",
-        #     )
-        #     self.assertEqual(response.status_code, expected_status["update"])
+        with self.subTest("Update operation"):
+            response = self.client.put(
+                detail_path,
+                {
+                    "credentials": self._get_credentials().pk,
+                    "update_strategy": app_settings.UPDATE_STRATEGIES[1][0],
+                    "enabled": False,
+                    "failure_reason": "",
+                },
+                content_type="application/json",
+            )
+            self.assertEqual(response.status_code, expected_status["update"])
 
-        # with self.subTest("Partial update operation"):
-        #     response = self.client.patch(
-        #         detail_path, {"enabled": False}, content_type="application/json"
-        #     )
-        #     self.assertEqual(response.status_code, expected_status["patch"])
+        with self.subTest("Partial update operation"):
+            response = self.client.patch(
+                detail_path, {"enabled": False}, content_type="application/json"
+            )
+            self.assertEqual(response.status_code, expected_status["patch"])
 
-        # with self.subTest("Delete operation"):
-        #     response = self.client.delete(detail_path)
-        #     self.assertEqual(response.status_code, expected_status["delete"])
+        with self.subTest("Delete operation"):
+            response = self.client.delete(detail_path)
+            self.assertEqual(response.status_code, expected_status["delete"])
 
     def test_deviceconnection_endpoints_for_org_operators_own_org(self):
         self.client.logout()

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -574,7 +574,7 @@ class TestConnectionApi(
             "enabled": True,
             "failure_reason": "",
         }
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(12):
             response = self.client.post(path, data, content_type="application/json")
         error_msg = """
             the update strategy can be determined automatically only if

--- a/openwisp_controller/mixins.py
+++ b/openwisp_controller/mixins.py
@@ -1,4 +1,4 @@
-from openwisp_users.api.mixins import FilterByOrganizationManaged
+from openwisp_users.api.mixins import FilterByOrganizationManaged, FilterByParentManaged
 from openwisp_users.api.mixins import ProtectedAPIMixin as BaseProtectedAPIMixin
 from openwisp_users.api.permissions import DjangoModelPermissions, IsOrganizationManager
 
@@ -24,9 +24,7 @@ class RelatedDeviceModelPermission(DjangoModelPermissions):
         return self._has_permissions(request, view, perm, obj)
 
 
-class RelatedDeviceProtectedAPIMixin(
-    BaseProtectedAPIMixin, FilterByOrganizationManaged
-):
+class RelatedDeviceProtectedAPIMixin(FilterByParentManaged, BaseProtectedAPIMixin):
     permission_classes = [
         IsOrganizationManager,
         RelatedDeviceModelPermission,


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Added a test to reveal a problem noticed during openwisp 1.1.1 usage.
When a user, who is not a superuser (but with correct permissions), tried to access the details of a device command, an error is triggered:
```
AttributeError: Organization not found, `organization_field` not implemented correctly.
```
This scenario currently seems to be a blind spot in unit tests

Let me know what you think about this...