### PR TITLE
[fix] Don't delete VpnClients when enforcing required templates

### DIFF
--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2077,16 +2077,22 @@ class TestAdmin(
 
         # Remove first VPN template via admin
         _update_template(templates=[required_template, vpn2_template])
-
         self.assertEqual(config.templates.count(), 2)
         self.assertEqual(config.vpnclient_set.count(), 1)
         # Verify only vpn2 client remains
-        self.assertFalse(config.vpnclient_set.filter(vpn=vpn1).exists())
-        self.assertTrue(config.vpnclient_set.filter(vpn=vpn2).exists())
+        self.assertEqual(config.vpnclient_set.filter(vpn=vpn1).exists(), False)
+        self.assertEqual(config.vpnclient_set.filter(vpn=vpn2).exists(), True)
         # Verify that the vpn2 client is the same as before (same PK)
         self.assertEqual(
             vpn2_client.pk, config.vpnclient_set.filter(vpn=vpn2).first().pk
         )
+
+        # Remove the second VPN template and ensure the required template remains.
+        # This verifies that VpnClient object should get deleted it there's only
+        # one required template applied.
+        _update_template(templates=[required_template])
+        self.assertEqual(config.templates.count(), 1)
+        self.assertEqual(config.vpnclient_set.count(), 0)
 
     def test_vpn_template_switch(self):
         """


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


Bug: 
The SortedManyToManyField clears all templates before adding new ones.
This operation emits an `m2m_changed` signal with the `post_clear` action,
which triggers the `Config.enforce_required_templates` receiver to add
required templates back.

Adding required templates emits another `m2m_changed` signal with the
`post_add` action, which executes `Config.manage_vpn_clients` receiver. 
At this point, only required templates exist in the DB, hence we cannot 
decide which VpnClient objects to delete.

Fix:
We don't delete any VpnClient objects when the `m2m_changed` signal 
is sent for the `post_add` action for adding required templates.
The receiver will be called again with the `post_add` action when 
all the templates are added back, including the required ones. 
And then, it will delete any VpnClient objects that are not 
associated with the current templates.
