### PR TITLE
[fix] Use uuid path converter in geo API URLs

### DIFF
--- a/openwisp_controller/geo/tests/test_api.py
+++ b/openwisp_controller/geo/tests/test_api.py
@@ -7,6 +7,7 @@ from django.contrib.gis.geos import Point
 from django.test import TestCase
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 from PIL import Image
 from rest_framework.authtoken.models import Token
 from swapper import load_model
@@ -499,18 +500,20 @@ class TestGeoApi(
         self.assertEqual(response.status_code, 201)
 
     def test_get_location_detail(self):
-        with self.subTest("Test with invalid pk"):
-            path = reverse("geo_api:detail_location", args=["wrong-pk"])
-            with self.assertNumQueries(1):
-                response = self.client.get(path)
-            self.assertEqual(response.status_code, 404)
-
-        with self.subTest("Test with correct pk"):
+        with self.subTest("Test standard behavior"):
             location = self._create_location()
             path = reverse("geo_api:detail_location", args=[location.pk])
             with self.assertNumQueries(3):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
+
+        with self.subTest("Test with invalid pk"):
+            try:
+                reverse("geo_api:detail_location", args=["wrong-pk"])
+            except NoReverseMatch as e:
+                self.assertIn("wrong-pk", str(e))
+            else:
+                self.fail("NoReverseMatch not raised as expected")
 
     def test_put_location_detail(self):
         l1 = self._create_location()

--- a/openwisp_controller/geo/utils.py
+++ b/openwisp_controller/geo/utils.py
@@ -4,12 +4,12 @@ from django.urls import path
 def get_geo_urls(geo_views):
     return [
         path(
-            "api/v1/controller/device/<str:pk>/coordinates/",
+            "api/v1/controller/device/<uuid:pk>/coordinates/",
             geo_views.device_coordinates,
             name="device_coordinates",
         ),
         path(
-            "api/v1/controller/device/<str:pk>/location/",
+            "api/v1/controller/device/<uuid:pk>/location/",
             geo_views.device_location,
             name="device_location",
         ),
@@ -19,7 +19,7 @@ def get_geo_urls(geo_views):
             name="location_geojson",
         ),
         path(
-            "api/v1/controller/location/<str:pk>/device/",
+            "api/v1/controller/location/<uuid:pk>/device/",
             geo_views.location_device_list,
             name="location_device_list",
         ),
@@ -29,7 +29,7 @@ def get_geo_urls(geo_views):
             name="list_floorplan",
         ),
         path(
-            "api/v1/controller/floorplan/<str:pk>/",
+            "api/v1/controller/floorplan/<uuid:pk>/",
             geo_views.detail_floorplan,
             name="detail_floorplan",
         ),
@@ -37,7 +37,7 @@ def get_geo_urls(geo_views):
             "api/v1/controller/location/", geo_views.list_location, name="list_location"
         ),
         path(
-            "api/v1/controller/location/<str:pk>/",
+            "api/v1/controller/location/<uuid:pk>/",
             geo_views.detail_location,
             name="detail_location",
         ),


### PR DESCRIPTION
The path converter used for the geo API URLs was not precise, it allowed any string, even bogus UUIDs, which is wrong.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.