### PR TITLE
[enhancement] Estimated Location: Admin and API filters

### DIFF
--- a/docs/user/estimated-location.rst
+++ b/docs/user/estimated-location.rst
@@ -74,5 +74,7 @@ will set the ``is_estimated`` field to ``False`` and remove the
 In REST API, the field will be visible in the :ref:`Device Location
 <device_location_estimated>`, :ref:`Location list
 <location_list_estimated>`, :ref:`Location Detail
-<location_detail_estimated>` and :ref:`Location Detail (GeoJson)
-<location_geojson_estimated>` if the feature is **enabled**.
+<location_detail_estimated>` and :ref:`Location list (GeoJson)
+<location_geojson_estimated>` if the feature is **enabled**. The field can
+also be used for filtering in the location list (including geojson)
+endpoints and in the :ref:`Device List <device_list_estimated_filters>`.

--- a/docs/user/estimated-location.rst
+++ b/docs/user/estimated-location.rst
@@ -70,3 +70,9 @@ includes indicators for the estimated status.
 Changes to the ``coordinates`` and ``geometry`` of the estimated location
 will set the ``is_estimated`` field to ``False`` and remove the
 "(Estimated Location)" suffix with IP from the location name.
+
+In REST API, the field will be visible in the :ref:`Device Location
+<device_location_estimated>`, :ref:`Location list
+<location_list_estimated>`, :ref:`Location Detail
+<location_detail_estimated>` and :ref:`Location Detail (GeoJson)
+<location_geojson_estimated>` if the feature is **enabled**.

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -544,6 +544,13 @@ of certificate's organization as show in the example below:
 
     GET /api/v1/controller/cert/{common_name}/group/?org={org1_slug},{org2_slug}
 
+.. |est_loc| replace:: Estimated Location feature
+
+.. _est_loc: estimated-location.html
+
+.. |estimated_details| replace:: If |est_loc|_ is enabled, the location
+    response will also include ``is_estimated`` status field.
+
 Get Device Location
 ~~~~~~~~~~~~~~~~~~~
 
@@ -555,9 +562,7 @@ Get Device Location
 
 **Estimated Status**
 
-If :doc:`Estimate Location feature <estimated-location>` is enabled, the
-location response will also include a ``is_estimated`` field in the
-``properties`` object.
+|estimated_details|
 
 .. _create_device_location:
 
@@ -799,8 +804,7 @@ List Locations
 
 **Estimated Status**
 
-If :doc:`Estimate Location feature <estimated-location>` is enabled, each
-location in the response will also include a ``is_estimated`` field.
+|estimated_details|
 
 **Available filters**
 
@@ -887,8 +891,7 @@ Get Location Details
 
 **Estimated Status**
 
-If :doc:`Estimate Location feature <estimated-location>` is enabled, the
-location response will also include a ``is_estimated`` field.
+|estimated_details|
 
 Change Location Details
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -936,9 +939,7 @@ List Locations with Devices Deployed (in GeoJSON Format)
 
 **Estimated Status**
 
-If :doc:`Estimate Location feature <estimated-location>` is enabled, each
-location in the response will also include a ``is_estimated`` field in the
-``properties`` object.
+|estimated_details|
 
 **Available filters**
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -551,6 +551,14 @@ Get Device Location
 
     GET /api/v1/controller/device/{id}/location/
 
+.. _device_location_estimated:
+
+**Estimated Status**
+
+If :doc:`Estimate Location feature <estimated-location>` is enabled, the
+location response will also include a ``is_estimated`` field in the
+``properties`` object.
+
 .. _create_device_location:
 
 Create Device Location
@@ -787,6 +795,13 @@ List Locations
 
     GET /api/v1/controller/location/
 
+.. _location_list_estimated:
+
+**Estimated Status**
+
+If :doc:`Estimate Location feature <estimated-location>` is enabled, each
+location in the response will also include a ``is_estimated`` field.
+
 **Available filters**
 
 You can filter using ``organization_id`` or ``organization_slug`` to get
@@ -868,6 +883,13 @@ Get Location Details
 
     GET /api/v1/controller/location/{pk}/
 
+.. _location_detail_estimated:
+
+**Estimated Status**
+
+If :doc:`Estimate Location feature <estimated-location>` is enabled, the
+location response will also include a ``is_estimated`` field.
+
 Change Location Details
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -909,6 +931,14 @@ List Locations with Devices Deployed (in GeoJSON Format)
 .. code-block:: text
 
     GET /api/v1/controller/location/geojson/
+
+.. _location_geojson_estimated:
+
+**Estimated Status**
+
+If :doc:`Estimate Location feature <estimated-location>` is enabled, each
+location in the response will also include a ``is_estimated`` field in the
+``properties`` object.
 
 **Available filters**
 

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -76,6 +76,14 @@ If :doc:`WHOIS Lookup feature <whois>` is enabled, each device in the list
 response will also include a ``whois_info`` field with related brief WHOIS
 information.
 
+.. _device_list_estimated_filters:
+
+**Estimated Location Filters**
+
+if :doc:`Estimated Location feature <estimated-location>` is enabled,
+devices can be filtered based on the estimated nature of their location
+using the ``geo_is_estimated``.
+
 **Available filters**
 
 You can filter a list of devices based on their configuration status using
@@ -806,6 +814,8 @@ List Locations
 
 |estimated_details|
 
+Locations can also be filtered using the ``is_estimated``.
+
 **Available filters**
 
 You can filter using ``organization_id`` or ``organization_slug`` to get
@@ -940,6 +950,8 @@ List Locations with Devices Deployed (in GeoJSON Format)
 **Estimated Status**
 
 |estimated_details|
+
+Locations can also be filtered using the ``is_estimated``.
 
 **Available filters**
 

--- a/docs/user/whois.rst
+++ b/docs/user/whois.rst
@@ -28,6 +28,7 @@ associated with the device's public IP address and includes:
 - CIDR block assigned to the ASN
 - Physical address registered to the ASN
 - Timezone of the ASN's registered location
+- Coordinates (Latitude and Longitude)
 
 Trigger Conditions
 ------------------

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -25,31 +25,6 @@ class WHOISService:
         return f"organization_config_{org_id}"
 
     @staticmethod
-    def get_config_settings(org_id):
-        """
-        Caches the organization settings for WHOIS.
-        """
-        OrganizationConfigSettings = load_model("config", "OrganizationConfigSettings")
-        Config = load_model("config", "Config")
-
-        cache_key = WHOISService.get_cache_key(org_id=org_id)
-        org_settings = cache.get(cache_key)
-        if org_settings is None:
-            try:
-                org_settings = OrganizationConfigSettings.objects.get(
-                    organization=org_id
-                )
-            except OrganizationConfigSettings.DoesNotExist:
-                # If organization settings do not exist, fall back to global setting
-                return None
-            cache.set(
-                cache_key,
-                org_settings,
-                timeout=Config._CHECKSUM_CACHE_TIMEOUT,
-            )
-        return org_settings
-
-    @staticmethod
     def is_valid_public_ip_address(ip):
         """
         Check if given IP address is a valid public IP address.

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -78,6 +78,8 @@ class WHOISService:
         if not app_settings.WHOIS_CONFIGURED:
             return False
         org_settings = WHOISService.get_org_config_settings(org_id=org_id)
+        # there can be case of organization having no config settings, in that case
+        # we want to fallback to global setting
         return getattr(
             org_settings,
             "estimated_location_enabled",
@@ -90,6 +92,8 @@ class WHOISService:
         Check if the WHOIS lookup feature is enabled.
         """
         org_settings = self.get_org_config_settings(org_id=self.device.organization.pk)
+        # there can be case of organization having no config settings, in that case
+        # we want to fallback to global setting
         return getattr(org_settings, "whois_enabled", app_settings.WHOIS_ENABLED)
 
     @property
@@ -98,6 +102,8 @@ class WHOISService:
         Check if the Estimated location feature is enabled.
         """
         org_settings = self.get_org_config_settings(org_id=self.device.organization.pk)
+        # there can be case of organization having no config settings, in that case
+        # we want to fallback to global setting
         return getattr(
             org_settings,
             "estimated_location_enabled",

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -78,7 +78,11 @@ class WHOISService:
         if not app_settings.WHOIS_CONFIGURED:
             return False
         org_settings = WHOISService.get_org_config_settings(org_id=org_id)
-        return getattr(org_settings, "estimated_location_enabled")
+        return getattr(
+            org_settings,
+            "estimated_location_enabled",
+            app_settings.ESTIMATED_LOCATION_ENABLED,
+        )
 
     @property
     def is_whois_enabled(self):
@@ -94,7 +98,11 @@ class WHOISService:
         Check if the Estimated location feature is enabled.
         """
         org_settings = self.get_org_config_settings(org_id=self.device.organization.pk)
-        return getattr(org_settings, "estimated_location_enabled")
+        return getattr(
+            org_settings,
+            "estimated_location_enabled",
+            app_settings.ESTIMATED_LOCATION_ENABLED,
+        )
 
     def _need_whois_lookup(self, new_ip):
         """

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -25,6 +25,31 @@ class WHOISService:
         return f"organization_config_{org_id}"
 
     @staticmethod
+    def get_config_settings(org_id):
+        """
+        Caches the organization settings for WHOIS.
+        """
+        OrganizationConfigSettings = load_model("config", "OrganizationConfigSettings")
+        Config = load_model("config", "Config")
+
+        cache_key = WHOISService.get_cache_key(org_id=org_id)
+        org_settings = cache.get(cache_key)
+        if org_settings is None:
+            try:
+                org_settings = OrganizationConfigSettings.objects.get(
+                    organization=org_id
+                )
+            except OrganizationConfigSettings.DoesNotExist:
+                # If organization settings do not exist, fall back to global setting
+                return None
+            cache.set(
+                cache_key,
+                org_settings,
+                timeout=Config._CHECKSUM_CACHE_TIMEOUT,
+            )
+        return org_settings
+
+    @staticmethod
     def is_valid_public_ip_address(ip):
         """
         Check if given IP address is a valid public IP address.

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -46,10 +46,15 @@ class WHOISService:
     @staticmethod
     def get_org_config_settings(org_id):
         """
-        Caches the OrganizationConfigSettings as these settings
-        are not expected to change frequently. The timeout for the cache
-        is set to the same as the checksum cache timeout for consistency
-        with DeviceChecksumView.
+        Retrieve and cache organization-specific configuration settings.
+
+        Returns a "read-only" OrganizationConfigSettings instance for the
+        given organization.
+        If no settings exist for the organization, returns an empty instance to allow
+        fallback to global defaults.
+
+        OrganizationConfigSettings are cached for performance, using the same timeout
+        as DeviceChecksumView for consistency.
         """
         OrganizationConfigSettings = load_model("config", "OrganizationConfigSettings")
         Config = load_model("config", "Config")
@@ -63,7 +68,7 @@ class WHOISService:
                 )
             except OrganizationConfigSettings.DoesNotExist:
                 # If organization settings do not exist, fall back to global setting
-                return None
+                org_settings = OrganizationConfigSettings()
             cache.set(
                 cache_key,
                 org_settings,
@@ -78,13 +83,7 @@ class WHOISService:
         if not app_settings.WHOIS_CONFIGURED:
             return False
         org_settings = WHOISService.get_org_config_settings(org_id=org_id)
-        # there can be case of organization having no config settings, in that case
-        # we want to fallback to global setting
-        return getattr(
-            org_settings,
-            "estimated_location_enabled",
-            app_settings.ESTIMATED_LOCATION_ENABLED,
-        )
+        return org_settings.estimated_location_enabled
 
     @property
     def is_whois_enabled(self):
@@ -92,9 +91,7 @@ class WHOISService:
         Check if the WHOIS lookup feature is enabled.
         """
         org_settings = self.get_org_config_settings(org_id=self.device.organization.pk)
-        # there can be case of organization having no config settings, in that case
-        # we want to fallback to global setting
-        return getattr(org_settings, "whois_enabled", app_settings.WHOIS_ENABLED)
+        return org_settings.whois_enabled
 
     @property
     def is_estimated_location_enabled(self):
@@ -102,13 +99,7 @@ class WHOISService:
         Check if the Estimated location feature is enabled.
         """
         org_settings = self.get_org_config_settings(org_id=self.device.organization.pk)
-        # there can be case of organization having no config settings, in that case
-        # we want to fallback to global setting
-        return getattr(
-            org_settings,
-            "estimated_location_enabled",
-            app_settings.ESTIMATED_LOCATION_ENABLED,
-        )
+        return org_settings.estimated_location_enabled
 
     def _need_whois_lookup(self, new_ip):
         """

--- a/openwisp_controller/config/whois/test_whois.py
+++ b/openwisp_controller/config/whois/test_whois.py
@@ -636,14 +636,6 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             for log in self.get_browser_logs():
                 if self.browser == "chrome" and log["source"] != "console-api":
                     continue
-                # ignore errors coming from the library
-                # to reduce flakyness, if there's really
-                # a sever error the UI will not work as expected
-                elif (
-                    "/static/netjsongraph/js/src/netjsongraph.min.js" in log["message"]
-                ):
-                    print(f"ignoring library error: {log}")
-                    continue
                 elif log["message"] in ["wrong event specified: touchleave"]:
                     continue
                 browser_logs.append(log)

--- a/openwisp_controller/config/whois/test_whois.py
+++ b/openwisp_controller/config/whois/test_whois.py
@@ -631,12 +631,23 @@ class TestWHOISTransaction(
 class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTestCase):
     @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
     def test_whois_device_admin(self):
-        def no_console_warnings():
-            for error in self.get_browser_logs():
-                if error["level"] == "WARNING" and error["message"] not in [
-                    "wrong event specified: touchleave"
-                ]:
-                    self.fail(f'Browser console error: {error["message"]}')
+        def _assert_no_js_errors():
+            browser_logs = []
+            for log in self.get_browser_logs():
+                if self.browser == "chrome" and log["source"] != "console-api":
+                    continue
+                # ignore errors coming from the library
+                # to reduce flakyness, if there's really
+                # a sever error the UI will not work as expected
+                elif (
+                    "/static/netjsongraph/js/src/netjsongraph.min.js" in log["message"]
+                ):
+                    print(f"ignoring library error: {log}")
+                    continue
+                elif log["message"] in ["wrong event specified: touchleave"]:
+                    continue
+                browser_logs.append(log)
+            self.assertEqual(browser_logs, [])
 
         whois_obj = self._create_whois_info()
         device = self._create_device(last_ip=whois_obj.ip_address)
@@ -662,7 +673,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             self.assertIn(whois_obj.timezone, additional_text[1].text)
             self.assertIn(whois_obj.formatted_address, additional_text[2].text)
             self.assertIn(whois_obj.cidr, additional_text[3].text)
-            no_console_warnings()
+            _assert_no_js_errors()
 
         with mock.patch.object(app_settings, "WHOIS_CONFIGURED", False):
             with self.subTest(
@@ -672,7 +683,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
                 self.open(reverse("admin:config_device_change", args=[device.pk]))
                 self.wait_for_invisibility(By.CSS_SELECTOR, "table.whois-table")
                 self.wait_for_invisibility(By.CSS_SELECTOR, "details.whois")
-                no_console_warnings()
+                _assert_no_js_errors()
 
         with self.subTest(
             "WHOIS details not visible in device admin when WHOIS is disabled"
@@ -683,7 +694,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             self.open(reverse("admin:config_device_change", args=[device.pk]))
             self.wait_for_invisibility(By.CSS_SELECTOR, "table.whois-table")
             self.wait_for_invisibility(By.CSS_SELECTOR, "details.whois")
-            no_console_warnings()
+            _assert_no_js_errors()
 
         with self.subTest(
             "WHOIS details not visible in device admin when WHOIS Info does not exist"
@@ -695,4 +706,4 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             self.open(reverse("admin:config_device_change", args=[device.pk]))
             self.wait_for_invisibility(By.CSS_SELECTOR, "table.whois-table")
             self.wait_for_invisibility(By.CSS_SELECTOR, "details.whois")
-            no_console_warnings()
+            _assert_no_js_errors()

--- a/openwisp_controller/config/whois/test_whois.py
+++ b/openwisp_controller/config/whois/test_whois.py
@@ -631,6 +631,13 @@ class TestWHOISTransaction(
 class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTestCase):
     @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
     def test_whois_device_admin(self):
+        def no_console_warnings():
+            for error in self.get_browser_logs():
+                if error["level"] == "WARNING" and error["message"] not in [
+                    "wrong event specified: touchleave"
+                ]:
+                    self.fail(f'Browser console error: {error["message"]}')
+
         whois_obj = self._create_whois_info()
         device = self._create_device(last_ip=whois_obj.ip_address)
         self.login()
@@ -655,6 +662,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             self.assertIn(whois_obj.timezone, additional_text[1].text)
             self.assertIn(whois_obj.formatted_address, additional_text[2].text)
             self.assertIn(whois_obj.cidr, additional_text[3].text)
+            no_console_warnings()
 
         with mock.patch.object(app_settings, "WHOIS_CONFIGURED", False):
             with self.subTest(
@@ -664,6 +672,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
                 self.open(reverse("admin:config_device_change", args=[device.pk]))
                 self.wait_for_invisibility(By.CSS_SELECTOR, "table.whois-table")
                 self.wait_for_invisibility(By.CSS_SELECTOR, "details.whois")
+                no_console_warnings()
 
         with self.subTest(
             "WHOIS details not visible in device admin when WHOIS is disabled"
@@ -674,6 +683,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             self.open(reverse("admin:config_device_change", args=[device.pk]))
             self.wait_for_invisibility(By.CSS_SELECTOR, "table.whois-table")
             self.wait_for_invisibility(By.CSS_SELECTOR, "details.whois")
+            no_console_warnings()
 
         with self.subTest(
             "WHOIS details not visible in device admin when WHOIS Info does not exist"
@@ -685,3 +695,4 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
             self.open(reverse("admin:config_device_change", args=[device.pk]))
             self.wait_for_invisibility(By.CSS_SELECTOR, "table.whois-table")
             self.wait_for_invisibility(By.CSS_SELECTOR, "details.whois")
+            no_console_warnings()

--- a/openwisp_controller/geo/admin.py
+++ b/openwisp_controller/geo/admin.py
@@ -155,7 +155,7 @@ class DeviceLocationFilter(admin.SimpleListFilter):
     def lookups(self, request, model_admin):
         if config_app_settings.WHOIS_CONFIGURED:
             return (
-                ("outdoor", _("Outdoor (Not Estimated)")),
+                ("outdoor", _("Outdoor")),
                 ("indoor", _("Indoor")),
                 ("estimated", _("Estimated")),
                 ("false", _("No Location")),

--- a/openwisp_controller/geo/api/filters.py
+++ b/openwisp_controller/geo/api/filters.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 
+from openwisp_controller.config import settings as config_app_settings
 from openwisp_controller.config.api.filters import (
     DeviceListFilter as BaseDeviceListFilter,
 )
@@ -20,6 +21,20 @@ class DeviceListFilter(BaseDeviceListFilter):
     def filter_devicelocation(self, queryset, name, value):
         # Returns list of device that have devicelocation objects
         return queryset.exclude(devicelocation__isnull=value)
+
+    def filter_is_estimated(self, queryset, name, value):
+        return queryset.filter(devicelocation__location__is_estimated=value)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if config_app_settings.WHOIS_CONFIGURED:
+            self.filters["geo_is_estimated"] = filters.BooleanFilter(
+                field_name="devicelocation__location__is_estimated",
+                method=self.filter_is_estimated,
+            )
+            self.filters["geo_is_estimated"].label = _(
+                "Is geographic location estimated?"
+            )
 
     class Meta:
         model = BaseDeviceListFilter.Meta.model

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -232,7 +232,7 @@ class LocationSerializer(EstimatedLocationMixin, BaseSerializer):
 
 
 class NestedtLocationSerializer(
-    EstimatedLocationMixin, gis_serializers.GeoFeatureModelSerializer
+    EstimatedLocationGeoJsonSerializer, gis_serializers.GeoFeatureModelSerializer
 ):
     class Meta:
         model = Location

--- a/openwisp_controller/geo/api/serializers.py
+++ b/openwisp_controller/geo/api/serializers.py
@@ -11,6 +11,10 @@ from swapper import load_model
 from openwisp_utils.api.serializers import ValidatedModelSerializer
 
 from ...serializers import BaseSerializer
+from ..estimated_location.mixins import (
+    EstimatedLocationGeoJsonSerializer,
+    EstimatedLocationMixin,
+)
 
 Device = load_model("config", "Device")
 Location = load_model("geo", "Location")
@@ -31,7 +35,9 @@ class LocationDeviceSerializer(ValidatedModelSerializer):
         fields = "__all__"
 
 
-class GeoJsonLocationSerializer(gis_serializers.GeoFeatureModelSerializer):
+class GeoJsonLocationSerializer(
+    EstimatedLocationGeoJsonSerializer, gis_serializers.GeoFeatureModelSerializer
+):
     device_count = IntegerField()
 
     class Meta:
@@ -126,7 +132,7 @@ class DeviceCoordinatesSerializer(gis_serializers.GeoFeatureModelSerializer):
         read_only_fields = ("name",)
 
 
-class LocationSerializer(BaseSerializer):
+class LocationSerializer(EstimatedLocationMixin, BaseSerializer):
     floorplan = FloorPlanLocationSerializer(required=False, allow_null=True)
 
     class Meta:
@@ -225,7 +231,9 @@ class LocationSerializer(BaseSerializer):
         return super().update(instance, validated_data)
 
 
-class NestedtLocationSerializer(gis_serializers.GeoFeatureModelSerializer):
+class NestedtLocationSerializer(
+    EstimatedLocationMixin, gis_serializers.GeoFeatureModelSerializer
+):
     class Meta:
         model = Location
         geo_field = "geometry"

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework_gis.pagination import GeoJsonPagination
 from swapper import load_model
 
+from openwisp_controller.config import settings as config_app_settings
 from openwisp_controller.config.api.views import DeviceListCreateView
 from openwisp_users.api.filters import OrganizationManagedFilter
 from openwisp_users.api.mixins import FilterByOrganizationManaged, FilterByParentManaged
@@ -43,7 +44,12 @@ class DevicePermission(BasePermission):
 class LocationOrganizationFilter(OrganizationManagedFilter):
     class Meta(OrganizationManagedFilter.Meta):
         model = Location
-        fields = OrganizationManagedFilter.Meta.fields + ["is_mobile", "type"]
+        fields = OrganizationManagedFilter.Meta.fields + [
+            "is_mobile",
+            "type",
+            "is_estimated",
+        ]
+        exclude = None if config_app_settings.WHOIS_CONFIGURED else ["is_estimated"]
 
 
 class FloorPlanOrganizationFilter(OrganizationManagedFilter):

--- a/openwisp_controller/geo/api/views.py
+++ b/openwisp_controller/geo/api/views.py
@@ -44,12 +44,14 @@ class DevicePermission(BasePermission):
 class LocationOrganizationFilter(OrganizationManagedFilter):
     class Meta(OrganizationManagedFilter.Meta):
         model = Location
-        fields = OrganizationManagedFilter.Meta.fields + [
-            "is_mobile",
-            "type",
-            "is_estimated",
-        ]
-        exclude = None if config_app_settings.WHOIS_CONFIGURED else ["is_estimated"]
+        fields = OrganizationManagedFilter.Meta.fields + ["is_mobile", "type"]
+
+    def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
+        super().__init__(data, queryset, request=request, prefix=prefix)
+        if config_app_settings.WHOIS_CONFIGURED:
+            self.filters["is_estimated"] = filters.BooleanFilter(
+                field_name="is_estimated"
+            )
 
 
 class FloorPlanOrganizationFilter(OrganizationManagedFilter):

--- a/openwisp_controller/geo/estimated_location/mixins.py
+++ b/openwisp_controller/geo/estimated_location/mixins.py
@@ -9,7 +9,7 @@ class EstimatedLocationMixin:
 
     def to_representation(self, obj):
         data = super().to_representation(obj)
-        if check_estimate_location_configured(obj):
+        if check_estimate_location_configured(obj.organization_id):
             data["is_estimated"] = obj.is_estimated
         else:
             data.pop("is_estimated", None)
@@ -23,7 +23,7 @@ class EstimatedLocationGeoJsonSerializer(EstimatedLocationMixin):
 
     def to_representation(self, obj):
         data = super(EstimatedLocationMixin, self).to_representation(obj)
-        if check_estimate_location_configured(obj):
+        if check_estimate_location_configured(obj.organization_id):
             data["properties"]["is_estimated"] = obj.is_estimated
         else:
             data["properties"].pop("is_estimated", None)

--- a/openwisp_controller/geo/estimated_location/mixins.py
+++ b/openwisp_controller/geo/estimated_location/mixins.py
@@ -1,4 +1,4 @@
-from .utils import check_estimate_location_configured
+from openwisp_controller.config.whois.service import WHOISService
 
 
 class EstimatedLocationMixin:
@@ -9,7 +9,7 @@ class EstimatedLocationMixin:
 
     def to_representation(self, obj):
         data = super().to_representation(obj)
-        if check_estimate_location_configured(obj.organization_id):
+        if WHOISService.check_estimate_location_configured(obj.organization_id):
             data["is_estimated"] = obj.is_estimated
         else:
             data.pop("is_estimated", None)
@@ -23,7 +23,7 @@ class EstimatedLocationGeoJsonSerializer(EstimatedLocationMixin):
 
     def to_representation(self, obj):
         data = super(EstimatedLocationMixin, self).to_representation(obj)
-        if check_estimate_location_configured(obj.organization_id):
+        if WHOISService.check_estimate_location_configured(obj.organization_id):
             data["properties"]["is_estimated"] = obj.is_estimated
         else:
             data["properties"].pop("is_estimated", None)

--- a/openwisp_controller/geo/estimated_location/mixins.py
+++ b/openwisp_controller/geo/estimated_location/mixins.py
@@ -1,0 +1,30 @@
+from .utils import check_estimate_location_configured
+
+
+class EstimatedLocationMixin:
+    """
+    Serializer mixin to add estimated location field to the serialized data
+    if the estimated location feature is configured and enabled for the organization.
+    """
+
+    def to_representation(self, obj):
+        data = super().to_representation(obj)
+        if check_estimate_location_configured(obj):
+            data["is_estimated"] = obj.is_estimated
+        else:
+            data.pop("is_estimated", None)
+        return data
+
+
+class EstimatedLocationGeoJsonSerializer(EstimatedLocationMixin):
+    """
+    Extension of EstimatedLocationMixin for GeoJSON serialization.
+    """
+
+    def to_representation(self, obj):
+        data = super(EstimatedLocationMixin, self).to_representation(obj)
+        if check_estimate_location_configured(obj):
+            data["properties"]["is_estimated"] = obj.is_estimated
+        else:
+            data["properties"].pop("is_estimated", None)
+        return data

--- a/openwisp_controller/geo/estimated_location/test_estimated_location.py
+++ b/openwisp_controller/geo/estimated_location/test_estimated_location.py
@@ -536,6 +536,11 @@ class TestEstimatedLocationFieldFilters(
     def test_estimated_location_api_status_configured(self):
         org1 = self._get_org()
         org2 = self._create_org(name="org2")
+        OrganizationConfigSettings.objects.create(
+            organization=org2,
+            whois_enabled=False,
+            estimated_location_enabled=False,
+        )
         org1_location = self._create_location(
             name="org1-location", organization=org1, is_estimated=True
         )
@@ -547,7 +552,7 @@ class TestEstimatedLocationFieldFilters(
 
         with self.subTest("Test Estimated Location in Locations List"):
             path = reverse("geo_api:list_location")
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(5):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 2)
@@ -566,14 +571,14 @@ class TestEstimatedLocationFieldFilters(
             self.assertIn("is_estimated", response.data["location"]["properties"])
 
             path = reverse("geo_api:device_location", args=[org2_device.pk])
-            with self.assertNumQueries(5):
+            with self.assertNumQueries(4):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertNotIn("is_estimated", response.data["location"]["properties"])
 
         with self.subTest("Test Estimated Location in GeoJSON List"):
             path = reverse("geo_api:location_geojson")
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 response = self.client.get(path)
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.data["count"], 2)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1028 

## Description of Changes

Added filters for geographic location in admin via `DeviceLocationFilter` to filter for estimated locations. Since this is a type of location, added 'outdoor' (excluding estimated) and 'indoor' as well.
Added filters for filtering on estimated status via `LocationOrganizationFilter`
Added `is_estimated` field to location lists/objects only if the feature is configured and enabled

## Screenshot
<img width="1385" height="462" alt="Screenshot 2025-08-08 at 1 20 54 AM" src="https://github.com/user-attachments/assets/0dcb49fc-f4c6-45b8-9dbe-ac9d29275909" />
