### PR TITLE
[fix] Avoid re-populating peer cache in post_save to prevent slow requests

### DIFF
--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -904,7 +904,7 @@ class AbstractVpnClient(models.Model):
     @classmethod
     def post_save(cls, instance, **kwargs):
         def _post_save():
-            instance.vpn._invalidate_peer_cache(update=True)
+            instance.vpn._invalidate_peer_cache()
 
         transaction.on_commit(_post_save)
         # ZT network member should be authorized and assigned

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -97,7 +97,9 @@ def invalidate_devicegroup_cache_delete(instance_id, model_name, **kwargs):
         )
 
 
-@shared_task(base=OpenwispCeleryTask)
+# Generating large configurations can be time-consuming; hence,
+# a custom soft time limit is applied here.
+@shared_task(soft_time_limit=120)
 def trigger_vpn_server_endpoint(endpoint, auth_token, vpn_id):
     Vpn = load_model("config", "Vpn")
     try:

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -99,7 +99,7 @@ def invalidate_devicegroup_cache_delete(instance_id, model_name, **kwargs):
 
 # Generating large configurations can be time-consuming; hence,
 # a custom soft time limit is applied here.
-@shared_task(soft_time_limit=120)
+@shared_task(soft_time_limit=300)
 def trigger_vpn_server_endpoint(endpoint, auth_token, vpn_id):
     Vpn = load_model("config", "Vpn")
     try:

--- a/openwisp_controller/config/tests/utils.py
+++ b/openwisp_controller/config/tests/utils.py
@@ -164,8 +164,11 @@ class TestWireguardVpnMixin(CreateIpamModelsMixin):
         vpn.save()
         return vpn
 
-    def _create_wireguard_vpn_template(self, auto_cert=True, **kwargs):
-        vpn = self._create_wireguard_vpn()
+    def _create_wireguard_vpn_template(
+        self, auto_cert=True, vpn_options=None, **kwargs
+    ):
+        vpn_options = vpn_options or {}
+        vpn = self._create_wireguard_vpn(**vpn_options)
         org1 = kwargs.get("organization", vpn.organization)
         template = self._create_template(
             name="wireguard",
@@ -180,7 +183,7 @@ class TestWireguardVpnMixin(CreateIpamModelsMixin):
 
 
 class TestVxlanWireguardVpnMixin(CreateIpamModelsMixin):
-    def _create_vxlan_tunnel(self, config=None):
+    def _create_vxlan_tunnel(self, config=None, **kwargs):
         if config is None:
             config = {"wireguard": [{"name": "wg0", "port": 51820}]}
         org = self._get_org()
@@ -193,11 +196,13 @@ class TestVxlanWireguardVpnMixin(CreateIpamModelsMixin):
             config=config,
             subnet=subnet,
             ca=None,
+            **kwargs,
         )
         return tunnel, subnet
 
-    def _create_vxlan_vpn_template(self):
-        vpn, subnet = self._create_vxlan_tunnel()
+    def _create_vxlan_vpn_template(self, vpn_options=None):
+        vpn_options = vpn_options or {}
+        vpn, subnet = self._create_vxlan_tunnel(**vpn_options)
         org1 = vpn.organization
         template = self._create_template(
             name="vxlan-wireguard",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Description of Changes

Previously, `VpnClient.post_save` re-populated the peer cache immediately. With a large number of peers, this could make uWSGI requests slow or even timeout.

Now, the method only invalidates the peer cache. The cache will be re-populated later by the `trigger_vpn_server_endpoint` task.

Additionally, the `trigger_vpn_server_endpoint` task now has a higher soft time limit (120s) to accommodate generating large configurations for many peers, which could exceed the default
`OpenwispCeleryTask.soft_time_limit`.





Please include any relevant screenshots.
