### PR TITLE
[fix] Added "default" kwarg for unique nullable fields

### DIFF
--- a/openwisp_controller/pki/api/serializers.py
+++ b/openwisp_controller/pki/api/serializers.py
@@ -73,7 +73,12 @@ class CaListSerializer(BaseListSerializer):
         ]
         read_only_fields = ["created", "modified"]
         extra_kwargs = {
-            "organization": {"required": True},
+            # In DRF 3.16+, nullable fields that are part of a unique constraint
+            # automatically get `default: None`, which can cause validation issues.
+            # Setting the default to `serializers.empty` ensures DRF does not treat
+            # these fields as both required and having a default value, avoiding
+            # conflicts.
+            "organization": {"required": True, "default": serializers.empty},
             "common_name": {"default": "", "required": False},
             "key_length": {"initial": "2048"},
             "digest": {"initial": "sha256"},


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.

## Reference to Existing Issue

## Description of Changes

CI builds were failing as in DRF 3.16+, nullable fields part of unique constraint were getting `default: None` causing Validation errors. Added `default: serializers.empty` to bypass it.

## Screenshot

