### PR TITLE
[tests] Disable ACCOUNT_RATE_LIMITS during automated testing

### DIFF
--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -14,6 +14,7 @@ DATABASES = {
     "default": {
         "ENGINE": "openwisp_utils.db.backends.spatialite",
         "NAME": os.path.join(BASE_DIR, "openwisp-controller.db"),
+        "OPTIONS": {"timeout": 10},
     }
 }
 if TESTING and "--exclude-tag=selenium_tests" not in sys.argv:


### PR DESCRIPTION
Related to https://github.com/openwisp/openwisp-users/pull/459. Recent versions of allauth have a default rate limiting which breaks our automated tests.