### PR TITLE
[feature] Added location and floorplan filters to device list API

### DIFF
--- a/openwisp_controller/config/api/filters.py
+++ b/openwisp_controller/config/api/filters.py
@@ -100,12 +100,6 @@ class DeviceListFilter(BaseConfigAPIFilter):
         field_name="created",
         lookup_expr="lt",
     )
-    location = filters.UUIDFilter(
-        field_name="devicelocation__location", label=_("Location UUID")
-    )
-    floorplan = filters.UUIDFilter(
-        field_name="devicelocation__floorplan", label=_("Floor plan UUID")
-    )
 
     def _set_valid_filterform_lables(self):
         self.filters["group"].label = _("Device group")
@@ -125,8 +119,6 @@ class DeviceListFilter(BaseConfigAPIFilter):
             "config__status",
             "config__backend",
             "config__templates",
-            "location",
-            "floorplan",
             "group",
             "created",
         ]

--- a/openwisp_controller/geo/api/filters.py
+++ b/openwisp_controller/geo/api/filters.py
@@ -10,12 +10,21 @@ class DeviceListFilter(BaseDeviceListFilter):
     # Using filter query param name `with_geo`
     # which is similar to admin filter
     with_geo = filters.BooleanFilter(
-        field_name="devicelocation", method="filter_devicelocation"
+        field_name="devicelocation",
+        method="filter_devicelocation",
+        label=_("Has geographic location set?"),
     )
-
-    def _set_valid_filterform_lables(self):
-        super()._set_valid_filterform_lables()
-        self.filters["with_geo"].label = _("Has geographic location set?")
+    location__name = filters.CharFilter(
+        field_name="devicelocation__location__name",
+        lookup_expr="icontains",
+        label=_("Location name"),
+    )
+    location = filters.UUIDFilter(
+        field_name="devicelocation__location", label=_("Location UUID")
+    )
+    floorplan = filters.UUIDFilter(
+        field_name="devicelocation__floorplan", label=_("Floor plan UUID")
+    )
 
     def filter_devicelocation(self, queryset, name, value):
         # Returns list of device that have devicelocation objects
@@ -23,5 +32,12 @@ class DeviceListFilter(BaseDeviceListFilter):
 
     class Meta:
         model = BaseDeviceListFilter.Meta.model
-        fields = BaseDeviceListFilter.Meta.fields[:]
-        fields.insert(fields.index("created"), "with_geo")
+        geo_fields = [
+            "with_geo",
+            "location__name",
+            "location",
+            "floorplan",
+        ]
+        fields = BaseDeviceListFilter.Meta.fields
+        index_created = fields.index("created")
+        fields[index_created:index_created] = geo_fields


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #1158.

Description of Changes
Added two new query parameters to the Device list API endpoint:

?location=<uuid> - filters devices by their associated location
?floorplan=<uuid> - filters devices by their associated floorplan
The filters work through the DeviceLocation relationship. Added test cases for both filters.

## Screenshot

<img width="1512" height="925" alt="Screenshot 2025-12-02 at 12 32 31 PM" src="https://github.com/user-attachments/assets/8a759bf4-0487-47ae-96ec-c72da38531d4" />
<img width="1512" height="963" alt="Screenshot 2025-12-02 at 12 36 53 PM" src="https://github.com/user-attachments/assets/fef9f77e-ad32-4bed-bdb5-e9669a8ce1a6" />
<img width="1512" height="982" alt="Screenshot 2025-12-02 at 1 46 01 PM" src="https://github.com/user-attachments/assets/504dca2e-3630-4ae3-b48c-806ffaf27cde" />
<img width="1512" height="982" alt="Screenshot 2025-12-02 at 1 46 21 PM" src="https://github.com/user-attachments/assets/4b65d3d3-e671-4de3-9cfd-c4d4c590db93" />
