### PR TITLE
[connection] Support list/tuple arguments in custom commands #809

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -639,7 +639,13 @@ class AbstractCommand(TimeStampedEditableModel):
         if self.is_custom:
             return self.custom_command
         else:
-            return ", ".join(self.arguments)
+            processed = []
+            for arg in self.arguments:
+                if isinstance(arg, (list, tuple)):
+                    processed.append(",".join(str(item) for item in arg))
+                else:
+                    processed.append(str(arg))
+            return ", ".join(processed)
 
     @property
     def _schema(self):


### PR DESCRIPTION
The current implementation of the input_data property in the Command model
uses ', '.join(self.arguments) directly, which raises TypeError when an
argument is a list (e.g., from array schema properties like checkboxes).

This change adds safe handling by checking if each argument is a list or tuple,
flattening it to a comma-separated string, and converting all items to str.

This prevents the TypeError while maintaining backward compatibility for
string arguments and enables proper use of array types in user-registered
custom command schemas.

Fixes #809

## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #<issue-number>.

Please [open a new issue](https://github.com/openwisp/openwisp-controller/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Please describe these changes.

## Screenshot

Please include any relevant screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection input data processing to correctly handle and flatten nested sequences, ensuring consistent formatting of comma-separated values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->