### PR TITLE
[admin] Avoid loading advanced editor for commands #525

### DIFF
--- a/openwisp_controller/config/widgets.py
+++ b/openwisp_controller/config/widgets.py
@@ -25,9 +25,7 @@ class JsonSchemaWidget(AdminTextareaWidget):
             "config/js/widget.js",
             "config/js/utils.js",
         ]
-        css = {
-            "all": ["config/css/lib/jsonschema-ui.css"]
-        }
+        css = {"all": ["config/css/lib/jsonschema-ui.css"]}
         if self.advanced_mode:
             js.insert(0, "config/js/lib/advanced-mode.js")
             js.insert(1, "config/js/lib/tomorrow_night_bright.js")


### PR DESCRIPTION
Modified JsonSchemaWidget media property to load advanced assets only when advanced_mode=True. CommandSchemaWidget now skips loading unnecessary JS/CSS. Verified config forms load assets, commands do not.

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #525.

Please [open a new issue](https://github.com/openwisp/openwisp-controller/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

- Updated JsonSchemaWidget.media property to conditionally load advanced editor assets (advanced-mode.js, tomorrow_night_bright.js, advanced-mode.css) only when advanced_mode=True.
- CommandSchemaWidget overrides advanced_mode=False, so these assets are not loaded for command forms, improving page performance.
- Verified that configuration forms (templates, devices) still load the advanced editor as expected.
- Verified that command forms (Connection → Commands) no longer load advanced editor assets.