### PR TITLE
[fix] Prevent IPAM changes when VPN clients exist #1096

### DIFF
--- a/openwisp_controller/config/handlers.py
+++ b/openwisp_controller/config/handlers.py
@@ -160,8 +160,13 @@ def organization_disabled_handler(instance, **kwargs):
 def check_ipam_change_handler(sender, instance, **kwargs):
     if instance._state.adding:
         return
+    if kwargs.get("raw"):
+        return
     if hasattr(instance, "ip_address"):
-        old_instance = sender.objects.only("ip_address").get(pk=instance.pk)
+        try:
+            old_instance = sender.objects.only("ip_address").get(pk=instance.pk)
+        except sender.DoesNotExist:
+            return
         if old_instance.ip_address == instance.ip_address:
             return
         is_in_use = VpnClient.objects.filter(

--- a/openwisp_controller/config/handlers.py
+++ b/openwisp_controller/config/handlers.py
@@ -1,4 +1,6 @@
+from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Q
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 from openwisp_notifications.signals import notify
@@ -14,6 +16,7 @@ Device = load_model("config", "Device")
 DeviceGroup = load_model("config", "DeviceGroup")
 Organization = load_model("openwisp_users", "Organization")
 Cert = load_model("django_x509", "Cert")
+VpnClient = load_model("config", "VpnClient")
 
 
 @receiver(
@@ -152,3 +155,30 @@ def organization_disabled_handler(instance, **kwargs):
         # No change in is_active
         return
     tasks.invalidate_controller_views_cache.delay(str(instance.id))
+
+
+def check_ipam_change_handler(sender, instance, **kwargs):
+    if instance._state.adding:
+        return
+    if hasattr(instance, "ip_address"):
+        old_instance = sender.objects.only("ip_address").get(pk=instance.pk)
+        if old_instance.ip_address == instance.ip_address:
+            return
+        is_in_use = VpnClient.objects.filter(
+            Q(ip=instance) | Q(vpn__ip=instance)
+        ).exists()
+        error_msg = _(
+            "Cannot modify this IP address because it is assigned to an "
+            "active VPN connection. Disconnect the clients first."
+        )
+    else:
+        old_instance = sender.objects.only("subnet").get(pk=instance.pk)
+        if old_instance.subnet == instance.subnet:
+            return
+        is_in_use = VpnClient.objects.filter(vpn__subnet=instance).exists()
+        error_msg = _(
+            "Cannot modify this subnet because it is assigned to a VPN "
+            "server with active clients. Disconnect the clients first."
+        )
+    if is_in_use:
+        raise ValidationError(error_msg)

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -727,7 +727,7 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
             )
 
     def test_prevent_subnet_change_with_vpn_clients(self):
-        device, vpn, template = self._create_wireguard_vpn_template()
+        _device, vpn, _template = self._create_wireguard_vpn_template()
         subnet = vpn.subnet
         with self.subTest("Test subnet change blocked when clients exist"):
             subnet.subnet = "10.0.2.0/24"
@@ -736,7 +736,7 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
             self.assertIn("Cannot modify this subnet", str(cm.exception))
 
     def test_prevent_ip_change_with_vpn_clients(self):
-        device, vpn, template = self._create_wireguard_vpn_template()
+        device, vpn, _template = self._create_wireguard_vpn_template()
         with self.subTest("Test server IP change blocked when clients exist"):
             server_ip = vpn.ip
             server_ip.ip_address = "10.0.1.250"

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -726,6 +726,41 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
                 f"VPN Server UUID: {vpn_id} does not exist."
             )
 
+    def test_prevent_subnet_change_with_vpn_clients(self):
+        device, vpn, template = self._create_wireguard_vpn_template()
+        subnet = vpn.subnet
+        with self.subTest("Test subnet change blocked when clients exist"):
+            subnet.subnet = "10.0.2.0/24"
+            with self.assertRaises(ValidationError) as cm:
+                subnet.full_clean()
+            self.assertIn("Cannot modify this subnet", str(cm.exception))
+
+    def test_prevent_ip_change_with_vpn_clients(self):
+        device, vpn, template = self._create_wireguard_vpn_template()
+        with self.subTest("Test server IP change blocked when clients exist"):
+            server_ip = vpn.ip
+            server_ip.ip_address = "10.0.1.250"
+            with self.assertRaises(ValidationError) as cm:
+                server_ip.full_clean()
+            self.assertIn("assigned to an active VPN connection", str(cm.exception))
+        with self.subTest("Test client IP change blocked"):
+            vpn_client = device.config.vpnclient_set.first()
+            client_ip = vpn_client.ip
+            client_ip.ip_address = "10.0.1.251"
+            with self.assertRaises(ValidationError) as cm:
+                client_ip.full_clean()
+            self.assertIn("assigned to an active VPN connection", str(cm.exception))
+
+    def test_allow_ip_change_without_vpn_clients(self):
+        vpn = self._create_wireguard_vpn()
+        server_ip = vpn.ip
+        server_ip.ip_address = "10.0.1.252"
+        try:
+            server_ip.full_clean()
+            server_ip.save()
+        except ValidationError:
+            self.fail("ValidationError raised on IP change with no active clients!")
+
 
 class TestWireguardTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTestCase):
     mock_response = mock.Mock(spec=requests.Response)

--- a/openwisp_controller/config/utils.py
+++ b/openwisp_controller/config/utils.py
@@ -269,3 +269,18 @@ def handle_error_notification(task_key, sleep_time=False, **kwargs):
     if cached_value != "error":
         cache.set(task_key, "error", timeout=None)
         send_api_task_notification("error", sleep_time=sleep_time, **kwargs)
+
+
+def apply_model_clean_patch(model, validation_func):
+    """
+    Injects a validation function into a model's clean() method
+    at runtime to maintain clean ui
+    """
+    original_clean = model.clean
+
+    def patched_clean(instance):
+        if original_clean:
+            original_clean(instance)
+        validation_func(model, instance)
+
+    model.clean = patched_clean

--- a/openwisp_controller/config/utils.py
+++ b/openwisp_controller/config/utils.py
@@ -279,8 +279,7 @@ def apply_model_clean_patch(model, validation_func):
     original_clean = model.clean
 
     def patched_clean(instance):
-        if original_clean:
-            original_clean(instance)
+        original_clean(instance)
         validation_func(model, instance)
 
     model.clean = patched_clean


### PR DESCRIPTION
Blocks modification of Subnet and IpAddress objects if they are currently linked to an active VPN connection with connected clients.

Fixes #1096

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #1096.

## Description of Changes
Prevents  changing subnet and ip addresses if they are currently
linked to an active VPN connection with connected clients.