### PR TITLE
Fix VPN server peer cache desynchronization

### DIFF
--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -200,8 +200,8 @@ class DeviceConfigSerializer(BaseSerializer):
             if config_templates != old_templates:
                 with transaction.atomic():
                     vpn_list = config.templates.filter(type="vpn").values_list("vpn")
-                    if vpn_list:
-                        config.vpnclient_set.exclude(vpn__in=vpn_list).delete()
+                    for client in config.vpnclient_set.exclude(vpn__in=vpn_list).iterator():
+                        client.delete()
                     config.templates.set(config_templates, clear=True)
             config.save()
         except ValidationError as error:

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -338,7 +338,8 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
             if instance.is_deactivating_or_deactivated():
                 # If the device is deactivated or in the process of deactivating, then
                 # delete all vpn clients and return.
-                instance.vpnclient_set.all().delete()
+                for client in instance.vpnclient_set.all().iterator():
+                    client.delete()
             return
 
         vpn_client_model = cls.vpn.through
@@ -370,9 +371,10 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
             # signal is triggered again—after all templates, including the required
             # ones, have been fully added. At that point, we can identify and
             # delete VpnClient objects not linked to the final template set.
-            instance.vpnclient_set.exclude(
+            for client in instance.vpnclient_set.exclude(
                 template_id__in=instance.templates.values_list("id", flat=True)
-            ).delete()
+            ).iterator():
+                client.delete()
 
         if action == "post_add":
             for template in templates.filter(type="vpn"):


### PR DESCRIPTION
## Checklist

- [✔️] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [✔️] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue
Closes #1221 .


## Description of Changes
This PR fixes an issue where removing a VPN template from a device did not properly update the VPN server’s peer list.

The problem was caused by bulk deletion of VpnClient objects, which bypasses Django’s post_delete signals. As a result, the VPN peer cache was not invalidated and removed devices could remain authorized on the server.

To fix this, bulk deletes were replaced with instance-level .delete() calls so that the post_delete signal is always triggered. This ensures the VPN server peer cache is invalidated correctly when VPN templates are removed.

The change applies to both:
- `manage_vpn_clients` in the config component
- `DeviceConfigSerializer._update_config` in the API layer

This keeps admin and API behavior consistent.


