### PR TITLE
[fix] Use context variables in Vpn.auto_client for OpenVPN backend

### DIFF
--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -648,7 +648,7 @@ class AbstractVpn(ConfigChecksumCacheMixin, ShareableOrgMixinUniqueName, BaseCon
                 context_keys.pop("ip_address", None)
                 context_keys.pop("vpn_subnet", None)
                 auto = backend.auto_client(
-                    host=self.host,
+                    host=vpn_host,
                     server=self.config[config_dict_key][0],
                     **context_keys,
                 )

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -194,12 +194,13 @@ class TestVpn(BaseTestVpn, TestCase):
         vpn = self._create_vpn()
         auto = vpn.auto_client()
         context_keys = vpn._get_auto_context_keys()
-        del context_keys["vpn_host"]
         del context_keys["vpn_port"]
         for key in context_keys.keys():
             context_keys[key] = "{{%s}}" % context_keys[key]
         control = vpn.backend_class.auto_client(
-            host=vpn.host, server=self._vpn_config["openvpn"][0], **context_keys
+            host=context_keys.pop("vpn_host"),
+            server=self._vpn_config["openvpn"][0],
+            **context_keys,
         )
         control["files"] = [
             {
@@ -224,14 +225,15 @@ class TestVpn(BaseTestVpn, TestCase):
         vpn = self._create_vpn()
         auto = vpn.auto_client(auto_cert=False)
         context_keys = vpn._get_auto_context_keys()
-        del context_keys["vpn_host"]
         del context_keys["vpn_port"]
         for key in context_keys.keys():
             context_keys[key] = "{{%s}}" % context_keys[key]
         for key in ["cert_path", "cert_contents", "key_path", "key_contents"]:
             del context_keys[key]
         control = vpn.backend_class.auto_client(
-            host=vpn.host, server=self._vpn_config["openvpn"][0], **context_keys
+            host=context_keys.pop("vpn_host"),
+            server=self._vpn_config["openvpn"][0],
+            **context_keys,
         )
         control["files"] = [
             {


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.


## Description of Changes

Bug:

The `Vpn.auto_client` method was incorrectly using the Vpn.host field when generating the client configuration for the OpenVPN backend.

This resulted in the `remote` directive being hardcoded in the `Template.config`, instead of being rendered from the provided context variables.

Fix:

The `Vpn.auto_client` method has been updated to use the correct context-based values.

