### PR TITLE
[docs] Update organization limits screenshot and fix image paths

### DIFF
--- a/docs/user/organization-limits.rst
+++ b/docs/user/organization-limits.rst
@@ -12,6 +12,6 @@ To set these limits:
 
 Refer to the screenshot below for guidance:
 
-.. figure:: ../images/organization-limits.png
-    :target: ../images/organization-limits.png
+.. figure:: https://raw.githubusercontent.com/openwisp/openwisp-controller/docs/docs/1.1/organization-limits.png
+    :target: https://raw.githubusercontent.com/openwisp/openwisp-controller/docs/docs/1.1/organization-limits.png
     :alt: Organization limits


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1073 (First part of PR)

## Description of Changes

The screenshot for the Organization Limits page was missing the "Configuration Variables" field. I've replaced it with a fresh capture from my local dev environment that includes this section.

I also fixed the documentation code to stop pulling the image from an external URL. It now uses a local relative path, which keeps the documentation self-contained and easier to maintain.

Edit: Image paths reverted as per request





