### PR TITLE
[change] Remove hardcoded pathname in widget.js

### DIFF
--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -4,8 +4,8 @@
   django._jsonEditors = new Map();
   var inFullScreenMode = false,
     prevDefaultValues = {},
-    defaultValuesUrl =
-      window.location.origin + "/admin/config/device/get-default-values/",
+    current_app_label = `${window.location.pathname.split("/").filter(Boolean)[1]}`,
+    defaultValuesUrl = `${window.location.origin}/admin/${current_app_label}/device/get-default-values/`,
     removeDefaultValues = function (contextValue, defaultValues) {
       // remove default values when template is removed.
       Object.keys(prevDefaultValues).forEach(function (key) {


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

This removes a hardcoded pathname in the widget.js file, relying on window.location to resolve get_default_values url. 
