### PR TITLE
[tests] Fixed test_selenium to allow custom config app_label

### DIFF
--- a/openwisp_controller/tests/test_selenium.py
+++ b/openwisp_controller/tests/test_selenium.py
@@ -99,7 +99,10 @@ class TestDevice(
         ).click()
         try:
             WebDriverWait(self.web_driver, 5).until(
-                EC.url_to_be(f"{self.live_server_url}/admin/config/device/")
+                EC.url_to_be(
+                    self.live_server_url
+                    + reverse(f"admin:{self.config_app_label}_device_changelist")
+                )
             )
         except TimeoutException:
             self.fail("Deleted device was not restored")


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Small change in test_selenium to be use the config app_label attr in test
