### PR TITLE
[chores:tests] Fixed mocking in test_update_vpn_server_configuration

### DIFF
--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -845,10 +845,11 @@ class TestWireguardTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTe
                 post_save.send(
                     instance=vpn_client, sender=vpn_client._meta.model, created=False
                 )
-                self.assertEqual(mocked_logger.call_count, 2)
-                mocked_logger.assert_called_with(
+                expected_call = mock.call(
                     f"Triggered update webhook of VPN Server UUID: {vpn.pk}"
                 )
+                mocked_logger.assert_has_calls([expected_call, expected_call])
+                self.assertEqual(mocked_logger.call_count, 2)
 
             fail_response = mock.Mock(spec=requests.Response)
             fail_response.status_code = 404


### PR DESCRIPTION
The first call to vpn.save() was generting a real HTTP request, which failed in the CI of ansible-openwisp2.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.