### PR TITLE
[fix] Added delete_confirmation_template attr in DeviceAdmin

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -503,6 +503,7 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, UUIDAdmin):
     delete_selected_confirmation_template = (
         "admin/config/device/delete_selected_confirmation.html"
     )
+    delete_confirmation_template = "admin/config/device/delete_confirmation.html"
     list_display = [
         "name",
         "backend",


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

This add delete_confirmation_template attr to the Device Admin class, just like other templates.
Without it, selenium deletion tests will fail on apps deriving from config, that are not named `config`.
