### PR TITLE
[fix] Prevented fallback fields from generating migrations #1231

### DIFF
--- a/openwisp_controller/config/base/multitenancy.py
+++ b/openwisp_controller/config/base/multitenancy.py
@@ -14,6 +14,9 @@ from .. import settings as app_settings
 from ..exceptions import OrganizationDeviceLimitExceeded
 from ..tasks import bulk_invalidate_config_get_cached_checksum
 
+FALLBACK_WHOIS_ENABLED = False
+FALLBACK_ESTIMATED_LOCATION_ENABLED = False
+
 
 class AbstractOrganizationConfigSettings(UUIDModel):
     organization = models.OneToOneField(
@@ -36,12 +39,12 @@ class AbstractOrganizationConfigSettings(UUIDModel):
     )
     whois_enabled = FallbackBooleanChoiceField(
         help_text=_("Whether the WHOIS lookup feature is enabled"),
-        fallback=app_settings.WHOIS_ENABLED,
+        fallback=FALLBACK_WHOIS_ENABLED,
         verbose_name=_("WHOIS Enabled"),
     )
     estimated_location_enabled = FallbackBooleanChoiceField(
         help_text=_("Whether the estimated location feature is enabled"),
-        fallback=app_settings.ESTIMATED_LOCATION_ENABLED,
+        fallback=FALLBACK_ESTIMATED_LOCATION_ENABLED,
         verbose_name=_("Estimated Location Enabled"),
     )
     context = JSONField(

--- a/openwisp_controller/config/tests/test_config.py
+++ b/openwisp_controller/config/tests/test_config.py
@@ -1000,3 +1000,26 @@ class TestTransactionConfig(
         config.refresh_from_db()
         config._invalidate_backend_instance_cache()
         self.assertEqual(config.checksum, config.checksum_db)
+
+
+class MultitenancyMigrationTest(TestCase):
+    def test_no_migration_when_toggling_whois_estimated_location(self):
+        from django.apps import apps
+        from django.db.migrations.autodetector import MigrationAutodetector
+        from django.db.migrations.loader import MigrationLoader
+        from django.db.migrations.state import ProjectState
+        from django.test import override_settings
+
+        for whois, est_loc in [(True, False), (False, True), (True, True)]:
+            with self.subTest(whois=whois, est_loc=est_loc):
+                with override_settings(
+                    OPENWISP_CONTROLLER_WHOIS_ENABLED=whois,
+                    OPENWISP_CONTROLLER_ESTIMATED_LOCATION_ENABLED=est_loc,
+                ):
+                    loader = MigrationLoader(None, ignore_no_migrations=True)
+                    autodetector = MigrationAutodetector(
+                        loader.project_state(),
+                        ProjectState.from_apps(apps),
+                    )
+                    changes = autodetector.changes(graph=loader.graph)
+                    self.assertNotIn("config", changes)


### PR DESCRIPTION
No DB migrations should be created when default settings are changed. Defined constants FALLBACK_WHOIS_ENABLED and FALLBACK_ESTIMATED_LOCATION_ENABLED in multitenancy.py to hold default values, preventing migration churn when app settings are modified. Corrected help_text on the estimated_location_enabled field to explicitly match the original migration.

Fixes #1231

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #1231.
