### PR TITLE
[fix] WireGuard auto tunnel provisioning broken with IPv6 #721

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 Version 1.3.0 [unreleased]
 --------------------------
 
-Work in progress.
+Bugfixes
+~~~~~~~~
+
+- Fixed WireGuard auto tunnel provisioning broken with IPv6 subnets `#721
+  <https://github.com/openwisp/openwisp-controller/issues/721>`_
 
 Version 1.2.2 [2026-03-06]
 --------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 Version 1.3.0 [unreleased]
 --------------------------
 
-Work in progress.
+Bugfixes
+~~~~~~~~
+
+- Fixed WireGuard auto tunnel provisioning broken with IPv6 subnets `#721
+  <https://github.com/openwisp/openwisp-controller/issues/721>`_
 
 Version 1.2.3 [2026-04-09]
 --------------------------

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -629,6 +629,12 @@ class AbstractVpn(ConfigChecksumCacheMixin, ShareableOrgMixinUniqueName, BaseCon
                     vxlan=self.config.get("vxlan", [{}])[0],
                     **context_keys,
                 )
+                if self.subnet and self.subnet.subnet.version == 6:
+                    for interface in auto.get("interfaces", []):
+                        if interface.get("type") == "wireguard":
+                            for addr in interface.get("addresses", []):
+                                addr["family"] = "ipv6"
+                                addr["mask"] = 128
             # If the backend is 'zerotier' then
             # call auto_client and update the config
             elif self._is_backend_type("zerotier") and template_backend_class:

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -629,6 +629,10 @@ class AbstractVpn(ConfigChecksumCacheMixin, ShareableOrgMixinUniqueName, BaseCon
                     vxlan=self.config.get("vxlan", [{}])[0],
                     **context_keys,
                 )
+                # Workaround: netjsonconfig's wireguard_auto_client hardcodes
+                # family="ipv4" and mask=32. Correct these for IPv6 subnets.
+                # Remove when netjsonconfig handles IPv6 natively.
+                # See: https://github.com/openwisp/openwisp-controller/issues/721
                 if self.subnet and self.subnet.subnet.version == 6:
                     for interface in auto.get("interfaces", []):
                         if interface.get("type") == "wireguard":

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -718,6 +718,10 @@ class AbstractVpn(
                     vxlan=self.config.get("vxlan", [{}])[0],
                     **context_keys,
                 )
+                # Workaround: netjsonconfig's wireguard_auto_client hardcodes
+                # family="ipv4" and mask=32. Correct these for IPv6 subnets.
+                # Remove when netjsonconfig handles IPv6 natively.
+                # See: https://github.com/openwisp/openwisp-controller/issues/721
                 if self.subnet and self.subnet.subnet.version == 6:
                     for interface in auto.get("interfaces", []):
                         if interface.get("type") == "wireguard":

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -718,6 +718,12 @@ class AbstractVpn(
                     vxlan=self.config.get("vxlan", [{}])[0],
                     **context_keys,
                 )
+                if self.subnet and self.subnet.subnet.version == 6:
+                    for interface in auto.get("interfaces", []):
+                        if interface.get("type") == "wireguard":
+                            for addr in interface.get("addresses", []):
+                                addr["family"] = "ipv6"
+                                addr["mask"] = 128
             # If the backend is 'zerotier' then
             # call auto_client and update the config
             elif self._is_backend_type("zerotier") and template_backend_class:

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -641,11 +641,13 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         self.assertEqual(auto, expected)
 
     def test_auto_client_ipv6(self):
+        org = self._get_org()
         device, vpn, template = self._create_wireguard_vpn_template(
             vpn_options={
+                "organization": org,
                 "subnet": self._create_subnet(
-                    name="wireguard ipv6", subnet="fdca:1234::/64"
-                )
+                    name="wireguard ipv6", subnet="fdca:1234::/64", organization=org
+                ),
             }
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -652,7 +652,7 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
         wg_interface = next(
-            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+            (i for i in auto["interfaces"] if i.get("type") == "wireguard"), None
         )
         self.assertIsNotNone(wg_interface, "WireGuard interface not found")
         addresses = wg_interface["addresses"]
@@ -1030,7 +1030,7 @@ class TestVxlan(BaseTestVpn, TestVxlanWireguardVpnMixin, TestCase):
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
         wg_interface = next(
-            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+            (i for i in auto["interfaces"] if i.get("type") == "wireguard"), None
         )
         self.assertIsNotNone(wg_interface, "WireGuard interface not found")
         addresses = wg_interface["addresses"]

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -1012,6 +1012,24 @@ class TestVxlan(BaseTestVpn, TestVxlanWireguardVpnMixin, TestCase):
         )
         self.assertEqual(auto, expected)
 
+    def test_auto_client_ipv6(self):
+        org = self._get_org()
+        device, vpn, template = self._create_vxlan_vpn_template(
+            vpn_options={
+                "organization": org,
+                "subnet": self._create_subnet(
+                    name="vxlan wireguard ipv6",
+                    subnet="fdca:1234::/64",
+                    organization=org,
+                ),
+            }
+        )
+        auto = vpn.auto_client(template_backend_class=template.backend_class)
+        addresses = auto["interfaces"][0]["addresses"]
+        self.assertEqual(len(addresses), 1)
+        self.assertEqual(addresses[0]["family"], "ipv6")
+        self.assertEqual(addresses[0]["mask"], 128)
+
 
 class TestVxlanTransaction(
     BaseTestVpn, TestVxlanWireguardVpnMixin, TransactionTestCase

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -640,6 +640,20 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         )
         self.assertEqual(auto, expected)
 
+    def test_auto_client_ipv6(self):
+        device, vpn, template = self._create_wireguard_vpn_template(
+            vpn_options={
+                "subnet": self._create_subnet(
+                    name="wireguard ipv6", subnet="fdca:1234::/64"
+                )
+            }
+        )
+        auto = vpn.auto_client(template_backend_class=template.backend_class)
+        addresses = auto["interfaces"][0]["addresses"]
+        self.assertEqual(len(addresses), 1)
+        self.assertEqual(addresses[0]["family"], "ipv6")
+        self.assertEqual(addresses[0]["mask"], 128)
+
     def test_change_vpn_backend(self):
         vpn = self._create_vpn(name="new", backend=self._BACKENDS["openvpn"])
         subnet = self._create_subnet(

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -651,7 +651,11 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
             }
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
-        addresses = auto["interfaces"][0]["addresses"]
+        wg_interface = next(
+            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+        )
+        self.assertIsNotNone(wg_interface, "WireGuard interface not found")
+        addresses = wg_interface["addresses"]
         self.assertEqual(len(addresses), 1)
         self.assertEqual(addresses[0]["family"], "ipv6")
         self.assertEqual(addresses[0]["mask"], 128)
@@ -1025,7 +1029,11 @@ class TestVxlan(BaseTestVpn, TestVxlanWireguardVpnMixin, TestCase):
             }
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
-        addresses = auto["interfaces"][0]["addresses"]
+        wg_interface = next(
+            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+        )
+        self.assertIsNotNone(wg_interface, "WireGuard interface not found")
+        addresses = wg_interface["addresses"]
         self.assertEqual(len(addresses), 1)
         self.assertEqual(addresses[0]["family"], "ipv6")
         self.assertEqual(addresses[0]["mask"], 128)

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -730,11 +730,13 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         self.assertEqual(auto, expected)
 
     def test_auto_client_ipv6(self):
+        org = self._get_org()
         device, vpn, template = self._create_wireguard_vpn_template(
             vpn_options={
+                "organization": org,
                 "subnet": self._create_subnet(
-                    name="wireguard ipv6", subnet="fdca:1234::/64"
-                )
+                    name="wireguard ipv6", subnet="fdca:1234::/64", organization=org
+                ),
             }
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -729,6 +729,20 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         )
         self.assertEqual(auto, expected)
 
+    def test_auto_client_ipv6(self):
+        device, vpn, template = self._create_wireguard_vpn_template(
+            vpn_options={
+                "subnet": self._create_subnet(
+                    name="wireguard ipv6", subnet="fdca:1234::/64"
+                )
+            }
+        )
+        auto = vpn.auto_client(template_backend_class=template.backend_class)
+        addresses = auto["interfaces"][0]["addresses"]
+        self.assertEqual(len(addresses), 1)
+        self.assertEqual(addresses[0]["family"], "ipv6")
+        self.assertEqual(addresses[0]["mask"], 128)
+
     def test_change_vpn_backend(self):
         vpn = self._create_vpn(name="new", backend=self._BACKENDS["openvpn"])
         subnet = self._create_subnet(

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -741,7 +741,7 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
         wg_interface = next(
-            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+            (i for i in auto["interfaces"] if i.get("type") == "wireguard"), None
         )
         self.assertIsNotNone(wg_interface, "WireGuard interface not found")
         addresses = wg_interface["addresses"]
@@ -1121,7 +1121,7 @@ class TestVxlan(BaseTestVpn, TestVxlanWireguardVpnMixin, TestCase):
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
         wg_interface = next(
-            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+            (i for i in auto["interfaces"] if i.get("type") == "wireguard"), None
         )
         self.assertIsNotNone(wg_interface, "WireGuard interface not found")
         addresses = wg_interface["addresses"]

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -740,7 +740,11 @@ class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):
             }
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
-        addresses = auto["interfaces"][0]["addresses"]
+        wg_interface = next(
+            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+        )
+        self.assertIsNotNone(wg_interface, "WireGuard interface not found")
+        addresses = wg_interface["addresses"]
         self.assertEqual(len(addresses), 1)
         self.assertEqual(addresses[0]["family"], "ipv6")
         self.assertEqual(addresses[0]["mask"], 128)
@@ -1116,7 +1120,11 @@ class TestVxlan(BaseTestVpn, TestVxlanWireguardVpnMixin, TestCase):
             }
         )
         auto = vpn.auto_client(template_backend_class=template.backend_class)
-        addresses = auto["interfaces"][0]["addresses"]
+        wg_interface = next(
+            (i for i in auto["interfaces"] if "wg" in i.get("name", "")), None
+        )
+        self.assertIsNotNone(wg_interface, "WireGuard interface not found")
+        addresses = wg_interface["addresses"]
         self.assertEqual(len(addresses), 1)
         self.assertEqual(addresses[0]["family"], "ipv6")
         self.assertEqual(addresses[0]["mask"], 128)

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -1103,6 +1103,24 @@ class TestVxlan(BaseTestVpn, TestVxlanWireguardVpnMixin, TestCase):
         )
         self.assertEqual(auto, expected)
 
+    def test_auto_client_ipv6(self):
+        org = self._get_org()
+        device, vpn, template = self._create_vxlan_vpn_template(
+            vpn_options={
+                "organization": org,
+                "subnet": self._create_subnet(
+                    name="vxlan wireguard ipv6",
+                    subnet="fdca:1234::/64",
+                    organization=org,
+                ),
+            }
+        )
+        auto = vpn.auto_client(template_backend_class=template.backend_class)
+        addresses = auto["interfaces"][0]["addresses"]
+        self.assertEqual(len(addresses), 1)
+        self.assertEqual(addresses[0]["family"], "ipv6")
+        self.assertEqual(addresses[0]["mask"], 128)
+
 
 class TestVxlanTransaction(
     BaseTestVpn, TestVxlanWireguardVpnMixin, TransactionTestCase

--- a/openwisp_controller/config/tests/utils.py
+++ b/openwisp_controller/config/tests/utils.py
@@ -187,8 +187,8 @@ class TestVxlanWireguardVpnMixin(CreateIpamModelsMixin):
     def _create_vxlan_tunnel(self, config=None, **kwargs):
         if config is None:
             config = {"wireguard": [{"name": "wg0", "port": 51820}]}
-        org = self._get_org()
-        subnet = self._create_subnet(
+        org = kwargs.pop("organization", None) or self._get_org()
+        subnet = kwargs.pop("subnet", None) or self._create_subnet(
             name="wireguard test", subnet="10.0.0.0/16", organization=org
         )
         tunnel = self._create_vpn(

--- a/openwisp_controller/config/tests/utils.py
+++ b/openwisp_controller/config/tests/utils.py
@@ -189,8 +189,8 @@ class TestVxlanWireguardVpnMixin(CreateIpamModelsMixin):
     def _create_vxlan_tunnel(self, config=None, **kwargs):
         if config is None:
             config = {"wireguard": [{"name": "wg0", "port": 51820}]}
-        org = self._get_org()
-        subnet = self._create_subnet(
+        org = kwargs.pop("organization", None) or self._get_org()
+        subnet = kwargs.pop("subnet", None) or self._create_subnet(
             name="wireguard test", subnet="10.0.0.0/16", organization=org
         )
         tunnel = self._create_vpn(


### PR DESCRIPTION
When using an IPv6 subnet from OpenWISP IPAM for a WireGuard VPN, the auto-generated client template incorrectly set the address family to 'ipv4' with mask 32 because netjsonconfig's wireguard_auto_client hardcodes these values regardless of IP version.

After calling wireguard_auto_client, the resulting config is now post-processed to set family='ipv6' and mask=128 when the VPN subnet is IPv6. A regression test is also included.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #721


## Description of Changes

The wireguard_auto_client method in netjsonconfig's OpenWrt backend hardcodes family: ipv4 and mask: 32 when generating the WireGuard interface address, regardless of the actual IP version of the assigned subnet. When a user sets up a WireGuard VPN using an IPv6 IPAM subnet and auto-configures a VPN client template, the generated template gets an incorrect IPv4 address family. If the user then manually corrects the family to ipv6, schema validation fails.
The fix post-processes the output of wireguard_auto_client in AbstractVpn.auto_client() (openwisp_controller/config/base/vpn.py): when self.subnet.subnet.version == 6, all WireGuard interface addresses in the auto-generated config are updated to family: ipv6 and mask: 128.

## Screenshot

N/A