### PR TITLE
[tests] Add test for CommandTimeoutException in launch_command task

### DIFF
--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -9,6 +9,7 @@ from swapper import load_model
 
 from ...config.tests.test_controller import TestRegistrationMixin
 from .. import tasks
+from ..connectors.exceptions import CommandTimeoutException
 from .utils import CreateConnectionsMixin
 
 Command = load_model("connection", "Command")
@@ -66,6 +67,30 @@ class TestTasks(CreateConnectionsMixin, TestCase):
         command.refresh_from_db()
         self.assertEqual(command.status, "failed")
         self.assertEqual(command.output, "Background task time limit exceeded.\n")
+
+    @mock.patch(
+        _mock_execute,
+        side_effect=CommandTimeoutException("connection timed out after 30s"),
+    )
+    @mock.patch(_mock_connect, return_value=True)
+    def test_launch_command_ssh_timeout(self, *args):
+        dc = self._create_device_connection()
+        command = Command(
+            device=dc.device,
+            connection=dc,
+            type="custom",
+            input={"command": "/usr/sbin/exotic_command"},
+        )
+        command.full_clean()
+        command.save()
+        # must call this explicitly because lack of transactions in this test case
+        tasks.launch_command.delay(command.pk)
+        command.refresh_from_db()
+        self.assertEqual(command.status, "failed")
+        self.assertEqual(
+            command.output,
+            "The command took longer than expected: connection timed out after 30s\n",
+        )
 
     @mock.patch(_mock_execute, side_effect=RuntimeError("test error"))
     @mock.patch(_mock_connect, return_value=True)


### PR DESCRIPTION
## Checklist
- [x] I have read the OpenWISP Contributing Guidelines.
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue
No existing issue.

While exploring the command execution flow, I noticed that the
`CommandTimeoutException` branch in the `launch_command` task
was not covered by tests.

## Description of Changes

The `launch_command` task in `connection/tasks.py` handles multiple
exception paths during command execution.

The `CommandTimeoutException` case represents a device-side timeout
raised by the SSH connector when a command exceeds the configured
timeout. This is different from `SoftTimeLimitExceeded`, which is
triggered by Celery when the background task itself exceeds its time limit.

This PR adds a test (`test_launch_command_ssh_timeout`) in
`tests/test_tasks.py` to verify that when `CommandTimeoutException`
is raised:

- the command status is set to `failed`
- the output contains the timeout message and exception details

The test follows the structure of the existing
`test_launch_command_timeout` test to keep the testing style consistent
with the current codebase.