### PR TITLE
[ci] Enabled issue autoassignment bots

### DIFF
--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -1,0 +1,49 @@
+name: Issue Assignment Bot
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: bot-autoassign-issue-${{ github.repository }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  respond-to-assign-request:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request == null
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
+          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+
+      - name: Checkout openwisp-utils
+        uses: actions/checkout@v6
+        with:
+          repository: openwisp/openwisp-utils
+          ref: master
+          path: openwisp-utils
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e openwisp-utils/.[github_actions]
+
+      - name: Run issue assignment bot
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: >
+          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
+          issue_assignment "$GITHUB_EVENT_PATH"

--- a/.github/workflows/bot-autoassign-issue.yml
+++ b/.github/workflows/bot-autoassign-issue.yml
@@ -1,49 +1,19 @@
 name: Issue Assignment Bot
-
 on:
   issue_comment:
     types: [created]
-
 permissions:
   contents: read
   issues: write
-
 concurrency:
   group: bot-autoassign-issue-${{ github.repository }}-${{ github.event.issue.number }}
   cancel-in-progress: true
-
 jobs:
   respond-to-assign-request:
-    runs-on: ubuntu-latest
     if: github.event.issue.pull_request == null
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout openwisp-utils
-        uses: actions/checkout@v6
-        with:
-          repository: openwisp/openwisp-utils
-          ref: master
-          path: openwisp-utils
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e openwisp-utils/.[github_actions]
-
-      - name: Run issue assignment bot
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: >
-          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
-          issue_assignment "$GITHUB_EVENT_PATH"
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: issue_assignment
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,7 +1,7 @@
 name: PR Issue Auto-Assignment
 on:
   pull_request_target:
-    types: [opened, reopened, closed]
+    types: [opened, closed]
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,13 +1,13 @@
 name: PR Issue Auto-Assignment
 on:
   pull_request_target:
-    types: [opened, closed]
+    types: [opened, reopened, closed]
 permissions:
   contents: read
   issues: write
   pull-requests: read
 concurrency:
-  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
+  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 jobs:
   auto-assign-issue:

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,49 +1,20 @@
 name: PR Issue Auto-Assignment
-
 on:
   pull_request_target:
     types: [opened, reopened, closed]
-
 permissions:
   contents: read
   issues: write
   pull-requests: read
-
 concurrency:
   group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
-
 jobs:
   auto-assign-issue:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout openwisp-utils
-        uses: actions/checkout@v6
-        with:
-          repository: openwisp/openwisp-utils
-          ref: master
-          path: openwisp-utils
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e openwisp-utils/.[github_actions]
-
-      - name: Run issue assignment bot
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: >
-          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
-          issue_assignment "$GITHUB_EVENT_PATH"
+    if: github.event.action != 'closed' || github.event.pull_request.merged == false
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: issue_assignment
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,0 +1,49 @@
+name: PR Issue Auto-Assignment
+
+on:
+  pull_request_target:
+    types: [opened, reopened, closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-assign-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
+          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+
+      - name: Checkout openwisp-utils
+        uses: actions/checkout@v6
+        with:
+          repository: openwisp/openwisp-utils
+          ref: master
+          path: openwisp-utils
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e openwisp-utils/.[github_actions]
+
+      - name: Run issue assignment bot
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: >
+          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
+          issue_assignment "$GITHUB_EVENT_PATH"

--- a/.github/workflows/bot-autoassign-pr-reopen.yml
+++ b/.github/workflows/bot-autoassign-pr-reopen.yml
@@ -1,0 +1,87 @@
+name: PR Reopen Reassignment
+
+on:
+  pull_request_target:
+    types: [reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: bot-autoassign-pr-reopen-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  reassign-on-reopen:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' && github.event.action == 'reopened'
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
+          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+
+      - name: Checkout openwisp-utils
+        uses: actions/checkout@v6
+        with:
+          repository: openwisp/openwisp-utils
+          ref: master
+          path: openwisp-utils
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e openwisp-utils/.[github_actions]
+
+      - name: Reassign issues on PR reopen
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: >
+          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
+          pr_reopen "$GITHUB_EVENT_PATH"
+
+  handle-pr-activity:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
+          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+
+      - name: Checkout openwisp-utils
+        uses: actions/checkout@v6
+        with:
+          repository: openwisp/openwisp-utils
+          ref: master
+          path: openwisp-utils
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e openwisp-utils/.[github_actions]
+
+      - name: Handle PR activity
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: >
+          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
+          pr_reopen "$GITHUB_EVENT_PATH"

--- a/.github/workflows/bot-autoassign-pr-reopen.yml
+++ b/.github/workflows/bot-autoassign-pr-reopen.yml
@@ -1,87 +1,30 @@
 name: PR Reopen Reassignment
-
 on:
   pull_request_target:
     types: [reopened]
   issue_comment:
     types: [created]
-
 permissions:
   contents: read
   issues: write
-  pull-requests: read
-
+  pull-requests: write
 concurrency:
   group: bot-autoassign-pr-reopen-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: true
-
 jobs:
   reassign-on-reopen:
-    runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' && github.event.action == 'reopened'
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout openwisp-utils
-        uses: actions/checkout@v6
-        with:
-          repository: openwisp/openwisp-utils
-          ref: master
-          path: openwisp-utils
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e openwisp-utils/.[github_actions]
-
-      - name: Reassign issues on PR reopen
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: >
-          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
-          pr_reopen "$GITHUB_EVENT_PATH"
-
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: pr_reopen
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
   handle-pr-activity:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'issue_comment' && github.event.issue.pull_request
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout openwisp-utils
-        uses: actions/checkout@v6
-        with:
-          repository: openwisp/openwisp-utils
-          ref: master
-          path: openwisp-utils
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e openwisp-utils/.[github_actions]
-
-      - name: Handle PR activity
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-        run: >
-          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
-          pr_reopen "$GITHUB_EVENT_PATH"
+    if: github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.issue.user.login == github.event.comment.user.login
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: pr_reopen
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}

--- a/.github/workflows/bot-autoassign-stale-pr.yml
+++ b/.github/workflows/bot-autoassign-stale-pr.yml
@@ -1,0 +1,49 @@
+name: Stale PR Management
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: bot-autoassign-stale-pr-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  manage-stale-prs-python:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
+          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
+
+      - name: Checkout openwisp-utils
+        uses: actions/checkout@v6
+        with:
+          repository: openwisp/openwisp-utils
+          ref: master
+          path: openwisp-utils
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install -e openwisp-utils/.[github_actions]
+
+      - name: Run stale PR bot
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: >
+          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
+          stale_pr

--- a/.github/workflows/bot-autoassign-stale-pr.yml
+++ b/.github/workflows/bot-autoassign-stale-pr.yml
@@ -1,49 +1,20 @@
 name: Stale PR Management
-
 on:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
-
 permissions:
   contents: read
   issues: write
   pull-requests: write
-
 concurrency:
   group: bot-autoassign-stale-pr-${{ github.repository }}
   cancel-in-progress: false
-
 jobs:
   manage-stale-prs-python:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Generate GitHub App token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.OPENWISP_BOT_APP_ID }}
-          private-key: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}
-
-      - name: Checkout openwisp-utils
-        uses: actions/checkout@v6
-        with:
-          repository: openwisp/openwisp-utils
-          ref: master
-          path: openwisp-utils
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: pip install -e openwisp-utils/.[github_actions]
-
-      - name: Run stale PR bot
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-          REPOSITORY: ${{ github.repository }}
-        run: >
-          python openwisp-utils/.github/actions/bot-autoassign/__main__.py
-          stale_pr
+    uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-autoassign.yml@master
+    with:
+      bot_command: stale_pr
+    secrets:
+      OPENWISP_BOT_APP_ID: ${{ secrets.OPENWISP_BOT_APP_ID }}
+      OPENWISP_BOT_PRIVATE_KEY: ${{ secrets.OPENWISP_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
This PR adds the GitHub Actions workflows to auto-assign issues, manage PR-issue linking, handle PR reopening reassignment, and manage stale PRs.

These workflows check out `openwisp/openwisp-utils` to run the bot Python scripts, ensuring uniform behavior across all repositories.

Related to the auto-assignment issue bot implementation.

closes #1265 