### PR TITLE
[tests] Fix missing parentheses on config.refresh_from_db call

### DIFF
--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -672,7 +672,7 @@ class TestTransactionDevice(
         mocked_config_deactivating.assert_called_once()
         mocked_config_deactivated.assert_called_once()
         device.refresh_from_db()
-        config.refresh_from_db
+        config.refresh_from_db()
         self.assertEqual(device.is_deactivated(), True)
         self.assertEqual(config.status, "deactivated")
         self.assertEqual(device.management_ip, None)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have updated existing tests for the change.
- [ ] I have updated the documentation.

## Reference to Existing Issue

None.

## Description of Changes

In `test_deactivating_device_empty_config`, `config.refresh_from_db` is referenced without calling it, so the object is not actually refreshed before the assertion.

If the configuration is updated via queryset operations (such as `update()`), the in-memory instance may contain stale values and the assertion could end up checking cached data.

This change simply adds the missing parentheses so `config.refresh_from_db()` is executed before the status assertion.