### PR TITLE
[fix] Auto-fill organization from master subnet in SubnetDivisionRule

### DIFF
--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -71,11 +71,11 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
     def clean(self):
         # Auto-fill organization from master subnet
         if (
-        self.master_subnet_id
-        and self.master_subnet.organization is not None
-        and not self.organization
-         ):
-         self.organization = self.master_subnet.organization
+            self.master_subnet_id
+            and self.master_subnet.organization is not None
+            and not self.organization_id
+        ):
+            self.organization = self.master_subnet.organization
         super().clean()
         self._validate_label()
         self._validate_master_subnet_validity()

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -72,10 +72,10 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
         # Auto-fill organization from master subnet
         if (
             self.master_subnet_id
-            and self.master_subnet.organization is not None
+            and self.master_subnet.organization_id is not None
             and not self.organization_id
         ):
-            self.organization = self.master_subnet.organization
+            self.organization_id = self.master_subnet.organization_id
         super().clean()
         self._validate_label()
         self._validate_master_subnet_validity()

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -69,6 +69,13 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
         return import_string(self.type)
 
     def clean(self):
+        # Auto-fill organization from master subnet
+        if (
+        self.master_subnet_id
+        and self.master_subnet.organization is not None
+        and not self.organization
+         ):
+         self.organization = self.master_subnet.organization
         super().clean()
         self._validate_label()
         self._validate_master_subnet_validity()


### PR DESCRIPTION
## Checklist
- [x] I have read the OpenWISP Contributing Guidelines.
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue
Closes #844

## Description of Changes
When a subnet has an organization set, the SubnetDivisionRule 
should automatically inherit the same organization at model level.

Added auto-fill logic in the clean() method of 
AbstractSubnetDivisionRule to set the organization from the 
master subnet if not already set.

## Screenshot
No UI changes, backend model fix only.