### PR TITLE
[fix] Use continue instead of return in manage_devices_group_templates

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -504,7 +504,7 @@ class AbstractDevice(OrgMixin, BaseModel):
             config_created = hasattr(device, "config")
             if not config_created:
                 # device has no config (device group has no templates)
-                return
+                continue
             group_templates = Template.objects.none()
             if group_id:
                 group = DeviceGroup.objects.get(pk=group_id)

--- a/openwisp_controller/config/tests/test_device_group.py
+++ b/openwisp_controller/config/tests/test_device_group.py
@@ -9,12 +9,17 @@ from openwisp_utils.tests import catch_signal
 
 from .. import settings as app_settings
 from ..signals import group_templates_changed
-from .utils import CreateDeviceGroupMixin, CreateTemplateMixin
+from .utils import CreateDeviceGroupMixin, CreateDeviceMixin, CreateTemplateMixin
 
+Config = load_model("config", "Config")
+Device = load_model("config", "Device")
 DeviceGroup = load_model("config", "DeviceGroup")
+Template = load_model("config", "Template")
 
 
-class TestDeviceGroup(CreateDeviceGroupMixin, CreateTemplateMixin, TestCase):
+class TestDeviceGroup(
+    CreateDeviceMixin, CreateDeviceGroupMixin, CreateTemplateMixin, TestCase
+):
     def test_device_group(self):
         self._create_device_group(
             meta_data={"captive_portal_url": "https//example.com"}
@@ -61,3 +66,51 @@ class TestDeviceGroup(CreateDeviceGroupMixin, CreateTemplateMixin, TestCase):
                 raw=False,
                 using="default",
             )
+
+    def test_manage_devices_group_templates_no_early_termination(self):
+        """
+        Regression test: when the first device in the batch has no config
+        (because its group has no templates), the loop must continue and
+        still apply group templates to the second device.
+        """
+        org = self._get_org()
+        t1 = self._create_template(name="t1")
+        # group_with_templates has a template; group_without does not
+        group_with_templates = self._create_device_group(
+            name="group-with-tpl", organization=org
+        )
+        group_with_templates.templates.add(t1)
+        group_without_templates = self._create_device_group(
+            name="group-without-tpl", organization=org
+        )
+        # device1: belongs to a group without templates → no config created
+        device1 = self._create_device(
+            name="device-no-config",
+            organization=org,
+            group=group_without_templates,
+            mac_address="00:00:00:00:00:01",
+        )
+        self.assertFalse(hasattr(device1, "config"))
+        # device2: has a config object
+        device2 = self._create_device(
+            name="device-with-config",
+            organization=org,
+            mac_address="00:00:00:00:00:02",
+        )
+        Config.objects.create(
+            device=device2,
+            backend="netjsonconfig.OpenWrt",
+        )
+        device2.refresh_from_db()
+        self.assertTrue(hasattr(device2, "config"))
+        self.assertEqual(device2.config.templates.count(), 0)
+        # Call manage_devices_group_templates with device1 (no config) first,
+        # then device2 (has config). device1 should be skipped, device2 must
+        # still get group_with_templates's template applied.
+        Device.manage_devices_group_templates(
+            device_ids=[device1.pk, device2.pk],
+            old_group_ids=[None, None],
+            group_id=group_with_templates.pk,
+        )
+        device2.refresh_from_db()
+        self.assertIn(t1, device2.config.templates.all())


### PR DESCRIPTION
  The loop in `manage_devices_group_templates` used `return` when a device had no config, which aborted processing of all remaining devices in the batch. Changed to `continue` 
  so that devices without a config are skipped individually while the rest of the batch is still processed.

  Fixes silent configuration drift when batch-changing device groups where some devices lack a config object.

  ## Checklist

  - [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
  - [x] I have manually tested the changes proposed in this pull request.
  - [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
  - [ ] I have updated the documentation.

  ## Reference to Existing Issue

  No existing issue found. A new issue should be opened at [openwisp-controller/issues](https://github.com/openwisp/openwisp-controller/issues/new/choose) before submitting the
   PR.

  ## Description of Changes

  In `openwisp_controller/config/base/device.py`, the `manage_devices_group_templates` method iterates over a batch of devices to apply/remove group templates. When a device   
  has no config (because `create_default_config()` silently no-ops when the group has no templates), line 507 used `return` which exits the **entire method**, skipping all     
  remaining devices in the batch.

  Changed `return` to `continue` so that only the current device is skipped and the loop continues processing the rest.

  **Before:**
  ```python
  if not config_created:
      # device has no config (device group has no templates)
      return  # exits entire method

  After:
  if not config_created:
      # device has no config (device group has no templates)
      continue  # skips this device, processes remaining

  Screenshot

  Not applicable — this is a backend logic fix with no UI changes.