### PR TITLE
[feature] Allow zero subnets in SubnetDivisionRuleFix/allow zero subnets

### DIFF
--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -71,11 +71,11 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
     def clean(self):
         # Auto-fill organization from master subnet
         if (
-        self.master_subnet_id
-        and self.master_subnet.organization is not None
-        and not self.organization
-         ):
-         self.organization = self.master_subnet.organization
+            self.master_subnet_id
+            and self.master_subnet.organization is not None
+            and not self.organization_id
+        ):
+            self.organization = self.master_subnet.organization
         super().clean()
         self._validate_label()
         self._validate_master_subnet_validity()

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -15,16 +15,6 @@ from .. import settings as app_settings
 
 class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
     _subnet_division_rule_update_queue = dict()
-    # It is used to monitor changes in fields of a SubnetDivisionRule object
-    # An entry is added to the queue from pre_save signal in the following format
-    #
-    # '<rule-uid>: {
-    #   '<field-name>': '<old-value>',
-    # }
-    #
-    # In post_save signal, it is checked whether entry for SubnetDivisionRule object
-    # exists in this queue. If it exists changes are made to related objects.
-
     type = models.CharField(max_length=200, choices=app_settings.SUBNET_DIVISION_TYPES)
     master_subnet = models.ForeignKey(
         swapper.get_model_name("openwisp_ipam", "Subnet"), on_delete=models.CASCADE
@@ -41,7 +31,6 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
             "from the main subnet."
         ),
         validators=[MinValueValidator(0)],
-    )
     )
     size = models.PositiveSmallIntegerField(
         verbose_name=_("Size of subnets"),

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -39,8 +39,9 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
             "Indicates how many subnets will be created. "
             "Set to 0 to assign IP addresses directly "
             "from the main subnet."
-         ),
+        ),
         validators=[MinValueValidator(0)],
+    )
     )
     size = models.PositiveSmallIntegerField(
         verbose_name=_("Size of subnets"),

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -72,10 +72,10 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
         # Auto-fill organization from master subnet
         if (
             self.master_subnet_id
-            and self.master_subnet.organization is not None
+            and self.master_subnet.organization_id is not None
             and not self.organization_id
         ):
-            self.organization = self.master_subnet.organization
+            self.organization_id = self.master_subnet.organization_id
         super().clean()
         self._validate_label()
         self._validate_master_subnet_validity()

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -35,8 +35,12 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
     )
     number_of_subnets = models.PositiveSmallIntegerField(
         verbose_name=_("Number of Subnets"),
-        help_text=_("Indicates how many subnets will be created"),
-        validators=[MinValueValidator(1)],
+        help_text=_(
+            "Indicates how many subnets will be created. "
+            "Set to 0 to assign IP addresses directly "
+            "from the main subnet.
+        ),
+        validators=[MinValueValidator(0)],
     )
     size = models.PositiveSmallIntegerField(
         verbose_name=_("Size of subnets"),

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -39,7 +39,7 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
             "Indicates how many subnets will be created. "
             "Set to 0 to assign IP addresses directly "
             "from the main subnet."
-        ),
+         ),
         validators=[MinValueValidator(0)],
     )
     size = models.PositiveSmallIntegerField(

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -69,6 +69,13 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
         return import_string(self.type)
 
     def clean(self):
+        # Auto-fill organization from master subnet
+        if (
+        self.master_subnet_id
+        and self.master_subnet.organization is not None
+        and not self.organization
+         ):
+         self.organization = self.master_subnet.organization
         super().clean()
         self._validate_label()
         self._validate_master_subnet_validity()

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -38,7 +38,7 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
         help_text=_(
             "Indicates how many subnets will be created. "
             "Set to 0 to assign IP addresses directly "
-            "from the main subnet.
+            "from the main subnet."
         ),
         validators=[MinValueValidator(0)],
     )

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -133,8 +133,8 @@ class TestSubnetDivisionRule(
             options = default_options.copy()
             options["number_of_subnets"] = 0
             rule = SubnetDivisionRule(**options)
-            # Should not raise ValidationError for number_of_subnets
-             rule.full_clean()
+            # Should not raise ValidationError
+            rule.full_clean()
 
         with self.subTest("Test rule does not provision any IP"):
             options = default_options.copy()

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -129,14 +129,12 @@ class TestSubnetDivisionRule(
                 context_manager.exception.message_dict, expected_message_dict
             )
 
-        with self.subTest("Test rule allows zero subnets to assign IPs from main subnet"):
+       with self.subTest("Test rule allows zero subnets"):
             options = default_options.copy()
             options["number_of_subnets"] = 0
             rule = SubnetDivisionRule(**options)
-            try:
-                rule.full_clean()
-            except ValidationError as e:
-                self.assertNotIn("number_of_subnets", e.message_dict)
+            # Should not raise ValidationError for number_of_subnets
+             rule.full_clean()
 
         with self.subTest("Test rule does not provision any IP"):
             options = default_options.copy()

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -129,13 +129,13 @@ class TestSubnetDivisionRule(
                 context_manager.exception.message_dict, expected_message_dict
             )
 
-       with self.subTest("Test rule allows zero subnets"):
+        with self.subTest("Test rule allows zero subnets"):
             options = default_options.copy()
             options["number_of_subnets"] = 0
             rule = SubnetDivisionRule(**options)
             # Should not raise ValidationError
             rule.full_clean()
-
+            
         with self.subTest("Test rule does not provision any IP"):
             options = default_options.copy()
             options["number_of_ips"] = 0

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -129,20 +129,14 @@ class TestSubnetDivisionRule(
                 context_manager.exception.message_dict, expected_message_dict
             )
 
-        with self.subTest("Test rule does not provision any subnet"):
+        with self.subTest("Test rule allows zero subnets to assign IPs from main subnet"):
             options = default_options.copy()
             options["number_of_subnets"] = 0
             rule = SubnetDivisionRule(**options)
-            with self.assertRaises(ValidationError) as context_manager:
+            try:
                 rule.full_clean()
-            expected_message_dict = {
-                "number_of_subnets": [
-                    "Ensure this value is greater than or equal to 1."
-                ]
-            }
-            self.assertDictEqual(
-                context_manager.exception.message_dict, expected_message_dict
-            )
+            except ValidationError as e:
+                self.assertNotIn("number_of_subnets", e.message_dict)
 
         with self.subTest("Test rule does not provision any IP"):
             options = default_options.copy()


### PR DESCRIPTION
## Reference to Existing Issue
Closes #843

## Description of Changes
Allow specifying 0 in the "Number of Subnets" field so that 
the rule does not trigger the creation of a new subnet but 
just assigns IP addresses directly from the main subnet.

Updated help_text to document the new behavior.

## Screenshot
No UI changes, backend model fix only.