### PR TITLE
[fix] Correct typo in update_strategy validation error

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -302,7 +302,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             except KeyError as e:
                 raise ValidationError(
                     {
-                        "update_stragy": _(
+                        "update_strategy": _(
                             "could not determine update strategy "
                             " automatically, exception: {0}".format(e)
                         )


### PR DESCRIPTION
A small typo in the validation error key (`update_stragy`) prevents the error from being associated with the correct field. This change fixes the spelling so the validation error is properly linked to
`update_strategy`.