### PR TITLE
[ci] Failure Bot: run only on PR merge, allowed auto-retry

### DIFF
--- a/.github/workflows/bot-ci-failure.yml
+++ b/.github/workflows/bot-ci-failure.yml
@@ -7,8 +7,8 @@ on:
       - completed
 
 permissions:
-  pull-requests: write
-  actions: write  # needed for auto retries of flaky CI builds
+  pull-requests: read
+  actions: read
   contents: read
 
 concurrency:
@@ -69,6 +69,10 @@ jobs:
   call-ci-failure-bot:
     needs: find-pr
     if: ${{ needs.find-pr.outputs.pr_number != '' }}
+    permissions:
+      pull-requests: write
+      actions: write
+      contents: read
     uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-ci-failure.yml@master
     with:
       pr_number: ${{ needs.find-pr.outputs.pr_number }}

--- a/.github/workflows/bot-ci-failure.yml
+++ b/.github/workflows/bot-ci-failure.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   pull-requests: write
-  actions: read
+  actions: write  # needed for auto retries of flaky CI builds
   contents: read
 
 concurrency:
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   find-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' }}
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
       pr_author: ${{ steps.pr.outputs.author }}


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Run the workflow only when pull requests are merged. Enabled auto-retry by adding write permissions to the action workflow.