### PR TITLE
[fix] SSH session leak and silent failure on config push error

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -1,5 +1,4 @@
 import collections
-import logging
 
 import django
 import jsonschema
@@ -31,8 +30,6 @@ from ..commands import (
 from ..exceptions import NoWorkingDeviceConnectionError
 from ..signals import is_working_changed
 from ..tasks import auto_add_credentials_to_devices, launch_command
-
-logger = logging.getLogger(__name__)
 
 
 class ConnectorMixin(object):
@@ -367,9 +364,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
         if self.is_working:
             try:
                 self.connector_instance.update_config()
-            except Exception as e:
-                logger.exception(e)
-            else:
+            finally:
                 self.disconnect()
 
     def save(self, *args, **kwargs):

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -56,7 +56,14 @@ def update_config(device_id):
         return
     else:
         logger.info(f"Updating {device} (pk: {device_id})")
-        device_conn.update_config()
+        try:
+            device_conn.update_config()
+        except Exception:
+            logger.exception(
+                f"Failed to push configuration to {device} (pk: {device_id})"
+            )
+            if hasattr(device, "config"):
+                device.config.set_status_error()
 
 
 # task timeout is SSH_COMMAND_TIMEOUT plus a 20% margin

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -899,6 +899,21 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
             command.refresh_from_db()
             self.assertIn(command.connection, [dc1, dc2])
 
+    def test_update_config_disconnect_always_called(self):
+        """
+        disconnect() must be called even when connector_instance.update_config()
+        raises, so that the SSH session is never leaked.
+        """
+        dc = self._create_device_connection()
+        connector_mock = mock.Mock()
+        connector_mock.update_config.side_effect = Exception("SSH channel closed")
+        dc.connector_instance = connector_mock
+
+        with self.assertRaises(Exception):
+            dc.update_config()
+
+        connector_mock.disconnect.assert_called_once()
+
 
 class TestModelsTransaction(BaseTestModels, TransactionTestCase):
     def _prepare_conf_object(self, organization=None):
@@ -968,7 +983,7 @@ class TestModelsTransaction(BaseTestModels, TransactionTestCase):
                 self.assertEqual(mocked_exec_command.call_count, 1)
                 _assert_version_check_command(mocked_exec_command)
             conf.refresh_from_db()
-            self.assertEqual(conf.status, "modified")
+            self.assertEqual(conf.status, "error")
 
         with self.subTest("openwisp_config >= 0.6.0a"):
             conf.config = '{"dns_servers": []}'
@@ -1019,8 +1034,8 @@ class TestModelsTransaction(BaseTestModels, TransactionTestCase):
                 args, _ = mocked_exec_command.call_args_list[2]
                 self.assertEqual(args[0], "/etc/init.d/openwisp_config restart")
             conf.refresh_from_db()
-            # exit code 1 considers the update not successful
-            self.assertEqual(conf.status, "modified")
+            # failed connector command sets config status to error
+            self.assertEqual(conf.status, "error")
 
     @mock.patch("time.sleep")
     @mock.patch.object(DeviceConnection, "update_config")
@@ -1062,6 +1077,26 @@ class TestModelsTransaction(BaseTestModels, TransactionTestCase):
             mocked_active.assert_called_once()
             mocked_get_working_connection.assert_called_once()
             mocked_update_config.assert_called_once()
+
+    @capture_any_output()
+    @mock.patch(_connect_path)
+    @mock.patch("time.sleep")
+    def test_update_config_task_sets_status_error_on_failure(
+        self, mocked_sleep, mocked_connect
+    ):
+        """
+        When the SSH connector raises during a config push, the update_config
+        task must set the config status to 'error' so the failure is visible
+        in the admin dashboard rather than silently staying 'modified'.
+        """
+        conf = self._prepare_conf_object()
+        conf.config = {"general": {"timezone": "UTC"}}
+        conf.full_clean()
+        with mock.patch(_exec_command_path) as mocked_exec_command:
+            mocked_exec_command.side_effect = Exception("SSH channel closed")
+            conf.save()
+        conf.refresh_from_db()
+        self.assertEqual(conf.status, "error")
 
     @mock.patch(_connect_path)
     def test_schedule_command_called(self, connect_mocked):


### PR DESCRIPTION
## Summary

This PR fixes two issues related to connection handling and error visibility during device configuration updates.

### 1. SSH session leak
In `base/models.py`, the SSH `disconnect()` method was only executed when the operation succeeded (inside the `else` block).  
If an exception occurred, the connection remained open, potentially leading to resource leaks and connection exhaustion over time.

This has been fixed by moving the `disconnect()` call into a `finally` block, ensuring it always executes regardless of success or failure.

### 2. Silent failure in update_config task
In `tasks.py`, exceptions raised during the `update_config` task were being swallowed without updating the device status.  
As a result, devices could remain stuck in a `modified` state with no indication of failure, making debugging difficult.

This has been fixed by explicitly catching exceptions and calling `set_status_error()`, ensuring failures are properly reflected in the system and visible in the admin interface.

## Impact

- Prevents SSH connection leaks in failure scenarios
- Improves reliability of background tasks
- Ensures accurate device status reporting
- Makes failures visible and easier to debug

## Tests

- Added tests to verify that SSH connections are properly closed even when exceptions occur
- Added tests to ensure device status is correctly set to error when the update task fails

## Notes

These changes improve robustness and observability of the configuration workflow without altering existing successful execution paths.