### PR TITLE
[fix] Disallow changing configuration backend from UI #789

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -66,6 +66,15 @@ else:  # pragma: nocover
     from django.contrib.admin import ModelAdmin
 
 
+def is_recover_view(request):
+    resolver_match = getattr(request, "resolver_match", None)
+    return getattr(request, "_recover_view", False) or bool(
+        resolver_match
+        and resolver_match.url_name
+        and resolver_match.url_name.endswith("_recover")
+    )
+
+
 class SystemDefinedVariableMixin(object):
     def system_context(self, obj):
         system_context = obj.get_system_context()
@@ -349,6 +358,12 @@ class BaseForm(forms.ModelForm):
 
 class ConfigForm(AlwaysHasChangedMixin, BaseForm):
     _old_templates = None
+    readonly_backend = False
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.readonly_backend and "backend" in self.fields:
+            self.fields["backend"].disabled = True
 
     def get_temp_model_instance(self, **options):
         config_model = self.Meta.model
@@ -457,6 +472,17 @@ class ConfigInline(
     verbose_name_plural = verbose_name
     multitenant_shared_relations = ("templates",)
 
+    def get_formset(self, request, obj=None, **kwargs):
+        readonly_backend = bool(
+            obj and obj._has_config() and not is_recover_view(request)
+        )
+        kwargs["form"] = type(
+            "ConfigInlineForm",
+            (self.form,),
+            {"readonly_backend": readonly_backend},
+        )
+        return super().get_formset(request, obj, **kwargs)
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         return qs.select_related(*self.change_select_related)
@@ -468,7 +494,14 @@ class ConfigInline(
         return fields
 
     def get_readonly_fields(self, request, obj):
-        fields = super().get_readonly_fields(request, obj)
+        fields = list(super().get_readonly_fields(request, obj))
+        if (
+            obj
+            and obj._has_config()
+            and not is_recover_view(request)
+            and "backend" not in fields
+        ):
+            fields.append("backend")
         return self._error_reason_field_conditional(obj, fields)
 
     def get_fields(self, request, obj):
@@ -1082,6 +1115,12 @@ class TemplateAdmin(MultitenantAdminMixin, BaseConfigAdmin, SystemDefinedVariabl
     readonly_fields = ["system_context"]
     autocomplete_fields = ["vpn"]
 
+    def get_readonly_fields(self, request, obj=None):
+        fields = list(super().get_readonly_fields(request, obj))
+        if obj and not is_recover_view(request) and "backend" not in fields:
+            fields.append("backend")
+        return fields
+
     @admin.action(permissions=["add"])
     def clone_selected_templates(self, request, queryset):
         selectable_orgs = None
@@ -1260,6 +1299,12 @@ class VpnAdmin(
         "created",
         "modified",
     ]
+
+    def get_readonly_fields(self, request, obj=None):
+        fields = list(super().get_readonly_fields(request, obj))
+        if obj and not is_recover_view(request) and "backend" not in fields:
+            fields.append("backend")
+        return fields
 
     class Media(BaseConfigAdmin):
         js = list(BaseConfigAdmin.Media.js) + [f"{prefix}js/vpn.js"]

--- a/openwisp_controller/config/static/config/js/relevant_templates.js
+++ b/openwisp_controller/config/static/config/js/relevant_templates.js
@@ -10,9 +10,11 @@ django.jQuery(function ($) {
       return isDeviceGroup() ? "templates" : "config-0-templates";
     },
     isAddingNewObject = function () {
-      return isDeviceGroup()
-        ? !$(".add-form").length
-        : $('input[name="config-0-id"]').val().length === 0;
+      if (isDeviceGroup()) {
+        return $(".add-form").length > 0;
+      }
+      var configIdField = $('input[name="config-0-id"]');
+      return !configIdField.length || configIdField.val().length === 0;
     },
     getTemplateOptionElement = function (
       index,
@@ -123,11 +125,12 @@ django.jQuery(function ($) {
     },
     showRelevantTemplates = function () {
       var orgID = $(orgFieldSelector).val(),
-        backend = isDeviceGroup() ? "" : $(backendFieldSelector).val(),
+        backend = isDeviceGroup() ? "" : $(backendFieldSelector).val() || "",
+        configID = $('input[name="config-0-id"]').val(),
         currentSelection = getSelectedTemplates();
 
       // Hide templates if no organization or backend is selected
-      if (!orgID || (!isDeviceGroup() && backend.length === 0)) {
+      if (!orgID || (!isDeviceGroup() && backend.length === 0 && !configID)) {
         resetTemplateOptions();
         updateTemplateHelpText();
         return;
@@ -193,14 +196,23 @@ django.jQuery(function ($) {
       initTemplateField();
       var backendField = $(backendFieldSelector);
       $(orgFieldSelector).change(function () {
-        // Only fetch templates when backend field is present
-        if ($(backendFieldSelector).length > 0 || isDeviceGroup()) {
+        // Fetch templates when backend can be determined either from
+        // an editable backend field or from an existing config object.
+        if (
+          $(backendFieldSelector).length > 0 ||
+          isDeviceGroup() ||
+          !isAddingNewObject()
+        ) {
           showRelevantTemplates();
         }
       });
       // Change view: backendField is rendered on page load
       if (backendField.length > 0) {
         addChangeEventHandlerToBackendField();
+      } else if (!isDeviceGroup() && !isAddingNewObject()) {
+        // Change view for device config has readonly backend with no input element.
+        // In this case the backend is inferred server-side from config_id.
+        showRelevantTemplates();
       } else if (isDeviceGroup()) {
         // Initially request data to get templates
         initTemplateField();

--- a/openwisp_controller/config/static/config/js/vpn.js
+++ b/openwisp_controller/config/static/config/js/vpn.js
@@ -33,12 +33,29 @@ django.jQuery(function ($) {
     return el.parents(".form-row").eq(0);
   };
 
+  var getBackendValue = function () {
+    var backendInput = $("#id_backend");
+    if (backendInput.length && backendInput.val() !== undefined) {
+      return String(backendInput.val()).toLocaleLowerCase();
+    }
+    var readonlyBackendEl = $(".field-backend .readonly").first();
+    if (!readonlyBackendEl.length) {
+      return "";
+    }
+    var readonlyBackend = readonlyBackendEl.data("backend");
+    if (
+      readonlyBackend === undefined ||
+      readonlyBackend === null ||
+      String(readonlyBackend).trim() === ""
+    ) {
+      readonlyBackend = readonlyBackendEl.text().trim();
+    }
+    return String(readonlyBackend).toLocaleLowerCase();
+  };
+
   var toggleRelatedFields = function () {
     // Show IP and Subnet field only for WireGuard backend
-    var backendValue =
-        $("#id_backend").val() === undefined
-          ? ""
-          : $("#id_backend").val().toLocaleLowerCase().toLocaleLowerCase(),
+    var backendValue = getBackendValue(),
       op;
     if (backendValue.includes("wireguard") || backendValue.includes("vxlan")) {
       op = "show";
@@ -62,10 +79,12 @@ django.jQuery(function ($) {
   };
 
   // clean config when VPN backend is changed
-  $("#id_backend").change(function () {
-    $("#id_config").val("{}");
-    toggleRelatedFields();
-  });
+  if ($("#id_backend").length) {
+    $("#id_backend").change(function () {
+      $("#id_config").val("{}");
+      toggleRelatedFields();
+    });
+  }
 
   toggleRelatedFields();
 });

--- a/openwisp_controller/config/static/config/js/widget.js
+++ b/openwisp_controller/config/static/config/js/widget.js
@@ -413,6 +413,57 @@
     });
   };
 
+  var getReadonlySchemaKey = function (schemas) {
+    var readonlyBackendEl = $(".field-backend .readonly").first();
+    if (!readonlyBackendEl.length) {
+      return false;
+    }
+    var backendValue = String(
+      readonlyBackendEl.data("backend") || readonlyBackendEl.attr("data-backend") || "",
+    ).trim();
+    if (backendValue) {
+      if (schemas[backendValue] !== undefined) {
+        return backendValue;
+      }
+      var normalizedBackendValue = backendValue.toLocaleLowerCase(),
+        directSchemaKey = false;
+      $.each(Object.keys(schemas), function (index, key) {
+        if (String(key).toLocaleLowerCase() === normalizedBackendValue) {
+          directSchemaKey = key;
+          return false;
+        }
+      });
+      if (directSchemaKey) {
+        return directSchemaKey;
+      }
+    }
+    // Fallback for deployments that do not expose data-backend yet.
+    // Match readonly backend labels to schema keys using normalize().
+    var backendLabel = readonlyBackendEl.text().trim();
+    if (!backendLabel) {
+      return false;
+    }
+    var normalize = function (value) {
+      return String(value)
+        .toLocaleLowerCase()
+        .replace(/[^a-z0-9]/g, "");
+    };
+    var normalizedBackendLabel = normalize(backendLabel);
+    var schemaKey = false;
+    $.each(Object.keys(schemas), function (index, key) {
+      var normalizedBackendKey = normalize(key.split(".").pop());
+      if (
+        normalizedBackendLabel === normalizedBackendKey ||
+        normalizedBackendLabel.includes(normalizedBackendKey) ||
+        normalizedBackendKey.includes(normalizedBackendLabel)
+      ) {
+        schemaKey = key;
+        return false;
+      }
+    });
+    return schemaKey;
+  };
+
   var bindLoadUi = function () {
     $('.jsoneditor-raw:not([name*="__prefix__"]):not(.manual)').each(function (i, el) {
       // Add query parameters defined in the widget
@@ -439,7 +490,12 @@
             schemaSelector = "#id_backend, #id_config-0-backend";
           }
           var selector = $(schemaSelector),
+            schemaKey = false;
+          if (selector.length) {
             schemaKey = selector.val() || false;
+          } else {
+            schemaKey = getReadonlySchemaKey(schemas);
+          }
           // load first time
           loadUi(el, schemaKey, schemas, true);
           // reload when selector is changed

--- a/openwisp_controller/config/templates/admin/config/change_form.html
+++ b/openwisp_controller/config/templates/admin/config/change_form.html
@@ -64,6 +64,16 @@
 {% block content %}
 <div class="{% if not add %}change-form{% else %}add-form{% endif %}">
     {{ block.super }}
+    {% if not add and original %}
+    {% firstof original.config.backend original.backend "" as readonly_backend %}
+    {% if readonly_backend %}
+    <script>
+        django
+            .jQuery(".field-backend .readonly")
+            .attr("data-backend", "{{ readonly_backend|escapejs }}");
+    </script>
+    {% endif %}
+    {% endif %}
     <div class="djnjc-overlay">
         <div class="inner"></div>
     </div>

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1,10 +1,12 @@
 import io
 import json
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 from uuid import uuid4
 
 import django
+from django.contrib import admin as django_admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -12,7 +14,7 @@ from django.core.files.base import ContentFile
 from django.core.management import call_command
 from django.db import IntegrityError
 from django.db.models.signals import post_save
-from django.test import TestCase, TransactionTestCase
+from django.test import RequestFactory, TestCase, TransactionTestCase
 from django.urls import reverse
 from reversion.models import Version
 from swapper import load_model
@@ -1435,12 +1437,76 @@ class TestAdmin(
         response = self.client.get(path)
         self.assertContains(response, '<option value="netjsonconfig.OpenWrt" selected')
 
-    def test_existing_device_backend(self):
+    def test_device_backend_readonly_on_change(self):
         d = self._create_device()
         self._create_config(device=d, backend="netjsonconfig.OpenWisp")
         path = reverse(f"admin:{self.app_label}_device_change", args=[d.pk])
         response = self.client.get(path)
-        self.assertContains(response, '<option value="netjsonconfig.OpenWisp" selected')
+        self.assertContains(response, "field-backend")
+        self.assertNotContains(response, 'name="config-0-backend"')
+
+    def test_device_backend_cannot_be_changed_from_change_form(self):
+        template = Template.objects.first()
+        device = self._create_device()
+        config = self._create_config(
+            device=device,
+            backend=template.backend,
+            config=template.config,
+        )
+        original_backend = config.backend
+        alternate_backend = (
+            "netjsonconfig.OpenWisp"
+            if original_backend != "netjsonconfig.OpenWisp"
+            else "netjsonconfig.OpenWrt"
+        )
+        path = reverse(f"admin:{self.app_label}_device_change", args=[device.pk])
+        params = self._get_device_params(org=device.organization)
+        params.update(
+            {
+                "name": "device-backend-unchanged",
+                "config-0-id": str(config.pk),
+                "config-0-device": str(device.pk),
+                "config-0-backend": alternate_backend,
+                "config-INITIAL_FORMS": 1,
+            }
+        )
+        response = self.client.post(path, params)
+        self.assertNotContains(response, "errors field-backend", status_code=302)
+        config.refresh_from_db()
+        self.assertEqual(config.backend, original_backend)
+        device.refresh_from_db(fields=["name"])
+        self.assertEqual(device.name, "device-backend-unchanged")
+
+    def _build_admin_request(self, url_name=None):
+        request = RequestFactory().get("/")
+        request.user = self._get_admin()
+        if url_name:
+            request.resolver_match = SimpleNamespace(url_name=url_name)
+        return request
+
+    def test_device_backend_recover_view_behavior(self):
+        template = Template.objects.first()
+        device = self._create_device()
+        self._create_config(
+            device=device, backend=template.backend, config=template.config
+        )
+        change_request = self._build_admin_request()
+        recover_request = self._build_admin_request(
+            url_name=f"{self.app_label}_device_recover"
+        )
+        device_admin = django_admin.site._registry[Device]
+        config_inline_cls = next(
+            inline
+            for inline in device_admin.inlines
+            if getattr(inline, "model", None) is Config
+        )
+        config_inline = config_inline_cls(Device, django_admin.site)
+        self.assertIn(
+            "backend", config_inline.get_readonly_fields(change_request, device)
+        )
+        self.assertNotIn(
+            "backend", config_inline.get_readonly_fields(recover_request, device)
+        )
 
     def test_device_search(self):
         d = self._create_device(name="admin-search-test")
@@ -1502,7 +1568,7 @@ class TestAdmin(
         response = self.client.get(path)
         self.assertContains(response, '<option value="netjsonconfig.OpenWrt" selected')
 
-    def test_existing_template_backend(self):
+    def test_template_backend_readonly_on_change(self):
         t = Template.objects.first()
         t.backend = "netjsonconfig.OpenWisp"
         t.config = {
@@ -1513,7 +1579,48 @@ class TestAdmin(
         t.save()
         path = reverse(f"admin:{self.app_label}_template_change", args=[t.pk])
         response = self.client.get(path)
-        self.assertContains(response, '<option value="netjsonconfig.OpenWisp" selected')
+        self.assertContains(response, "field-backend")
+        self.assertNotContains(response, 'name="backend"')
+
+    def test_template_backend_cannot_be_changed_from_change_form(self):
+        template = self._create_template()
+        original_backend = template.backend
+        path = reverse(f"admin:{self.app_label}_template_change", args=[template.pk])
+        params = {
+            "name": "template-backend-unchanged",
+            "organization": str(template.organization_id or ""),
+            "type": template.type,
+            "backend": "totally.invalid.backend",
+            "vpn": str(template.vpn_id or ""),
+            "tags": ",".join(template.tags.names()),
+            "default_values": json.dumps(template.default_values or {}),
+            "config": json.dumps(template.config),
+        }
+        if template.auto_cert:
+            params["auto_cert"] = "on"
+        if template.default:
+            params["default"] = "on"
+        if template.required:
+            params["required"] = "on"
+        response = self.client.post(path, params)
+        self.assertNotContains(response, "errors field-backend", status_code=302)
+        template.refresh_from_db()
+        self.assertEqual(template.backend, original_backend)
+        self.assertEqual(template.name, "template-backend-unchanged")
+
+    def test_template_backend_recover_view_behavior(self):
+        template = self._create_template()
+        change_request = self._build_admin_request()
+        recover_request = self._build_admin_request(
+            url_name=f"{self.app_label}_template_recover"
+        )
+        template_admin = django_admin.site._registry[Template]
+        self.assertIn(
+            "backend", template_admin.get_readonly_fields(change_request, template)
+        )
+        self.assertNotIn(
+            "backend", template_admin.get_readonly_fields(recover_request, template)
+        )
 
     def test_preview_variables(self):
         path = reverse(f"admin:{self.app_label}_device_preview")
@@ -1625,6 +1732,49 @@ class TestAdmin(
         self.assertContains(
             response, 'value="openwisp_controller.vpn_backends.OpenVpn" selected'
         )
+
+    def test_vpn_backend_readonly_on_change(self):
+        vpn = self._create_vpn()
+        path = reverse(f"admin:{self.app_label}_vpn_change", args=[vpn.pk])
+        response = self.client.get(path)
+        self.assertContains(response, "field-backend")
+        self.assertNotContains(response, 'name="backend"')
+
+    def test_vpn_backend_cannot_be_changed_from_change_form(self):
+        vpn = self._create_vpn()
+        original_backend = vpn.backend
+        path = reverse(f"admin:{self.app_label}_vpn_change", args=[vpn.pk])
+        params = {
+            "organization": str(vpn.organization_id or ""),
+            "name": "vpn-backend-unchanged",
+            "host": vpn.host,
+            "key": vpn.key,
+            "backend": "totally.invalid.backend",
+            "ca": str(vpn.ca_id or ""),
+            "cert": str(vpn.cert_id or ""),
+            "subnet": str(vpn.subnet_id or ""),
+            "ip": str(vpn.ip_id or ""),
+            "webhook_endpoint": vpn.webhook_endpoint or "",
+            "auth_token": vpn.auth_token or "",
+            "notes": vpn.notes or "",
+            "dh": vpn.dh or "",
+            "config": json.dumps(vpn.config),
+        }
+        response = self.client.post(path, params)
+        self.assertNotContains(response, "errors field-backend", status_code=302)
+        vpn.refresh_from_db()
+        self.assertEqual(vpn.backend, original_backend)
+        self.assertEqual(vpn.name, "vpn-backend-unchanged")
+
+    def test_vpn_backend_recover_view_behavior(self):
+        vpn = self._create_vpn()
+        change_request = self._build_admin_request()
+        recover_request = self._build_admin_request(
+            url_name=f"{self.app_label}_vpn_recover"
+        )
+        vpn_admin = django_admin.site._registry[Vpn]
+        self.assertIn("backend", vpn_admin.get_readonly_fields(change_request, vpn))
+        self.assertNotIn("backend", vpn_admin.get_readonly_fields(recover_request, vpn))
 
     def test_vpn_clients_deleted(self):
         def _update_template(templates):

--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -270,13 +270,13 @@ class TestDeviceAdmin(
             + "#config-group"
         )
         self.hide_loading_overlay()
-        self.find_element(by=By.XPATH, value=f'//*[@value="{template.id}"]')
-        # Change config backed to
-        config_backend_select = Select(
-            self.find_element(by=By.NAME, value="config-0-backend")
-        )
-        config_backend_select.select_by_visible_text("OpenWISP Firmware 1.x")
-        self.wait_for_invisibility(By.XPATH, f'//*[@value="{template.id}"]')
+        with self.subTest("Backend should not be editable on change form"):
+            self.wait_for_visibility(By.CSS_SELECTOR, "#config-group .field-backend")
+            self.assertEqual(
+                len(self.web_driver.find_elements(By.NAME, "config-0-backend")), 0
+            )
+        with self.subTest("Templates should still load using stored backend"):
+            self.find_element(by=By.XPATH, value=f'//*[@value="{template.id}"]')
 
     def test_force_delete_device_with_deactivating_config(self):
         self._create_template(default=True)
@@ -649,7 +649,7 @@ class TestVpnAdmin(
 ):
     def test_vpn_edit(self):
         self.login()
-        device, vpn, template = self._create_wireguard_vpn_template()
+        _, vpn, _ = self._create_wireguard_vpn_template()
         self.open(reverse(f"admin:{self.config_app_label}_vpn_change", args=[vpn.id]))
         with self.subTest("Ca and Cert should not be visible"):
             self.wait_for_invisibility(by=By.CLASS_NAME, value="field-ca")
@@ -665,8 +665,21 @@ class TestVpnAdmin(
         # Close the configuration preview
         self.find_element(by=By.CSS_SELECTOR, value=".djnjc-overlay a.close").click()
 
-        with self.subTest("Changing VPN backend should hide webhook and authtoken"):
-            backend = Select(self.find_element(by=By.ID, value="id_backend"))
-            backend.select_by_visible_text("OpenVPN")
-            self.wait_for_invisibility(by=By.CLASS_NAME, value="field-webhook_endpoint")
-            self.wait_for_invisibility(by=By.CLASS_NAME, value="field-auth_token")
+        with self.subTest("Backend should not be editable on change form"):
+            self.wait_for_visibility(By.CSS_SELECTOR, ".field-backend .readonly")
+            self.assertEqual(len(self.web_driver.find_elements(By.ID, "id_backend")), 0)
+
+        with self.subTest("WireGuard fields should remain visible on change form"):
+            self.wait_for_visibility(by=By.CLASS_NAME, value="field-webhook_endpoint")
+            self.wait_for_visibility(by=By.CLASS_NAME, value="field-auth_token")
+
+    def test_vpn_add_backend_switches_related_fields(self):
+        self.login()
+        self.open(reverse(f"admin:{self.config_app_label}_vpn_add"))
+        backend = Select(self.find_element(by=By.ID, value="id_backend"))
+        backend.select_by_visible_text("WireGuard")
+        self.wait_for_visibility(by=By.CLASS_NAME, value="field-webhook_endpoint")
+        self.wait_for_visibility(by=By.CLASS_NAME, value="field-auth_token")
+        backend.select_by_visible_text("OpenVPN")
+        self.wait_for_invisibility(by=By.CLASS_NAME, value="field-webhook_endpoint")
+        self.wait_for_invisibility(by=By.CLASS_NAME, value="field-auth_token")

--- a/openwisp_controller/config/tests/test_views.py
+++ b/openwisp_controller/config/tests/test_views.py
@@ -171,6 +171,95 @@ class TestViews(
         )
         self.assertNotIn(str(t1.pk), templates)
 
+    def test_get_relevant_templates_uses_config_backend_if_missing(self):
+        org1 = self._create_org(name="org1")
+        config = self._create_config(organization=org1, backend="netjsonconfig.OpenWrt")
+        t1 = self._create_template(
+            name="t1",
+            organization=org1,
+            default=True,
+            backend="netjsonconfig.OpenWrt",
+            required=True,
+        )
+        t2 = self._create_template(
+            name="t2",
+            organization=org1,
+            default=True,
+            backend="netjsonconfig.OpenWisp",
+            required=True,
+        )
+        self._login()
+        response = self.client.get(
+            reverse("admin:get_relevant_templates", args=[org1.pk]),
+            {"config_id": str(config.pk)},
+        )
+        self.assertEqual(response.status_code, 200)
+        templates = response.json()
+        self.assertIn(str(t1.pk), templates)
+        self.assertNotIn(str(t2.pk), templates)
+
+    def test_get_relevant_templates_ignores_config_backend_of_other_organization(self):
+        org_owner = self._create_org_owner()
+        org1 = org_owner.organization
+        org2 = self._create_org(name="org2")
+        foreign_config = self._create_config(
+            organization=org2, backend="netjsonconfig.OpenWisp"
+        )
+        t1 = self._create_template(
+            name="t1",
+            organization=org1,
+            default=True,
+            backend="netjsonconfig.OpenWrt",
+            required=True,
+        )
+        t2 = self._create_template(
+            name="t2",
+            organization=org1,
+            default=True,
+            backend="netjsonconfig.OpenWisp",
+            required=True,
+        )
+        user = org_owner.organization_user.user
+        user.is_staff = True
+        user.save()
+        self.client.force_login(user)
+        response = self.client.get(
+            reverse("admin:get_relevant_templates", args=[org1.pk]),
+            {"config_id": str(foreign_config.pk)},
+        )
+        self.assertEqual(response.status_code, 200)
+        templates = response.json()
+        self.assertNotIn(str(t1.pk), templates)
+        self.assertNotIn(str(t2.pk), templates)
+
+    def test_get_relevant_templates_uses_config_backend_when_org_changes(self):
+        org1 = self._create_org(name="org1")
+        org2 = self._create_org(name="org2")
+        config = self._create_config(organization=org1, backend="netjsonconfig.OpenWrt")
+        t1 = self._create_template(
+            name="t1",
+            organization=org2,
+            default=True,
+            backend="netjsonconfig.OpenWrt",
+            required=True,
+        )
+        t2 = self._create_template(
+            name="t2",
+            organization=org2,
+            default=True,
+            backend="netjsonconfig.OpenWisp",
+            required=True,
+        )
+        self._login()
+        response = self.client.get(
+            reverse("admin:get_relevant_templates", args=[org2.pk]),
+            {"config_id": str(config.pk)},
+        )
+        self.assertEqual(response.status_code, 200)
+        templates = response.json()
+        self.assertIn(str(t1.pk), templates)
+        self.assertNotIn(str(t2.pk), templates)
+
     def test_get_relevant_templates_authorization(self):
         org1 = self._create_org(name="org1")
         with self.subTest("Unauthenticated user"):

--- a/openwisp_controller/config/views.py
+++ b/openwisp_controller/config/views.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from uuid import UUID
 
+from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.http import Http404, HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.utils import timezone
@@ -69,6 +70,19 @@ def get_relevant_templates(request, organization_id):
     # this filter is for shared templates
     org_filters |= Q(organization_id=None)
 
+    # On device change pages the backend field is readonly, therefore the
+    # backend query argument is not sent by the browser.
+    if not backend and config_id:
+        try:
+            config_queryset = Config.objects.only("backend")
+            if not user.is_superuser:
+                config_queryset = config_queryset.filter(
+                    device__organization_id__in=user.organizations_managed
+                )
+            backend = config_queryset.get(pk=config_id).backend
+        except (Config.DoesNotExist, ValidationError, ValueError):
+            pass
+
     filter_options = {}
     if backend:
         filter_options.update(backend=backend)
@@ -91,7 +105,7 @@ def get_relevant_templates(request, organization_id):
                 .templates.filter(org_filters)
                 .filter(**filter_options)
             )
-        except (Config.DoesNotExist, ValueError):
+        except (Config.DoesNotExist, ValidationError, ValueError):
             pass
 
     if group_id:


### PR DESCRIPTION
## What does this PR do?

  This PR makes backend read-only on Django admin change forms for device configuration, template, and VPN server, while keeping
  it selectable on create forms.

  ## Why the scope is bigger than the issue title

 The admin change made backend non-editable, which removed selectors used by existing JS and Selenium flows on change pages. The extra updates are regression/compatibility fixes to keep current admin behavior working with the new readonly contract, not additional feature work.

  ## What changed

  - Enforced UI-only readonly-on-change for backend in:
      - device configuration
      - template
      - VPN server
  - Kept backend selectable on create forms.
  - No model/API/shell restrictions added.
  - Updated JS/view logic and tests so change-page behavior remains stable when backend is readonly.
  - Added/updated regression tests for immutability, recover behavior, and backend inference paths.

  ## Files updated (and why)

  - `openwisp_controller/config/admin.py` core readonly-on-change behavior.
  - `openwisp_controller/config/tests/test_admin.py` create/change immutability + recover-view coverage.
  - `openwisp_controller/config/static/config/js/relevant_templates.js` template loading on readonly change forms.
  - `openwisp_controller/config/views.py` backend inference fallback for readonly flows with tenant safety.
  - `openwisp_controller/config/tests/test_views.py` coverage for fallback and cross-org safety.
  - `openwisp_controller/config/static/config/js/vpn.js` VPN related-field behavior with readonly backend.
  - `openwisp_controller/config/static/config/js/widget.js` schema selection fallback when backend is readonly.
  - `openwisp_controller/config/tests/test_selenium.py` aligned Selenium expectations with readonly-on-change behavior.

  ## UI Behaviour

  Manually verified in admin UI for create vs edit flows for VPN, devices, and templates.

  ### VPN
  <img width="630" height="344" alt="Screenshot 2026-03-17 at 3 19 54 PM" src="https://github.com/user-attachments/assets/2e2f8748-43e0-426b-a083-db99b8222c3d" />

  ### Devices
  <img width="630" height="344" alt="Screenshot 2026-03-17 at 3 27 11 PM" src="https://github.com/user-attachments/assets/08204f5b-40bc-4676-99e7-60d52bc9119b" />

  ### Templates
  <img width="630" height="344" alt="Screenshot 2026-03-17 at 3 17 03 PM" src="https://github.com/user-attachments/assets/1e019fa5-f78a-4862-9062-03a1d937af06" />

  ## Self-review checklist

  - [x] Change is scoped only to issue #789
  - [x] Backend remains selectable on create forms
  - [x] Backend is not editable on change forms
  - [x] No model/API/shell restriction was introduced
  - [x] Relevant tests pass
  - [x] UI behavior was manually verified for VPN, devices, and templates
  - [x] No unrelated changes were included

  Closes #789