### PR TITLE
[fix] Handle missing device connection during command execution

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -541,7 +541,11 @@ class AbstractCommand(TimeStampedEditableModel):
         # because the system couldn't connect to the device
         if exit_code is None:
             self.status = "failed"
-            self.output = self.connection.failure_reason
+            self.output = (
+                self.connection.failure_reason
+                if self.connection and self.connection.failure_reason
+                else "No device connection available"
+            )
         # one command failed
         elif exit_code != 0:
             self.status = "failed"
@@ -566,7 +570,7 @@ class AbstractCommand(TimeStampedEditableModel):
         else:
             self.connection.connect()
         # if couldn't connect to device, stop here
-        if not self.connection.is_working:
+        if not self.connection or not self.connection.is_working:
             return None
         # custom commands, perform each one separately and save output incrementally
         if self.is_custom:


### PR DESCRIPTION
In some edge cases, a command may not have any associated device connection (for example if connections are removed before execution).

In this situation, `_exec_command` assumes `self.connection` is always present and tries to access `is_working`, which can raise an `AttributeError`.

This change adds a small guard to handle a missing connection safely and avoid unexpected crashes during execution.