### PR TITLE
[fix] Invalidate controller views cache when org/group context variables change #1070

### DIFF
--- a/.github/workflows/bot-ci-failure.yml
+++ b/.github/workflows/bot-ci-failure.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 permissions:
-  pull-requests: write
+  pull-requests: read
   actions: read
   contents: read
 
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   find-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    if: ${{ github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event == 'pull_request' }}
     outputs:
       pr_number: ${{ steps.pr.outputs.number }}
       pr_author: ${{ steps.pr.outputs.author }}
@@ -35,9 +35,8 @@ jobs:
             local pr_number="$1"
             local pr_author
             pr_author=$(gh pr view "$pr_number" --repo "$REPO" --json author --jq '.author.login // empty' 2>/dev/null || echo "")
-            if [ -z "$pr_author" ]; then
-              pr_author="${{ github.event.workflow_run.actor.login }}"
-              echo "::warning::Could not fetch PR author for PR #$pr_number; falling back to @$pr_author"
+            if [ -z "$pr_author" ] || [ "$pr_author" = "null" ]; then
+              echo "::warning::Could not fetch PR author for PR #$pr_number"
             fi 
             echo "number=$pr_number" >> "$GITHUB_OUTPUT"
             echo "author=$pr_author" >> "$GITHUB_OUTPUT"
@@ -69,6 +68,10 @@ jobs:
   call-ci-failure-bot:
     needs: find-pr
     if: ${{ needs.find-pr.outputs.pr_number != '' }}
+    permissions:
+      pull-requests: write
+      actions: write
+      contents: read
     uses: openwisp/openwisp-utils/.github/workflows/reusable-bot-ci-failure.yml@master
     with:
       pr_number: ${{ needs.find-pr.outputs.pr_number }}

--- a/openwisp_controller/config/base/device_group.py
+++ b/openwisp_controller/config/base/device_group.py
@@ -15,7 +15,10 @@ from openwisp_utils.base import TimeStampedEditableModel
 from .. import settings as app_settings
 from ..signals import group_templates_changed
 from ..sortedm2m.fields import SortedManyToManyField
-from ..tasks import bulk_invalidate_config_get_cached_checksum
+from ..tasks import (
+    bulk_invalidate_config_get_cached_checksum,
+    invalidate_controller_views_for_group,
+)
 from .config import TemplatesThrough
 
 
@@ -88,6 +91,7 @@ class AbstractDeviceGroup(OrgMixin, TimeStampedEditableModel):
             bulk_invalidate_config_get_cached_checksum.delay(
                 {"device__group_id": str(self.id)}
             )
+            invalidate_controller_views_for_group.delay(str(self.id))
 
     def get_context(self):
         return deepcopy(self.context)

--- a/openwisp_controller/config/base/multitenancy.py
+++ b/openwisp_controller/config/base/multitenancy.py
@@ -12,7 +12,7 @@ from openwisp_utils.fields import FallbackBooleanChoiceField
 
 from .. import settings as app_settings
 from ..exceptions import OrganizationDeviceLimitExceeded
-from ..tasks import bulk_invalidate_config_get_cached_checksum
+from ..tasks import bulk_invalidate_config_get_cached_checksum, invalidate_controller_views_cache
 
 
 class AbstractOrganizationConfigSettings(UUIDModel):
@@ -100,6 +100,7 @@ class AbstractOrganizationConfigSettings(UUIDModel):
             bulk_invalidate_config_get_cached_checksum.delay(
                 {"device__organization_id": str(self.organization_id)}
             )
+            invalidate_controller_views_cache.delay(str(self.organization_id))
 
 
 class AbstractOrganizationLimits(models.Model):

--- a/openwisp_controller/config/base/multitenancy.py
+++ b/openwisp_controller/config/base/multitenancy.py
@@ -12,7 +12,10 @@ from openwisp_utils.fields import FallbackBooleanChoiceField
 
 from .. import settings as app_settings
 from ..exceptions import OrganizationDeviceLimitExceeded
-from ..tasks import bulk_invalidate_config_get_cached_checksum, invalidate_controller_views_cache
+from ..tasks import (
+    bulk_invalidate_config_get_cached_checksum,
+    invalidate_controller_views_cache,
+)
 
 
 class AbstractOrganizationConfigSettings(UUIDModel):

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -217,3 +217,19 @@ def invalidate_controller_views_cache(organization_id):
         Vpn.objects.filter(organization_id=organization_id).only("id").iterator()
     ):
         GetVpnView.invalidate_get_vpn_cache(vpn)
+
+
+@shared_task(base=OpenwispCeleryTask)
+def invalidate_controller_views_for_group(group_id):
+    """
+    Invalidates the DeviceChecksumView cache only for devices in the given group.
+
+    Unlike invalidate_controller_views_cache, this is scoped to a single device
+    group and does not invalidate VPN caches.
+    """
+    from .controller.views import DeviceChecksumView
+
+    Device = load_model("config", "Device")
+
+    for device in Device.objects.filter(group_id=group_id).only("id").iterator():
+        DeviceChecksumView.invalidate_get_device_cache(device)

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -433,6 +433,61 @@ class TestDevice(
         new_checksum = config.get_cached_checksum()
         self.assertNotEqual(old_checksum, new_checksum)
 
+    def test_status_update_on_org_variable_change(self):
+        org = self._get_org()
+        cs = OrganizationConfigSettings.objects.create(organization=org, context={})
+        c1 = self._create_config(organization=org)
+        c1.templates.add(
+            self._create_template(
+                name="t-with-var",
+                config={"interfaces": [{"name": "eth0", "type": "{{ ssid }}"}]},
+                default_values={"ssid": "default"},
+            )
+        )
+        c1.set_status_applied()
+        d2 = self._create_device(
+            organization=org, name="d2", mac_address="00:11:22:33:44:56"
+        )
+        c2 = self._create_config(device=d2)
+        c2.set_status_applied()
+        cs.context = {"ssid": "OrgA"}
+        cs.full_clean()
+        cs.save()
+        c1.refresh_from_db()
+        c2.refresh_from_db()
+        with self.subTest("affected config changes to modified"):
+            self.assertEqual(c1.status, "modified")
+        with self.subTest("unaffected config remains applied"):
+            self.assertEqual(c2.status, "applied")
+
+    def test_status_update_on_group_variable_change(self):
+        org = self._get_org()
+        dg = self._create_device_group(organization=org, context={})
+        d1 = self._create_device(organization=org, group=dg)
+        c1 = self._create_config(device=d1)
+        c1.templates.add(
+            self._create_template(
+                name="t-with-var",
+                config={"interfaces": [{"name": "eth0", "type": "{{ ssid }}"}]},
+                default_values={"ssid": "default"},
+            )
+        )
+        c1.set_status_applied()
+        d2 = self._create_device(
+            organization=org, group=dg, name="d2", mac_address="00:11:22:33:44:56"
+        )
+        c2 = self._create_config(device=d2)
+        c2.set_status_applied()
+        dg.context = {"ssid": "OrgA"}
+        dg.full_clean()
+        dg.save()
+        c1.refresh_from_db()
+        c2.refresh_from_db()
+        with self.subTest("affected config changes to modified"):
+            self.assertEqual(c1.status, "modified")
+        with self.subTest("unaffected config remains applied"):
+            self.assertEqual(c2.status, "applied")
+
     def test_management_ip_changed_not_emitted_on_creation(self):
         with catch_signal(management_ip_changed) as handler:
             self._create_device(organization=self._get_org())

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -440,8 +440,8 @@ class TestDevice(
         c1.templates.add(
             self._create_template(
                 name="t-with-var",
-                config={"interfaces": [{"name": "eth0", "type": "{{ ssid }}"}]},
-                default_values={"ssid": "default"},
+                config={"interfaces": [{"name": "{{ ssid }}", "type": "ethernet"}]},
+                default_values={"ssid": "eth0"},
             )
         )
         c1.set_status_applied()
@@ -468,8 +468,8 @@ class TestDevice(
         c1.templates.add(
             self._create_template(
                 name="t-with-var",
-                config={"interfaces": [{"name": "eth0", "type": "{{ ssid }}"}]},
-                default_values={"ssid": "default"},
+                config={"interfaces": [{"name": "{{ ssid }}", "type": "ethernet"}]},
+                default_values={"ssid": "eth0"},
             )
         )
         c1.set_status_applied()
@@ -480,7 +480,13 @@ class TestDevice(
         c2.set_status_applied()
         dg.context = {"ssid": "OrgA"}
         dg.full_clean()
-        dg.save()
+        patch_path = (
+            "openwisp_controller.config.base.device_group"
+            ".invalidate_controller_views_for_group"
+        )
+        with mock.patch(patch_path) as mocked_task:
+            dg.save()
+            mocked_task.delay.assert_called_once_with(str(dg.id))
         c1.refresh_from_db()
         c2.refresh_from_db()
         with self.subTest("affected config changes to modified"):


### PR DESCRIPTION
## Checklist

- [x] I have read the OpenWISP Contributing Guidelines.
- [ ] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.


## Reference to Existing Issue

Closes #1070.


## Description of Changes

When organization or device group configuration variables are updated, only
`bulk_invalidate_config_get_cached_checksum` was called to bust the Config
checksum cache. However, the `DeviceChecksumView` controller endpoint maintains
a separate cache that was never invalidated on this code path.

As a result, devices kept receiving the old (stale) checksum when polling the
controller, so they never transitioned to ``modified`` status and never pulled
the updated configuration.

**Root cause:** two separate cache layers exist for configuration checksums:

1. **Config checksum cache** — invalidated by ``bulk_invalidate_config_get_cached_checksum``
2. **DeviceChecksumView cache** — invalidated by ``invalidate_controller_views_cache``

Only layer 1 was being cleared; layer 2 was left stale.

**Fix:**

- ``openwisp_controller/config/base/multitenancy.py`` — call
  ``invalidate_controller_views_cache`` when org context changes, mirroring
  the existing behaviour already done in ``handlers.py`` when an organisation
  is disabled or enabled.

- ``openwisp_controller/config/base/device_group.py`` — add a new group-scoped
  task ``invalidate_controller_views_for_group`` instead of the org-wide
  ``invalidate_controller_views_cache``, so only the DeviceChecksumView entries
  for devices in the changed group are cleared (avoids unnecessary invalidation
  of unrelated devices and VPN caches).

- ``openwisp_controller/config/tasks.py`` — new task
  ``invalidate_controller_views_for_group(group_id)`` that clears
  ``DeviceChecksumView`` only for devices filtered by ``group_id``.

- ``openwisp_controller/config/tests/test_device.py`` — regression tests for
  both org and group variable changes; verifies only configs whose rendered
  output is actually affected transition to ``modified``, and asserts the
  group-scoped task is enqueued with the correct ``group_id``.