### PR TITLE
[fix:backport-1.2] Corrected initial field value assignment in AbstractDevice class

### DIFF
--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -325,9 +325,9 @@ class AbstractDevice(OrgMixin, BaseModel):
         if not present_values:
             return
         self.refresh_from_db(fields=present_values.keys())
-        for field in self._changed_checked_fields:
-            setattr(self, f"_initial_{field}", field)
-            setattr(self, field, present_values[field])
+        for field, value in present_values.items():
+            setattr(self, f"_initial_{field}", getattr(self, field))
+            setattr(self, field, value)
 
     def _check_name_changed(self):
         if self._initial_name == models.DEFERRED:

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -529,6 +529,20 @@ class TestDevice(
             with self.assertNumQueries(3):
                 device._check_changed_fields()
 
+    def test_deferred_fields_populated_correctly(self):
+        device = self._create_device(
+            name="deferred-test",
+            management_ip="10.0.0.1",
+        )
+        # Load the instance with deferred fields omitted
+        device = Device.objects.only("id").get(pk=device.pk)
+        device.management_ip = "10.0.0.55"
+        # Saving the device object will populate the deferred fields
+        device.save()
+        # Ensure `_initial_<field>` contains the actual value, not the field name
+        self.assertEqual(getattr(device, "_initial_management_ip"), "10.0.0.55")
+        self.assertNotEqual(getattr(device, "_initial_management_ip"), "management_ip")
+
     def test_exceed_organization_device_limit(self):
         org = self._get_org()
         org.config_limits.device_limit = 1


### PR DESCRIPTION
Backport of #1301 to 1. 2 branch.