### PR TITLE
Reconcile stuck "modified" config status on device checksum request

### DIFF
--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Q
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -144,6 +145,13 @@ class DeviceChecksumView(UpdateLastIpMixin, GetDeviceView):
     returns device's configuration checksum
     """
 
+    # Grace period before reconciling a "modified" status.
+    # If the config has been in "modified" state for longer than this,
+    # and the device is actively requesting its checksum (proving it's
+    # online and polling), we assume a previous report_status call was
+    # lost due to a transient error and reconcile the status to "applied".
+    _STATUS_RECONCILE_GRACE_SECONDS = 300  # 5 minutes
+
     def get(self, request, pk):
         device = self.get_device()
         bad_request = forbid_unallowed(request, "GET", "key", device.key)
@@ -156,9 +164,86 @@ class DeviceChecksumView(UpdateLastIpMixin, GetDeviceView):
         checksum_requested.send(
             sender=device.__class__, instance=device, request=request
         )
+        self._reconcile_modified_status(device)
         return ControllerResponse(
             device.config.get_cached_checksum(), content_type="text/plain"
         )
+
+    @staticmethod
+    def _reconcile_modified_status(device):
+        """
+        Reconciles config status for devices stuck in "modified" state.
+
+        When a device applies a new configuration but fails to report its
+        status back (e.g., due to a transient HTTP error like 502), the
+        config remains in "modified" state on the controller even though
+        the device already has the current configuration.
+
+        The device's agent will compare its local checksum with the
+        remote checksum on the next polling cycle and find they match,
+        so it won't re-download or re-report. The status stays "modified"
+        indefinitely.
+
+        This method detects this condition: if the config has been in
+        "modified" state for longer than the grace period and the device
+        is actively polling (proven by this very checksum request), we
+        set the status to "applied".
+
+        Fast path: the cached device object (from cache_memoize) is used
+        first to check the status. Only when the cached status indicates
+        "modified" do we re-query the database for the fresh state. This
+        keeps the checksum endpoint zero-query for the common case where
+        the status is already "applied".
+        """
+        # Best-effort: never let reconciliation fail the checksum endpoint.
+        try:
+            # Fast path 1: if the cached device's config is not "modified",
+            # there is nothing to reconcile.
+            try:
+                cached_config = device.config
+            except Config.DoesNotExist:
+                return
+            if cached_config is None or cached_config.status != "modified":
+                return
+
+            # Fast path 2: even if cached status is "modified", the cached
+            # `modified` timestamp gives a lower bound on the real elapsed
+            # time. If that lower bound is below the grace period, the real
+            # value cannot be above it either, so skip the DB query entirely.
+            grace = DeviceChecksumView._STATUS_RECONCILE_GRACE_SECONDS
+            cached_elapsed = (timezone.now() - cached_config.modified).total_seconds()
+            if cached_elapsed < grace:
+                return
+
+            # Slow path: re-read config fresh from the database because
+            # cache_memoize has a 30-day TTL and may be serving a stale
+            # "modified" status that was already reconciled earlier.
+            # Fetch the full Config (not ``.only()``) so that ``save()``
+            # path (via ``_check_changes``) can evaluate the checksum
+            # without triggering lazy-loads that would recompute it
+            # against a partially-loaded instance and reset status.
+            try:
+                config = Config.objects.get(device=device)
+            except Config.DoesNotExist:
+                return
+            if config.status != "modified":
+                return
+            elapsed = (timezone.now() - config.modified).total_seconds()
+            if elapsed < grace:
+                return
+            config.set_status_applied()
+            logger.info(
+                "Reconciled config status for device %s: was 'modified' "
+                "for %d seconds with device actively polling, "
+                "setting to 'applied'.",
+                device,
+                int(elapsed),
+            )
+        except Exception:
+            logger.exception(
+                "Failed to reconcile config status for device %s",
+                device,
+            )
 
     @cache_memoize(
         timeout=Config._CHECKSUM_CACHE_TIMEOUT, args_rewrite=get_device_args_rewrite

--- a/openwisp_controller/config/tests/test_controller.py
+++ b/openwisp_controller/config/tests/test_controller.py
@@ -270,6 +270,68 @@ class TestController(
                 request=response.wsgi_request,
             )
 
+    def test_device_checksum_reconciles_modified_status(self):
+        """
+        When a device with status "modified" requests its checksum,
+        and enough time has passed (grace period), the status should
+        be automatically reconciled to "applied".
+        """
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        d = self._create_device_config()
+        c = d.config
+        c.set_status_modified()
+        self.assertEqual(c.status, "modified")
+        url = reverse("controller:device_checksum", args=[d.pk])
+
+        # First request within grace period: status should stay "modified"
+        response = self.client.get(url, {"key": d.key})
+        self.assertEqual(response.status_code, 200)
+        c.refresh_from_db()
+        self.assertEqual(c.status, "modified")
+
+        # Simulate that grace period has elapsed by backdating the
+        # modified timestamp. ``.update()`` bypasses the cache
+        # invalidation signal that ``Device.save()`` would normally
+        # emit, so we invalidate the cached device explicitly to make
+        # sure the view re-reads the backdated timestamp.
+        Config.objects.filter(pk=c.pk).update(
+            modified=timezone.now()
+            - timedelta(seconds=DeviceChecksumView._STATUS_RECONCILE_GRACE_SECONDS + 1)
+        )
+        DeviceChecksumView.invalidate_get_device_cache(instance=d)
+
+        # Second request after grace period: status should be reconciled
+        # to "applied"
+        response = self.client.get(url, {"key": d.key})
+        self.assertEqual(response.status_code, 200)
+        c.refresh_from_db()
+        self.assertEqual(c.status, "applied")
+
+    def test_device_checksum_no_reconcile_for_applied(self):
+        """Status "applied" should not be changed."""
+        d = self._create_device_config()
+        c = d.config
+        c.set_status_applied()
+        url = reverse("controller:device_checksum", args=[d.pk])
+        response = self.client.get(url, {"key": d.key})
+        self.assertEqual(response.status_code, 200)
+        c.refresh_from_db()
+        self.assertEqual(c.status, "applied")
+
+    def test_device_checksum_no_reconcile_within_grace_period(self):
+        """Status should not be reconciled if within the grace period."""
+        d = self._create_device_config()
+        c = d.config
+        c.set_status_modified()
+        url = reverse("controller:device_checksum", args=[d.pk])
+        response = self.client.get(url, {"key": d.key})
+        self.assertEqual(response.status_code, 200)
+        c.refresh_from_db()
+        self.assertEqual(c.status, "modified")
+
     def test_device_checksum_bad_uuid(self):
         d = self._create_device_config()
         pk = "{}-wrong".format(d.pk)


### PR DESCRIPTION
## Summary

When a device applies a new configuration but fails to report its status back to the controller (e.g., due to a transient HTTP 502 error during server maintenance), the config status remains `modified` indefinitely.

### Root Cause

The device agent (openwisp-config) compares its local checksum with the remote checksum on subsequent polling cycles. Since the checksums match (the device already has the current config), the agent skips re-downloading and never calls `report_status`. The controller keeps showing `modified` even though the device is up to date.

While the agent does delete checksums when `report_status` fails (triggering a re-download on the next cycle), this self-healing mechanism can fail when:
- The server has extended downtime covering multiple polling cycles
- Multiple server restarts interrupt the healing process
- The agent's retry backoff exceeds the server's recovery time

### Fix

In `DeviceChecksumView.get()`, after returning the checksum, check if the device's config has been in `modified` state for longer than a grace period (5 minutes). If so, and the device is actively polling (proven by this checksum request), reconcile the status to `applied`.

The grace period ensures we don't prematurely reconcile during the normal apply cycle (download → apply → report).

### Backward Compatibility

This fix is entirely server-side and requires no changes to the openwisp-config agent. It works with all existing agent versions.

### Tests

Added 3 unit tests:
- `test_device_checksum_reconciles_modified_status`: Verifies reconciliation after grace period
- `test_device_checksum_no_reconcile_for_applied`: Verifies no false reconciliation
- `test_device_checksum_no_reconcile_within_grace_period`: Verifies grace period is respected


## Related Issues

Related #1306 — SSH connection leaked when update_config() raises an exception
Related #1070 — Device config status does not update to "modified" when organization variable is changed
Related #182 — Add synchronized update strategy
Related openwisp/openwisp-config#172 — The agent may be stopped and started while the configuration is applied
