### PR TITLE
[fix] Guard missing skip_push_update_on_save in DeviceRegisterView

### DIFF
--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -475,7 +475,19 @@ class DeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
         normalized_name = name.replace(":", "").replace("-", "").lower()
         if normalized_name != normalized_mac:
             device.name = name
-            device.skip_push_update_on_save()
+            # NOTE: ``device.skip_push_update_on_save()`` is defined on
+            # AbstractDevice, but we guard the call defensively so that
+            # subclasses or older installations that may lack the method
+            # do not crash during factory-reset re-registration.
+            skip = getattr(device, "skip_push_update_on_save", None)
+            if callable(skip):
+                skip()
+            else:
+                logger.warning(
+                    "Device %s does not implement skip_push_update_on_save(); "
+                    "continuing registration without push-skip optimization.",
+                    device.pk,
+                )
 
 
 class GetVpnView(SingleObjectMixin, View):


### PR DESCRIPTION
## Problem

`DeviceRegisterView._update_device_name` calls `device.skip_push_update_on_save()` whenever an agent re-registers with a hostname that differs from the MAC address. That method is referenced in the view but is **not implemented** on the `Device` model, so every such re-registration crashes with HTTP 500:

```
AttributeError: 'Device' object has no attribute 'skip_push_update_on_save'
```

### Impact

This breaks the `consistent_registration` / factory-reset workflow:

1. A router does a factory reset → loses its local UUID/key
2. The agent computes `consistent_key = md5(MAC + "+" + secret)` and POSTs `/controller/register/`
3. OpenWISP looks up the existing device by `key=consistent_key` and finds it
4. The view enters the `_update_device_name` branch (because the hostname `<MAC>-fwr-unprovisioned` differs from the bare MAC)
5. The bogus method call raises `AttributeError` → server returns HTTP 500
6. The agent sees a response without `X-Openwisp-Controller` header (the 500 error page doesn't have it) and aborts
7. After 6 crash retries `procd` kills the agent

The router never recovers from a factory reset until an admin manually deletes the existing device record. This affects every deployment that uses `consistent_registration` and runs agents with hostnames that don't equal the bare MAC (e.g. anything that names devices by location or status).

## Reproduction

```bash
# On a router that has been registered before:
uci -q delete openwisp.http.uuid
uci -q delete openwisp.http.key
uci set openwisp.http.shared_secret='<your secret>'
uci commit openwisp
rm -rf /tmp/openwisp/
/etc/init.d/openwisp-config restart
logread | grep openwisp
```

Result before patch:
```
openwisp: Registering device...
openwisp: Invalid url: missing X-Openwisp-Controller header
```

## Fix

Wrap the call in `getattr` so the registration succeeds whether the helper method exists or not. The actual `skip_push_update_on_save` method can be re-introduced separately without changing this site again — the guard is forward-compatible.

Result after patch:
```
openwisp: Registering device...
openwisp: Existing device registered successfully as <hostname>, id: <uuid>
```

The device keeps its existing UUID and key (because `consistent_registration` is now able to find it), and the agent continues with the same configuration as before the reset.

## Compatibility

- **Backward-compatible**: if `skip_push_update_on_save` is reintroduced on the `Device` model later, the guard happily calls it.
- **Client-agnostic**: no agent-side changes are required. Every existing `openwisp-config` version benefits immediately.
- **No behaviour change for the success path**: when the hostname equals the MAC, this branch is not entered at all, so unaffected.

## Tested on

- openwisp-controller 1.2 (Docker, `openwisp/openwisp-dashboard:25.10.2`)
- openwisp-config agent on OpenWrt 25.x (BusyBox ash) and OpenWrt 24.x
- Cudy TR3000 v1, GL.iNet GL-AR300M16

## Related Issues

Related #212 — If default templates contain a flaw, auto-registration will fail
Related #1306 — SSH connection leaked when update_config() raises an exception
Related #1334 — Shared default templates not re-assigned after device organization change
