### PR TITLE
fix(geo): skip WHOIS and estimated location on deactivated devices

### DIFF
--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -210,7 +210,7 @@ class WHOISService:
         Trigger WHOIS lookup based on the conditions of `_need_whois_lookup`.
         Tasks are triggered on commit to ensure redundant data is not created.
         """
-        if not self.device.active:
+        if self.device.is_deactived():
             return
         new_ip = self.device.last_ip
         initial_ip = self.device._initial_last_ip
@@ -231,7 +231,7 @@ class WHOISService:
         when the data is older than
         ``OPENWISP_CONTROLLER_WHOIS_REFRESH_THRESHOLD_DAYS``.
         """
-        if not self.device.active:
+        if self.device.is_deactived():
             return
         ip_address = self.device.last_ip
         if not self.is_valid_public_ip_address(ip_address):

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -210,11 +210,7 @@ class WHOISService:
         Trigger WHOIS lookup based on the conditions of `_need_whois_lookup`.
         Tasks are triggered on commit to ensure redundant data is not created.
         """
-<<<<<<< HEAD
         if self.device.is_deactivated():
-=======
-        if self.device.is_deactived():
->>>>>>> d3173be671ff5dbef364d55ec120a8c083eaf7d4
             return
         new_ip = self.device.last_ip
         initial_ip = self.device._initial_last_ip
@@ -235,11 +231,7 @@ class WHOISService:
         when the data is older than
         ``OPENWISP_CONTROLLER_WHOIS_REFRESH_THRESHOLD_DAYS``.
         """
-<<<<<<< HEAD
         if self.device.is_deactivated():
-=======
-        if self.device.is_deactived():
->>>>>>> d3173be671ff5dbef364d55ec120a8c083eaf7d4
             return
         ip_address = self.device.last_ip
         if not self.is_valid_public_ip_address(ip_address):

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -210,7 +210,7 @@ class WHOISService:
         Trigger WHOIS lookup based on the conditions of `_need_whois_lookup`.
         Tasks are triggered on commit to ensure redundant data is not created.
         """
-        if not self.device.active:
+        if self.device.is_deactivated():
             return
         new_ip = self.device.last_ip
         initial_ip = self.device._initial_last_ip
@@ -231,7 +231,7 @@ class WHOISService:
         when the data is older than
         ``OPENWISP_CONTROLLER_WHOIS_REFRESH_THRESHOLD_DAYS``.
         """
-        if not self.device.active:
+        if self.device.is_deactivated():
             return
         ip_address = self.device.last_ip
         if not self.is_valid_public_ip_address(ip_address):

--- a/openwisp_controller/config/whois/service.py
+++ b/openwisp_controller/config/whois/service.py
@@ -210,6 +210,8 @@ class WHOISService:
         Trigger WHOIS lookup based on the conditions of `_need_whois_lookup`.
         Tasks are triggered on commit to ensure redundant data is not created.
         """
+        if not self.device.active:
+            return
         new_ip = self.device.last_ip
         initial_ip = self.device._initial_last_ip
         if force_lookup or self._need_whois_lookup(new_ip):
@@ -229,6 +231,8 @@ class WHOISService:
         when the data is older than
         ``OPENWISP_CONTROLLER_WHOIS_REFRESH_THRESHOLD_DAYS``.
         """
+        if not self.device.active:
+            return
         ip_address = self.device.last_ip
         if not self.is_valid_public_ip_address(ip_address):
             return

--- a/openwisp_controller/config/whois/tests/tests.py
+++ b/openwisp_controller/config/whois/tests/tests.py
@@ -3,6 +3,7 @@ import importlib
 from datetime import timedelta
 from io import StringIO
 from unittest import mock
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.conf import settings
@@ -21,7 +22,9 @@ from selenium.common.exceptions import UnexpectedAlertPresentException
 from selenium.webdriver.common.by import By
 from swapper import load_model
 
+from openwisp_controller.config.models import Device
 from openwisp_controller.config.signals import whois_fetched, whois_lookup_skipped
+from openwisp_controller.config.whois.service import WhoIsService
 from openwisp_utils.tests import SeleniumTestMixin, catch_signal
 
 from ....tests.utils import TestAdminMixin
@@ -347,7 +350,7 @@ class TestWHOIS(CreateWHOISMixin, TestAdminMixin, TestCase):
         )
         args = ["--noinput"]
         # 4 queries (3 for each device's last_ip update) and 1 for fetching devices
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(7):
             call_command("clear_last_ip", *args, stdout=out, stderr=StringIO())
 
     @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
@@ -1186,3 +1189,26 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
                 _assert_no_js_errors()
             except UnexpectedAlertPresentException:
                 self.fail("XSS vulnerability detected in WHOIS details admin view.")
+
+
+class TestWhoisDeactivated(TestCase):
+    def setUp(self):
+        self.device = Device.objects.create(name="test-device")
+
+    @patch("openwisp_controller.config.whois.service.fetch_whois_details.delay")
+    def test_process_ip_skips_when_deactivated(self, mock_task):
+        self.device._is_deactivated = True
+
+        service = WhoIsService(self.device)
+        service.process_ip_data_and_location()
+
+        mock_task.assert_not_called()
+
+    @patch("openwisp_controller.config.whois.service.fetch_whois_details.delay")
+    def test_update_whois_skips_when_deactivated(self, mock_task):
+        self.device._is_deactivated = True
+
+        service = WhoIsService(self.device)
+        service.update_whois_info()
+
+        mock_task.assert_not_called()

--- a/openwisp_controller/config/whois/tests/tests.py
+++ b/openwisp_controller/config/whois/tests/tests.py
@@ -22,9 +22,22 @@ from selenium.common.exceptions import UnexpectedAlertPresentException
 from selenium.webdriver.common.by import By
 from swapper import load_model
 
+<<<<<<< HEAD
 from openwisp_controller.config.models import Device
 from openwisp_controller.config.signals import whois_fetched, whois_lookup_skipped
 from openwisp_controller.config.whois.service import WhoIsService
+=======
+<<<<<<< HEAD
+from openwisp_controller.config import settings as app_settings
+from openwisp_controller.config.models import Device
+from openwisp_controller.config.signals import whois_fetched, whois_lookup_skipped
+from openwisp_controller.config.whois.service import WHOISService
+=======
+from openwisp_controller.config.models import Device
+from openwisp_controller.config.signals import whois_fetched, whois_lookup_skipped
+from openwisp_controller.config.whois.service import WhoIsService
+>>>>>>> 8d798b46448620c8536e84519b69134dc556bd56
+>>>>>>> 38cb7ad (test(geo): add regression tests for deactivated device WHOIS handling)
 from openwisp_utils.tests import SeleniumTestMixin, catch_signal
 
 from ....tests.utils import TestAdminMixin
@@ -349,7 +362,14 @@ class TestWHOIS(CreateWHOISMixin, TestAdminMixin, TestCase):
             name="default.test.device4", mac_address="66:33:44:55:66:77"
         )
         args = ["--noinput"]
+<<<<<<< HEAD
+
+=======
         # 4 queries (3 for each device's last_ip update) and 1 for fetching devices
+<<<<<<< HEAD
+=======
+>>>>>>> 8d798b46448620c8536e84519b69134dc556bd56
+>>>>>>> 38cb7ad (test(geo): add regression tests for deactivated device WHOIS handling)
         with self.assertNumQueries(7):
             call_command("clear_last_ip", *args, stdout=out, stderr=StringIO())
 
@@ -1191,6 +1211,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
                 self.fail("XSS vulnerability detected in WHOIS details admin view.")
 
 
+<<<<<<< HEAD
 class TestWhoisDeactivated(TestCase):
     def setUp(self):
         self.device = Device.objects.create(name="test-device")
@@ -1212,3 +1233,30 @@ class TestWhoisDeactivated(TestCase):
         service.update_whois_info()
 
         mock_task.assert_not_called()
+=======
+class TestWHOISDeactivated(TransactionTestCase):
+    def setUp(self):
+        self.device = self._create_device()
+        self.device.last_ip = "8.8.8.8"  # public IP
+        self.device.save()
+
+    @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
+    @mock.patch("openwisp_controller.config.whois.service.fetch_whois_details.delay")
+    def test_process_ip_skips_when_deactivated(self, mock_task):
+        self.device._is_deactivated = True
+
+        service = WHOISService(self.device)
+        service.process_ip_data_and_location()
+
+        self.assertEqual(mock_task.call_count, 0)
+
+    @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
+    @mock.patch("openwisp_controller.config.whois.service.fetch_whois_details.delay")
+    def test_process_ip_runs_when_active(self, mock_task):
+        self.device._is_deactivated = False
+
+        service = WHOISService(self.device)
+        service.process_ip_data_and_location()
+
+        self.assertEqual(mock_task.call_count, 1)
+>>>>>>> 38cb7ad (test(geo): add regression tests for deactivated device WHOIS handling)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #1325

## Description of Changes
This PR fixes an issue where WHOIS and Estimated Location lookups were still being triggered for deactivated devices.

Previously, the logic responsible for scheduling WHOIS lookup tasks (process_ip_data_and_location and update_whois_info) did not check whether the device was active. As a result, background tasks continued to run even when a device was deactivated, causing WHOIS and location data to be repopulated unintentionally.

This change introduces a guard condition to skip these operations when the device is inactive:
Added an early return in process_ip_data_and_location
Added an early return in update_whois_info

This ensures that:
No WHOIS lookup tasks are scheduled for deactivated devices
No unnecessary background processing occurs
Device state is respected consistently
