### PR TITLE
[change] Added generic enforcement of deactivated devices #1338

### DIFF
--- a/docs/user/device-config-status.rst
+++ b/docs/user/device-config-status.rst
@@ -35,9 +35,9 @@ scheduled to be removed from the device.
 
 The device has been deactivated. The configuration applied through
 OpenWISP has been removed, and any other operation to manage the device
-will be prevented or rejected. This also includes network operations
-which would normally push configuration updates, for example changes to
-shared templates.
+will be prevented or rejected. This also includes network operations which
+would normally push configuration updates, for example changes to shared
+templates.
 
 .. note::
 

--- a/docs/user/device-config-status.rst
+++ b/docs/user/device-config-status.rst
@@ -35,7 +35,9 @@ scheduled to be removed from the device.
 
 The device has been deactivated. The configuration applied through
 OpenWISP has been removed, and any other operation to manage the device
-will be prevented or rejected.
+will be prevented or rejected. This also includes network operations
+which would normally push configuration updates, for example changes to
+shared templates.
 
 .. note::
 

--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -679,6 +679,7 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, CopyableFieldsAdmin):
             form = ChangeDeviceGroupForm(data=request.POST, org_id=org_id)
             if form.is_valid():
                 group = form.cleaned_data["device_group"]
+                queryset = queryset.filter(_is_deactivated=False)
                 # Evaluate queryset to store old group id
                 old_group_qs = list(queryset)
                 queryset.update(group=group or None)

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -482,11 +482,6 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         except ObjectDoesNotExist:
             return
         else:
-            # Skip deactivated (and deactivating) configs: they are meant to stay
-            # inert, so a certificate renewal must not recompute their checksum or
-            # mark them modified again.
-            if config.is_deactivating_or_deactivated():
-                return
             transaction.on_commit(config.update_status_if_checksum_changed)
 
     @classmethod
@@ -862,13 +857,15 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         self._invalidate_backend_instance_cache()
         old_checksum = self.checksum
         self.add_default_templates()
-        if self.device._get_group():
-            self.device.manage_devices_group_templates(
-                device_ids=self.device.id,
-                old_group_ids=None,
-                group_id=self.device.group_id,
+        if self.device._has_group():
+            # Call manage_group_templates directly rather than going through
+            # manage_devices_group_templates, which would skip the device because
+            # it is still marked as deactivated at this point in the activation flow.
+            self.manage_group_templates(
+                self.device.group.templates.all(),
+                self.get_template_model().objects.none(),
             )
-        del self.backend_instance
+        self._invalidate_backend_instance_cache()
         if old_checksum == self.checksum:
             # Accelerate activation if the configuration remains
             # unchanged (i.e. empty configuration)
@@ -1001,6 +998,9 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         Config = load_model("config", "Config")
         Template = load_model("config", "Template")
         config = Config.objects.get(pk=instance_id)
+        # All modification operations are blocked on deactivated devices.
+        # Thus, a user cannot edit the backend for device when it is deactivating.
+        # Therefore. it will be safe to block this operation here. 
         if config.is_deactivating_or_deactivated():
             return
         device_group = config.device.group

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -1000,7 +1000,7 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         config = Config.objects.get(pk=instance_id)
         # All modification operations are blocked on deactivated devices.
         # Thus, a user cannot edit the backend for device when it is deactivating.
-        # Therefore. it will be safe to block this operation here.
+        # Therefore, it will be safe to block this operation here.
         if config.is_deactivating_or_deactivated():
             return
         device_group = config.device.group

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -996,6 +996,8 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         Config = load_model("config", "Config")
         Template = load_model("config", "Template")
         config = Config.objects.get(pk=instance_id)
+        if config.is_deactivating_or_deactivated():
+            return
         device_group = config.device.group
         if not device_group:
             return

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -1000,7 +1000,7 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         config = Config.objects.get(pk=instance_id)
         # All modification operations are blocked on deactivated devices.
         # Thus, a user cannot edit the backend for device when it is deactivating.
-        # Therefore. it will be safe to block this operation here. 
+        # Therefore. it will be safe to block this operation here.
         if config.is_deactivating_or_deactivated():
             return
         device_group = config.device.group

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -482,6 +482,11 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
         except ObjectDoesNotExist:
             return
         else:
+            # Skip deactivated (and deactivating) configs: they are meant to stay
+            # inert, so a certificate renewal must not recompute their checksum or
+            # mark them modified again.
+            if config.is_deactivating_or_deactivated():
+                return
             transaction.on_commit(config.update_status_if_checksum_changed)
 
     @classmethod

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -501,6 +501,11 @@ class AbstractDevice(OrgMixin, BaseModel):
             old_group_ids = [old_group_ids]
         for device_id, old_group_id in zip(device_ids, old_group_ids):
             device = Device.objects.get(pk=device_id)
+            if device.is_deactivated():
+                # Skip deactivated devices: their configuration is intentionally
+                # emptied during deactivation, so re-applying group templates
+                # would break that state and trigger a push to the device.
+                continue
             if not hasattr(device, "config"):
                 device.create_default_config()
             config_created = hasattr(device, "config")

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -307,7 +307,9 @@ class AbstractDevice(OrgMixin, BaseModel):
 
     def delete(self, using=None, keep_parents=False, check_deactivated=True):
         if check_deactivated and (not self.is_fully_deactivated()):
-            raise PermissionDenied("The device must be deactivated prior to deletion")
+            raise PermissionDenied(
+                _("The device must be deactivated prior to deletion")
+            )
         return super().delete(using, keep_parents)
 
     def _check_changed_fields(self):

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -481,7 +481,11 @@ class AbstractDevice(OrgMixin, BaseModel):
         creates a new config instance to apply group templates
         if group has templates.
         """
-        if self.is_deactivated() or not (self.group and self.group.templates.exists()):
+        if self.is_deactivated():
+            # All modification operations are blocked on deactivated devices.
+            # Hence, default config should not be created for deactivated devices.
+            return
+        if not (self.group and self.group.templates.exists()):
             return
         config = self.get_temp_config_instance(
             backend=app_settings.DEFAULT_BACKEND, **options

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -183,9 +183,11 @@ class AbstractDevice(OrgMixin, BaseModel):
         )
 
     def is_deactivated(self):
+        """Return whether deactivation has been initiated."""
         return self._is_deactivated
 
     def is_fully_deactivated(self):
+        """Return whether the device and its configuration are fully deactivated."""
         return self.is_deactivated() and (
             not self._has_config() or self.config.is_deactivated()
         )

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -185,6 +185,11 @@ class AbstractDevice(OrgMixin, BaseModel):
     def is_deactivated(self):
         return self._is_deactivated
 
+    def is_fully_deactivated(self):
+        return self.is_deactivated() and (
+            not self._has_config() or self.config.is_deactivated()
+        )
+
     def deactivate(self):
         if self.is_deactivated():
             # The device has already been deactivated.
@@ -299,10 +304,7 @@ class AbstractDevice(OrgMixin, BaseModel):
             self._check_changed_fields()
 
     def delete(self, using=None, keep_parents=False, check_deactivated=True):
-        if check_deactivated and (
-            not self.is_deactivated()
-            or (self._has_config() and not self.config.is_deactivated())
-        ):
+        if check_deactivated and (not self.is_fully_deactivated()):
             raise PermissionDenied("The device must be deactivated prior to deletion")
         return super().delete(using, keep_parents)
 
@@ -479,7 +481,7 @@ class AbstractDevice(OrgMixin, BaseModel):
         creates a new config instance to apply group templates
         if group has templates.
         """
-        if not (self.group and self.group.templates.exists()):
+        if self.is_deactivated() or not (self.group and self.group.templates.exists()):
             return
         config = self.get_temp_config_instance(
             backend=app_settings.DEFAULT_BACKEND, **options

--- a/openwisp_controller/config/base/device_group.py
+++ b/openwisp_controller/config/base/device_group.py
@@ -110,7 +110,7 @@ class AbstractDeviceGroup(OrgMixin, TimeStampedEditableModel):
         device_group = DeviceGroup.objects.get(id=group_id)
         templates = Template.objects.filter(pk__in=template_ids)
         old_templates = Template.objects.filter(pk__in=old_template_ids)
-        for device in device_group.device_set.iterator():
+        for device in device_group.device_set.exclude(_is_deactivated=True).iterator():
             if not hasattr(device, "config"):
                 device.create_default_config()
             device.config.manage_group_templates(templates, old_templates)

--- a/openwisp_controller/config/base/device_group.py
+++ b/openwisp_controller/config/base/device_group.py
@@ -110,7 +110,7 @@ class AbstractDeviceGroup(OrgMixin, TimeStampedEditableModel):
         device_group = DeviceGroup.objects.get(id=group_id)
         templates = Template.objects.filter(pk__in=template_ids)
         old_templates = Template.objects.filter(pk__in=old_template_ids)
-        for device in device_group.device_set.iterator():
-            for device in device_group.device_set.iterator():
+        for device in device_group.device_set.exclude(_is_deactivated=True).iterator():
+            if not hasattr(device, "config"):
                 device.create_default_config()
             device.config.manage_group_templates(templates, old_templates)

--- a/openwisp_controller/config/base/device_group.py
+++ b/openwisp_controller/config/base/device_group.py
@@ -110,7 +110,7 @@ class AbstractDeviceGroup(OrgMixin, TimeStampedEditableModel):
         device_group = DeviceGroup.objects.get(id=group_id)
         templates = Template.objects.filter(pk__in=template_ids)
         old_templates = Template.objects.filter(pk__in=old_template_ids)
-        for device in device_group.device_set.exclude(_is_deactivated=True).iterator():
-            if not hasattr(device, "config"):
+        for device in device_group.device_set.iterator():
+            for device in device_group.device_set.iterator():
                 device.create_default_config()
             device.config.manage_group_templates(templates, old_templates)

--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -416,7 +416,7 @@ class DeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
         try:
             device = self.model.objects.select_related("config").get(key=key)
             if device.is_deactivated():
-                return ControllerResponse(_("error: device deactivated"), status=403)
+                return ControllerResponse("error: device deactivated", status=403)
             # update device info
             for attr in self.UPDATABLE_FIELDS:
                 if attr in request.POST:

--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -416,7 +416,7 @@ class DeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
         try:
             device = self.model.objects.select_related("config").get(key=key)
             if device.is_deactivated():
-                return ControllerResponse("error: device deactivated", status=403)
+                return ControllerResponse(_("error: device deactivated"), status=403)
             # update device info
             for attr in self.UPDATABLE_FIELDS:
                 if attr in request.POST:

--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -408,7 +408,9 @@ class DeviceRegisterView(UpdateLastIpMixin, CsrfExtemptMixin, View):
         # (key is not None only if CONSISTENT_REGISTRATION is enabled)
         new = False
         try:
-            device = self.model.objects.get(key=key)
+            device = self.model.objects.select_related("config").get(key=key)
+            if device.is_deactivated():
+                return ControllerResponse("error: device deactivated", status=403)
             # update device info
             for attr in self.UPDATABLE_FIELDS:
                 if attr in request.POST:

--- a/openwisp_controller/config/controller/views.py
+++ b/openwisp_controller/config/controller/views.py
@@ -230,6 +230,12 @@ class DeviceUpdateInfoView(CsrfExtemptMixin, GetDeviceView):
         bad_request = forbid_unallowed(request, "POST", "key", device.key)
         if bad_request:
             return bad_request
+        if device.is_deactivated():
+            # Inventory metadata must not be recorded for deactivated devices.
+            # GetDeviceView already returns 404 once the config is fully
+            # "deactivated"; this additionally rejects the transient
+            # "deactivating" state, where the device flag is already set.
+            return ControllerResponse("error: device deactivated", status=403)
         # update device information
         for attr in self.UPDATABLE_FIELDS:
             if attr in request.POST:

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1,3 +1,4 @@
+import csv
 import io
 import json
 import os
@@ -652,6 +653,68 @@ class TestAdmin(
             required_perms=["change"],
             extra_payload={"device_group": group.pk, "apply": True},
         )
+
+    def test_device_export_includes_deactivated_config_status(self):
+        device = self._create_device_config()
+        device.deactivate()
+        response = self.client.post(
+            reverse(f"admin:{self.app_label}_device_export"), {"format": "0"}
+        )
+        self.assertNotContains(response, "error")
+        rows = list(csv.reader(response.content.decode().splitlines()))
+        header = rows[0]
+        status_col = header.index("config_status")
+        self.assertEqual(rows[1][status_col], "deactivated")
+
+    def test_device_import_deactivated_config_status_ignored(self):
+        # config_status is readonly=True in DeviceResource, so importing a
+        # row with config_status=deactivated must NOT create a deactivated device.
+        org = self._get_org(org_name="default")
+        contents = (
+            "name,mac_address,organization,group,model,os,system,notes,last_ip,"
+            "management_ip,config_status,config_backend,config_data,config_context,"
+            "config_templates,created,modified,id,key,organization_id,group_id\n"
+            "test-deactivated,00:11:22:33:44:66,{org_name},,,,,,,,"
+            "deactivated,netjsonconfig.OpenWrt,,,,"
+            "2022-10-17 15:26:51,2022-10-17 15:26:51,"
+            "559871c5-ce3d-4c7e-9176-fb6623d562f3,934d0799b1ce3a454bbb585cda1d7a49,"
+            "{org_id},"
+        ).strip()
+        contents = contents.format(org_name=org.name, org_id=org.id)
+        csv_file = ContentFile(contents)
+        response = self.client.post(
+            reverse(f"admin:{self.app_label}_device_import"),
+            {"format": "0", "import_file": csv_file, "file_name": "test.csv"},
+        )
+        self.assertFalse(response.context["result"].has_errors())
+        confirm_form = response.context["confirm_form"]
+        data = confirm_form.initial
+        response = self.client.post(
+            reverse(f"admin:{self.app_label}_device_process_import"), data, follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        device = Device.objects.get(name="test-deactivated")
+        self.assertFalse(device._is_deactivated)
+        self.assertTrue(device._has_config())
+        self.assertNotEqual(device.config.status, "deactivated")
+
+    def test_change_group_action_skips_deactivated_device(self):
+        path = reverse(f"admin:{self.app_label}_device_changelist")
+        org = self._get_org(org_name="default")
+        group = self._create_device_group(name="test-group", organization=org)
+        device = self._create_device(organization=org)
+        device.deactivate()
+        post_data = {
+            "_selected_action": [device.pk],
+            "action": "change_group",
+            "csrfmiddlewaretoken": "test",
+            "apply": True,
+            "device_group": group.pk,
+        }
+        response = self.client.post(path, post_data, follow=True)
+        self.assertEqual(response.status_code, 200)
+        device.refresh_from_db()
+        self.assertIsNone(device.group)
 
     def test_device_import_with_group_apply_templates(self):
         org = self._get_org(org_name="default")
@@ -3037,6 +3100,26 @@ class TestDeviceGroupAdminTransaction(
                 response = self.client.post(path, data, follow=True)
                 self.assertEqual(response.status_code, 200)
                 self.assertEqual(len(mocked.call_args_list), 2)
+
+        with self.subTest("Change group skips deactivated devices in signals"):
+            device3 = self._create_device(
+                organization=org1,
+                group=dg1,
+                name="default.test.device3",
+                mac_address="AA:BB:CC:DD:EE:01",
+            )
+            device3.deactivate()
+            data = post_data.copy()
+            data["_selected_action"] = [device1.pk, device3.pk]
+            data["device_group"] = str(dg2.pk)
+            with patch.object(Device, "_send_device_group_changed_signal") as mocked:
+                response = self.client.post(path, data, follow=True)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(len(mocked.call_args_list), 1)
+            device1.refresh_from_db()
+            device3.refresh_from_db()
+            self.assertEqual(device1.group_id, dg2.id)
+            self.assertEqual(device3.group_id, dg1.id)
 
         device2.organization = org2
         device2.save()

--- a/openwisp_controller/config/tests/test_config.py
+++ b/openwisp_controller/config/tests/test_config.py
@@ -564,6 +564,24 @@ class TestConfig(
         self.assertEqual(config.templates.count(), 0)
         self.assertEqual(cert.revoked, True)
 
+    def test_certificate_updated_skipped_for_deactivated_config(self):
+        self._create_template(type="vpn", vpn=self._create_vpn(), default=True)
+        config = self._create_config(organization=self._get_org())
+        cert = config.vpnclient_set.first().cert
+        config.deactivate()
+        config.refresh_from_db()
+        self.assertEqual(config.status, "deactivating")
+        # VpnClient is deleted on deactivation; cert is auto-revoked.
+        self.assertEqual(config.vpnclient_set.count(), 0)
+        # Un-revoke the cert so certificate_updated() bypasses the early
+        # "if revoked: return" guard and hits the ObjectDoesNotExist path.
+        cert.revoked = False
+        cert.save()
+        # Config status must not change: certificate_updated() returns early
+        # because the VpnClient was deleted during deactivation.
+        config.refresh_from_db()
+        self.assertEqual(config.status, "deactivating")
+
     def _get_vpn_context(self):
         self.test_create_cert()
         c = Config.objects.get(device__name="test-create-cert")

--- a/openwisp_controller/config/tests/test_controller.py
+++ b/openwisp_controller/config/tests/test_controller.py
@@ -786,6 +786,22 @@ class TestController(
         d.refresh_from_db()
         self.assertIsNotNone(d.config)
 
+    @capture_any_output()
+    def test_register_deactivated_device(self):
+        device = self._create_device_config()
+        device.key = TEST_CONSISTENT_KEY
+        device.save()
+        device.deactivate()
+        original_os = device.os
+        params = self._get_reregistration_payload(
+            device, name=device.name, os="OpenWrt 22.03"
+        )
+        response = self.client.post(self.register_url, params)
+        self.assertContains(response, "error: device deactivated", status_code=403)
+        device.refresh_from_db()
+        self.assertEqual(device.os, original_os)
+        self.assertEqual(device.config.templates.count(), 0)
+
     def test_device_registration_update_hw_info(self):
         d = self._create_device_config()
         d.key = TEST_CONSISTENT_KEY
@@ -1075,9 +1091,37 @@ class TestController(
             self.assertEqual(d.model, params["model"])
 
     def test_deactivated_device_update_info(self):
-        self._test_deactivating_deactivated_device_view(
-            "device_update_info", method="post", data={}
-        )
+        # Inventory metadata updates must be rejected for deactivated devices,
+        # including the transient "deactivating" state (which GetDeviceView does
+        # not exclude on its own).
+        self._create_template(required=True)
+        device = self._create_device_config()
+        url = reverse("controller:device_update_info", args=[device.pk])
+        params = {
+            "key": device.key,
+            "model": "TP-Link TL-WDR4300 v2",
+            "os": "OpenWrt 18.06-SNAPSHOT r7312-e60be11330",
+            "system": "Atheros AR9344 rev 3",
+        }
+        device.deactivate()
+        device.refresh_from_db()
+        self.assertEqual(device.config.status, "deactivating")
+        initial = (device.os, device.model, device.system)
+        # payload must differ from current values so a missed block is detectable
+        self.assertNotEqual((params["os"], params["model"], params["system"]), initial)
+
+        with self.subTest("rejected while deactivating"):
+            response = self.client.post(url, params)
+            self.assertEqual(response.status_code, 403)
+            self._check_header(response)
+            device.refresh_from_db()
+            # metadata must be left untouched
+            self.assertEqual((device.os, device.model, device.system), initial)
+
+        with self.subTest("not found once fully deactivated"):
+            device.config.set_status_deactivated()
+            response = self.client.post(url, params)
+            self.assertEqual(response.status_code, 404)
 
     def test_device_update_info_bad_uuid(self):
         d = self._create_device_config()

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -526,8 +526,12 @@ class TestDevice(
         self.assertEqual(device.config.templates.count(), 0)
         Device.manage_devices_group_templates(device.pk, old_group.pk, new_group.pk)
         device.config.refresh_from_db()
+        # Deactivated device config is skipped: adding templates to a cleared
+        # config would misrepresent what has been applied to the device.
         self.assertEqual(device.config.templates.count(), 0)
         self.assertNotIn(new_template, device.config.templates.all())
+        # Status must remain "deactivated" — no config push is initiated.
+        self.assertEqual(device.config.status, "deactivated")
 
     def test_device_field_changed_checks(self):
         self._create_device()

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -512,6 +512,23 @@ class TestDevice(
             self._create_device(name="test", organization=org, group=device_group)
         handler.assert_not_called()
 
+    def test_manage_devices_group_templates_skips_deactivated_devices(self):
+        org = self._get_org()
+        old_template = self._create_template(name="old-template", organization=org)
+        new_template = self._create_template(name="new-template", organization=org)
+        old_group = self._create_device_group(name="old-group", organization=org)
+        new_group = self._create_device_group(name="new-group", organization=org)
+        old_group.templates.add(old_template)
+        new_group.templates.add(new_template)
+        device = self._create_device(name="test", organization=org, group=old_group)
+        device.deactivate()
+        device.config.refresh_from_db()
+        self.assertEqual(device.config.templates.count(), 0)
+        Device.manage_devices_group_templates(device.pk, old_group.pk, new_group.pk)
+        device.config.refresh_from_db()
+        self.assertEqual(device.config.templates.count(), 0)
+        self.assertNotIn(new_template, device.config.templates.all())
+
     def test_device_field_changed_checks(self):
         self._create_device()
         device_group = self._create_device_group()

--- a/openwisp_controller/config/whois/tasks.py
+++ b/openwisp_controller/config/whois/tasks.py
@@ -76,6 +76,8 @@ def fetch_whois_details(self, device_pk, initial_ip_address):
     # so re-check here and do not run the external lookup for it.
     if device.is_deactivated():
         logger.info(f"Device {device_pk} is deactivated, skipping WHOIS lookup")
+        if initial_ip_address:
+            delete_whois_record(ip_address=initial_ip_address)
         return
     new_ip_address = device.last_ip
     whois_service = device.whois_service

--- a/openwisp_controller/config/whois/tasks.py
+++ b/openwisp_controller/config/whois/tasks.py
@@ -119,6 +119,8 @@ def delete_whois_record(ip_address, force=False):
     if force:
         queryset.delete()
     else:
+        # Only delete the WHOIS record if there are no active devices
+        # linked to the same IP address.
         if (
             not Device.objects.filter(_is_deactivated=False)
             .filter(last_ip=ip_address)

--- a/openwisp_controller/config/whois/tests/tests.py
+++ b/openwisp_controller/config/whois/tests/tests.py
@@ -1013,15 +1013,20 @@ class TestWHOISTransaction(
     @mock.patch(_WHOIS_TASKS_INFO_LOGGER)
     @mock.patch(_WHOIS_GEOIP_CLIENT)
     def test_fetch_whois_details_skips_when_deactivated(self, mock_client, mock_info):
+        # Device whose IP changed to 8.8.8.8 but was deactivated before the task ran.
+        # The new-IP lookup must be skipped, and the stale WHOIS row for the old IP
+        # (1.2.3.4) must be cleaned up.
+        self._create_whois_info(ip_address="1.2.3.4")
         whois_obj = self._create_whois_info(ip_address="8.8.8.8")
         device = self._create_device(last_ip=whois_obj.ip_address)
         mock_client.reset_mock()
         device.deactivate()
-        fetch_whois_details(device_pk=device.pk, initial_ip_address="10.0.0.1")
+        fetch_whois_details(device_pk=device.pk, initial_ip_address="1.2.3.4")
         mock_info.assert_called_once_with(
             f"Device {device.pk} is deactivated, skipping WHOIS lookup"
         )
         mock_client.assert_not_called()
+        self.assertEqual(WHOISInfo.objects.filter(ip_address="1.2.3.4").count(), 0)
 
     @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
     @mock.patch(_WHOIS_GEOIP_CLIENT)

--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -89,7 +89,7 @@ class ConnectionConfig(AppConfig):
         from .tasks import update_config
 
         # Check if push update should be skipped
-        if device.is_fully_deactivated() or device.should_skip_push_update():
+        if device.should_skip_push_update():
             return
         update_config.delay(str(device.pk))
 

--- a/openwisp_controller/connection/apps.py
+++ b/openwisp_controller/connection/apps.py
@@ -89,7 +89,7 @@ class ConnectionConfig(AppConfig):
         from .tasks import update_config
 
         # Check if push update should be skipped
-        if device.should_skip_push_update():
+        if device.is_fully_deactivated() or device.should_skip_push_update():
             return
         update_config.delay(str(device.pk))
 

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -361,7 +361,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             # already "deactivated"). A device that is only "deactivating" is let
             # through so the final cleared configuration can still be pushed.
             if self.device.is_fully_deactivated():
-                raise RuntimeError("Device is deactivated")
+                raise RuntimeError(_("Device is deactivated"))
             self.connector_instance.connect()
         except Exception as e:
             self.is_working = False

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -591,7 +591,6 @@ class AbstractCommand(TimeStampedEditableModel):
         # devices, but the device could be fully deactivated while the task
         # is still pending.
         if self.device.is_fully_deactivated():
-
             self.status = "failed"
             self._add_output("Device is deactivated.")
         else:

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -554,6 +554,14 @@ class AbstractCommand(TimeStampedEditableModel):
             raise RuntimeError(
                 "This command has already been executed, " "please create a new one."
             )
+        # Guard against a device that was deactivated after the command was queued.
+        # Command.clean() already rejects creation for deactivated devices, but
+        # the device could be deactivated while the task is still pending.
+        if self.device.is_deactivated():
+            self.status = "failed"
+            self._add_output(_("Device is deactivated."))
+            self.save()
+            return
         exit_code = self._exec_command()
         # if output is None, the commands couldn't execute
         # because the system couldn't connect to the device

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -559,21 +559,20 @@ class AbstractCommand(TimeStampedEditableModel):
         # the device could be deactivated while the task is still pending.
         if self.device.is_deactivated():
             self.status = "failed"
-            self._add_output(_("Device is deactivated."))
-            self.save()
-            return
-        exit_code = self._exec_command()
-        # if output is None, the commands couldn't execute
-        # because the system couldn't connect to the device
-        if exit_code is None:
-            self.status = "failed"
-            self.output = self.connection.failure_reason
-        # one command failed
-        elif exit_code != 0:
-            self.status = "failed"
-        # all commands succeeded
+            self._add_output("Device is deactivated.")
         else:
-            self.status = "success"
+            exit_code = self._exec_command()
+            # if output is None, the commands couldn't execute
+            # because the system couldn't connect to the device
+            if exit_code is None:
+                self.status = "failed"
+                self.output = self.connection.failure_reason
+            # one command failed
+            elif exit_code != 0:
+                self.status = "failed"
+            # all commands succeeded
+            else:
+                self.status = "success"
         self._clean_sensitive_info()
         self.save()
 

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -481,7 +481,7 @@ class AbstractCommand(TimeStampedEditableModel):
         return f'«{command}» {sent} {created.strftime("%d %b %Y at %I:%M %p")}'
 
     def clean(self):
-        if self.device.is_deactivated():
+        if self.device.is_fully_deactivated():
             raise ValidationError({"device": _("Device is deactivated.")})
         self._verify_command_type_allowed()
         self._verify_connection()
@@ -554,10 +554,11 @@ class AbstractCommand(TimeStampedEditableModel):
             raise RuntimeError(
                 "This command has already been executed, " "please create a new one."
             )
-        # Guard against a device that was deactivated after the command was queued.
-        # Command.clean() already rejects creation for deactivated devices, but
-        # the device could be deactivated while the task is still pending.
-        if self.device.is_deactivated():
+        # Guard against a device that was fully deactivated after the command was
+        # queued. Command.clean() already rejects creation for fully deactivated
+        # devices, but the device could be fully deactivated while the task
+        # is still pending.
+        if self.device.is_fully_deactivated():
             self.status = "failed"
             self._add_output("Device is deactivated.")
         else:

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -141,7 +141,11 @@ class AbstractCredentials(ConnectorMixin, ShareableOrgMixinUniqueName, BaseModel
         DeviceConnection = load_model("connection", "DeviceConnection")
         Device = load_model("config", "Device")
 
-        devices = Device.objects.exclude(config=None).exclude(_is_deactivated=True)
+        # Deactivated devices are intentionally included: attaching credentials
+        # is a database-only operation with no network activity (the connection
+        # cannot be used while the device is deactivated), and having the
+        # credentials ready avoids extra setup when the device is reactivated.
+        devices = Device.objects.exclude(config=None)
         if organization_id:
             devices = devices.filter(organization_id=organization_id)
         # exclude devices which have been already added
@@ -179,6 +183,9 @@ class AbstractCredentials(ConnectorMixin, ShareableOrgMixinUniqueName, BaseModel
         if not created:
             return
         device = instance.device
+        # Credentials are attached even when the device is deactivated: this only
+        # creates DeviceConnection rows (no network operation) and avoids extra
+        # setup on reactivation. See auto_add_to_devices for the same rationale.
         # select credentials which
         #   - are flagged as auto_add
         #   - belong to the same organization of the device
@@ -266,9 +273,13 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
     def get_working_connection(
         cls, device, connector="openwisp_controller.connection.connectors.ssh.Ssh"
     ):
+        # Deactivated devices are not filtered out here on purpose: a device that
+        # is still "deactivating" needs one last connection so the cleared
+        # configuration can be pushed to it. connect() below refuses fully
+        # deactivated devices, so only the legitimate deactivating push gets
+        # through.
         qs = cls.objects.filter(
             device=device,
-            device___is_deactivated=False,
             enabled=True,
             credentials__connector=connector,
         ).order_by("-is_working")
@@ -346,6 +357,9 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
 
     def connect(self):
         try:
+            # Refuse fully deactivated devices (device deactivated and its config
+            # already "deactivated"). A device that is only "deactivating" is let
+            # through so the final cleared configuration can still be pushed.
             if self.device.is_fully_deactivated():
                 raise RuntimeError("Device is deactivated")
             self.connector_instance.connect()

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -141,7 +141,7 @@ class AbstractCredentials(ConnectorMixin, ShareableOrgMixinUniqueName, BaseModel
         DeviceConnection = load_model("connection", "DeviceConnection")
         Device = load_model("config", "Device")
 
-        devices = Device.objects.exclude(config=None)
+        devices = Device.objects.exclude(config=None).exclude(_is_deactivated=True)
         if organization_id:
             devices = devices.filter(organization_id=organization_id)
         # exclude devices which have been already added
@@ -268,6 +268,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
     ):
         qs = cls.objects.filter(
             device=device,
+            device___is_deactivated=False,
             enabled=True,
             credentials__connector=connector,
         ).order_by("-is_working")
@@ -345,6 +346,8 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
 
     def connect(self):
         try:
+            if self.device.is_fully_deactivated():
+                raise RuntimeError("Device is deactivated")
             self.connector_instance.connect()
         except Exception as e:
             self.is_working = False
@@ -378,6 +381,8 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
         self._initial_failure_reason = self.failure_reason
 
     def send_is_working_changed_signal(self):
+        if self.device.is_fully_deactivated():
+            return
         is_working_changed.send(
             sender=self.__class__,
             is_working=self.is_working,
@@ -462,6 +467,8 @@ class AbstractCommand(TimeStampedEditableModel):
         return f'«{command}» {sent} {created.strftime("%d %b %Y at %I:%M %p")}'
 
     def clean(self):
+        if self.device.is_deactivated():
+            raise ValidationError({"device": _("Device is deactivated.")})
         self._verify_command_type_allowed()
         self._verify_connection()
         try:

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -79,14 +79,6 @@ def launch_command(command_id):
     except Command.DoesNotExist as e:
         logger.warning(f'launch_command("{command_id}") failed: {e}')
         return
-    # Do not execute commands on deactivated devices. Creation is already
-    # rejected by Command.clean(); this guards the case where the device was
-    # deactivated after the command had been queued.
-    if command.device.is_deactivated():
-        command.status = "failed"
-        command._add_output(_("Device is deactivated."))
-        command.save()
-        return
     try:
         command.execute()
     except SoftTimeLimitExceeded:

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -46,6 +46,9 @@ def update_config(self, device_id):
     time.sleep(2)
     try:
         device = Device.objects.select_related("config").get(pk=device_id)
+        if device.is_fully_deactivated():
+            logger.info(f"{device} (pk: {device_id}) is deactivated, skipping update")
+            return
         # abort operation if device shouldn't be updated
         if not device.can_be_updated():
             logger.info(f"{device} (pk: {device_id}) is not going to be updated")

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -79,6 +79,14 @@ def launch_command(command_id):
     except Command.DoesNotExist as e:
         logger.warning(f'launch_command("{command_id}") failed: {e}')
         return
+    # Do not execute commands on deactivated devices. Creation is already
+    # rejected by Command.clean(); this guards the case where the device was
+    # deactivated after the command had been queued.
+    if command.device.is_deactivated():
+        command.status = "failed"
+        command._add_output(_("Device is deactivated."))
+        command.save()
+        return
     try:
         command.execute()
     except SoftTimeLimitExceeded:

--- a/openwisp_controller/connection/tests/test_api.py
+++ b/openwisp_controller/connection/tests/test_api.py
@@ -287,6 +287,7 @@ class TestCommandsAPI(TestCase, AuthenticationMixin, CreateCommandMixin):
             self.assertDictEqual(response.data, device_not_found)
 
     def test_endpoints_for_deactivated_device(self):
+        command = self._create_command(device_conn=self.device_conn)
         self.device_conn.device.deactivate()
 
         with self.subTest("Test listing commands"):
@@ -308,7 +309,6 @@ class TestCommandsAPI(TestCase, AuthenticationMixin, CreateCommandMixin):
             self.assertEqual(response.status_code, 403)
 
         with self.subTest("Test retrieving commands"):
-            command = self._create_command(device_conn=self.device_conn)
             url = self._get_path("device_command_details", self.device_id, command.id)
             response = self.client.get(
                 url,

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -349,6 +349,15 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
         self.assertEqual(d.deviceconnection_set.count(), 1)
         self.assertEqual(d.deviceconnection_set.first().credentials, c)
 
+    def test_auto_add_to_new_deactivated_device(self):
+        org = Organization.objects.first()
+        self._create_credentials(auto_add=True, organization=None)
+        device = self._create_device(organization=org, name="deactivated-device")
+        device.deactivate()
+        self._create_config(device=device)
+        device.refresh_from_db()
+        self.assertEqual(device.deviceconnection_set.count(), 1)
+
     def test_auto_add_device_missing_config(self):
         org = Organization.objects.first()
         self._create_device(organization=org)
@@ -1163,6 +1172,27 @@ class TestModelsTransaction(BaseTestModels, TransactionTestCase):
         d.refresh_from_db()
         self.assertEqual(d.deviceconnection_set.count(), 1)
         self.assertEqual(d.deviceconnection_set.first().credentials, c)
+
+    @mock.patch.object(DeviceConnection, "update_config")
+    @mock.patch.object(DeviceConnection, "get_working_connection")
+    @mock.patch("time.sleep")
+    def test_deactivating_device_update_config(
+        self, mocked_sleep, mocked_get_working_connection, mocked_update_config
+    ):
+        conf = self._prepare_conf_object()
+        conf.save()
+        mocked_get_working_connection.reset_mock()
+        mocked_update_config.reset_mock()
+        mocked_get_working_connection.return_value = (
+            conf.device.deviceconnection_set.first()
+        )
+
+        conf.device.deactivate()
+
+        conf.refresh_from_db()
+        self.assertEqual(conf.status, "deactivating")
+        mocked_get_working_connection.assert_called_once_with(conf.device)
+        mocked_update_config.assert_called_once()
 
     def test_chunk_size(self):
         org = self._get_org()

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -255,9 +255,11 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
             device2 = self._create_device(
                 name="deactivating-device", mac_address="11:22:33:44:55:66"
             )
-            self._create_config(device=device2)
+            template = self._create_template(organization=device2.organization)
+            self._create_config(device=device2, templates=[template])
             dc2 = self._create_device_connection(credentials=cred2, device=device2)
-            dc2.device._is_deactivated = True
+            dc2.device.deactivate()
+            self.assertEqual(dc2.device.config.status, "deactivating")
             self.assertEqual(dc2.device.is_fully_deactivated(), False)
             with mock.patch.object(dc2.connector_instance, "connect") as mocked_conn:
                 dc2.connect()

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -375,7 +375,7 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
         self.assertEqual(d.deviceconnection_set.first().credentials, c)
 
     def test_auto_add_to_new_deactivated_device(self):
-        org = Organization.objects.first()
+        org = self._get_org()
         self._create_credentials(auto_add=True, organization=None)
         device = self._create_device(organization=org, name="deactivated-device")
         device.deactivate()

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -613,6 +613,38 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
                 ["Device has no credentials assigned."],
             )
 
+    def test_command_validation_deactivated_device(self):
+        dc = self._create_device_connection()
+
+        with self.subTest("deactivating device does not block command creation"):
+            dc.device._is_deactivated = True
+            dc.device.save(update_fields=["_is_deactivated"])
+            dc.device.config.set_status_deactivating()
+            device = Device.objects.get(pk=dc.device.pk)
+            command = Command(
+                device=device,
+                connection=dc,
+                type="custom",
+                input={"command": "echo test"},
+            )
+            command.clean()
+
+        with self.subTest("fully deactivated device blocks command creation"):
+            dc.device.config.set_status_deactivated()
+            device = Device.objects.get(pk=dc.device.pk)
+            command = Command(
+                device=device,
+                connection=dc,
+                type="custom",
+                input={"command": "echo test"},
+            )
+            with self.assertRaises(ValidationError) as ctx:
+                command.clean()
+            self.assertIn("device", ctx.exception.message_dict)
+            self.assertEqual(
+                ctx.exception.message_dict["device"], ["Device is deactivated."]
+            )
+
     @tag("skip_prod")
     def test_enabled_command(self):
         self.assertEqual(

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -1186,9 +1186,11 @@ class TestModelsTransaction(BaseTestModels, TransactionTestCase):
         mocked_get_working_connection.return_value = (
             conf.device.deviceconnection_set.first()
         )
-
+        # Deactivate the device
         conf.device.deactivate()
-
+        # Ensure that the config status is set to "deactivating" and
+        # update_config is called to apply the empty configuration for deactivated
+        # devices.
         conf.refresh_from_db()
         self.assertEqual(conf.status, "deactivating")
         mocked_get_working_connection.assert_called_once_with(conf.device)

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -238,6 +238,31 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
         self.assertIsNotNone(dc.last_attempt)
         self.assertEqual(dc.failure_reason, "Authentication failed.")
 
+    def test_connect_deactivated_device(self):
+        dc = self._create_device_connection()
+
+        with self.subTest("fully deactivated: connect blocked, signal suppressed"):
+            dc.device.deactivate()
+            self.assertTrue(dc.device.is_fully_deactivated())
+            with catch_signal(is_working_changed) as handler:
+                dc.connect()
+            self.assertEqual(dc.is_working, False)
+            self.assertEqual(dc.failure_reason, "Device is deactivated")
+            handler.assert_not_called()
+
+        with self.subTest("deactivating: connect allowed through"):
+            cred2 = self._create_credentials(name="cred-deactivating")
+            device2 = self._create_device(
+                name="deactivating-device", mac_address="11:22:33:44:55:66"
+            )
+            self._create_config(device=device2)
+            dc2 = self._create_device_connection(credentials=cred2, device=device2)
+            dc2.device._is_deactivated = True
+            self.assertEqual(dc2.device.is_fully_deactivated(), False)
+            with mock.patch.object(dc2.connector_instance, "connect") as mocked_conn:
+                dc2.connect()
+            mocked_conn.assert_called_once()
+
     def test_credentials_schema(self):
         # unrecognized parameter
         try:

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -13,6 +13,7 @@ from ..connectors.exceptions import CommandTimeoutException
 from .utils import CreateConnectionsMixin
 
 Command = load_model("connection", "Command")
+DeviceConnection = load_model("connection", "DeviceConnection")
 OrganizationConfigSettings = load_model("config", "OrganizationConfigSettings")
 
 
@@ -91,6 +92,25 @@ class TestTasks(CreateConnectionsMixin, TestCase):
             f'update_config("{pk}") failed: Device matching query does not exist.'
         )
         mocked_sleep.assert_called_once()
+
+    @mock.patch("logging.Logger.info")
+    @mock.patch("time.sleep")
+    def test_update_config_skipped_for_deactivated_device(
+        self, mocked_sleep, mocked_info
+    ):
+        dc = self._create_device_connection()
+        device = dc.device
+        device.deactivate()
+        self.assertTrue(device.is_fully_deactivated())
+        with mock.patch.object(
+            DeviceConnection, "get_working_connection"
+        ) as mocked_get_working_connection:
+            tasks.update_config.delay(device.pk)
+        mocked_get_working_connection.assert_not_called()
+        mocked_sleep.assert_called_once()
+        mocked_info.assert_called_with(
+            f"{device} (pk: {device.pk}) is deactivated, skipping update"
+        )
 
     @mock.patch("logging.Logger.warning")
     def test_launch_command_missing(self, mocked_warning):

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -163,6 +163,24 @@ class TestTasks(CreateConnectionsMixin, TestCase):
         self.assertEqual(command.status, "failed")
         self.assertEqual(command.output, "Internal system error: test error\n")
 
+    @mock.patch(_mock_execute)
+    def test_launch_command_deactivated_device(self, mocked_execute):
+        dc = self._create_device_connection()
+        command = Command(
+            device=dc.device,
+            connection=dc,
+            type="custom",
+            input={"command": "/usr/sbin/exotic_command"},
+        )
+        command.full_clean()
+        command.save()
+        dc.device.deactivate()
+        tasks.launch_command.delay(command.pk)
+        command.refresh_from_db()
+        self.assertEqual(command.status, "failed")
+        self.assertEqual(command.output, "Device is deactivated.\n")
+        mocked_execute.assert_not_called()
+
 
 class TestTransactionTasks(
     TestRegistrationMixin, CreateConnectionsMixin, TransactionTestCase

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -186,6 +186,29 @@ class TestTasks(CreateConnectionsMixin, TestCase):
     @mock.patch(
         "openwisp_controller.connection.base.models.AbstractCommand._exec_command"
     )
+    def test_launch_command_deactivating_device_not_blocked(self, mocked_exec_command):
+        mocked_exec_command.return_value = 0
+        dc = self._create_device_connection()
+        command = Command(
+            device=dc.device,
+            connection=dc,
+            type="custom",
+            input={"command": "/usr/sbin/exotic_command"},
+        )
+        command.full_clean()
+        command.save()
+        # Device deactivation has started but config is still deactivating
+        dc.device._is_deactivated = True
+        dc.device.save(update_fields=["_is_deactivated"])
+        dc.device.config.set_status_deactivating()
+        tasks.launch_command.delay(command.pk)
+        command.refresh_from_db()
+        self.assertNotEqual(command.output, "Device is deactivated.\n")
+        mocked_exec_command.assert_called_once()
+
+    @mock.patch(
+        "openwisp_controller.connection.base.models.AbstractCommand._exec_command"
+    )
     def test_launch_command_deactivated_device(self, mocked_exec_command):
         dc = self._create_device_connection()
         command = Command(

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -163,8 +163,10 @@ class TestTasks(CreateConnectionsMixin, TestCase):
         self.assertEqual(command.status, "failed")
         self.assertEqual(command.output, "Internal system error: test error\n")
 
-    @mock.patch(_mock_execute)
-    def test_launch_command_deactivated_device(self, mocked_execute):
+    @mock.patch(
+        "openwisp_controller.connection.base.models.AbstractCommand._exec_command"
+    )
+    def test_launch_command_deactivated_device(self, mocked_exec_command):
         dc = self._create_device_connection()
         command = Command(
             device=dc.device,
@@ -179,7 +181,7 @@ class TestTasks(CreateConnectionsMixin, TestCase):
         command.refresh_from_db()
         self.assertEqual(command.status, "failed")
         self.assertEqual(command.output, "Device is deactivated.\n")
-        mocked_execute.assert_not_called()
+        mocked_exec_command.assert_not_called()
 
 
 class TestTransactionTasks(

--- a/openwisp_controller/geo/estimated_location/handlers.py
+++ b/openwisp_controller/geo/estimated_location/handlers.py
@@ -68,8 +68,10 @@ def whois_lookup_skipped_handler(sender, device, **kwargs):
     Handler for skipped WHOIS lookups. If estimated location is enabled for
     the device's organization, trigger an estimated location task.
     """
+    # Skip deactivated devices: there is no value in estimating a location for
+    # a device that is no longer managed.
     if (
-        device.is_deactivated
+        device.is_deactivated()
         or not EstimatedLocationService.check_estimated_location_enabled(
             device.organization_id
         )

--- a/openwisp_controller/geo/estimated_location/handlers.py
+++ b/openwisp_controller/geo/estimated_location/handlers.py
@@ -43,6 +43,7 @@ def whois_fetched_handler(sender, whois, updated_fields, device=None, **kwargs):
     if (
         not updated_fields
         or not device
+        or device.is_deactivated()
         or not EstimatedLocationService.check_estimated_location_enabled(
             device.organization_id
         )
@@ -67,8 +68,11 @@ def whois_lookup_skipped_handler(sender, device, **kwargs):
     Handler for skipped WHOIS lookups. If estimated location is enabled for
     the device's organization, trigger an estimated location task.
     """
-    if not EstimatedLocationService.check_estimated_location_enabled(
-        device.organization_id
+    if (
+        device.is_deactivated
+        or not EstimatedLocationService.check_estimated_location_enabled(
+            device.organization_id
+        )
     ):
         return
     estimated_location_service = EstimatedLocationService(device)

--- a/openwisp_controller/geo/tests/utils.py
+++ b/openwisp_controller/geo/tests/utils.py
@@ -11,7 +11,7 @@ class TestGeoMixin(TestLociMixin):
         options = dict(name="org1")
         options.update(kwargs)
         options.setdefault("slug", slugify(options["name"]))
-        if not Organization.objects.filter(**options).count():
+        if not Organization.objects.filter(**options).exists():
             org = Organization(**options)
             org.full_clean()
             org.save()

--- a/openwisp_controller/geo/tests/utils.py
+++ b/openwisp_controller/geo/tests/utils.py
@@ -11,12 +11,12 @@ class TestGeoMixin(TestLociMixin):
         options = dict(name="org1")
         options.update(kwargs)
         options.setdefault("slug", slugify(options["name"]))
-        if not Organization.objects.filter(**kwargs).count():
+        if not Organization.objects.filter(**options).count():
             org = Organization(**options)
             org.full_clean()
             org.save()
         else:
-            org = Organization.objects.get(**kwargs)
+            org = Organization.objects.get(**options)
         return org
 
     def _add_default_org(self, kwargs):
@@ -44,7 +44,10 @@ class TestGeoMixin(TestLociMixin):
 
     def _create_object_location(self, **kwargs):
         if "location" not in kwargs:
-            kwargs["location"] = self._create_location()
+            location_kwargs = {}
+            if "content_object" in kwargs:
+                location_kwargs["organization"] = kwargs["content_object"].organization
+            kwargs["location"] = self._create_location(**location_kwargs)
         kwargs["organization"] = kwargs["location"].organization
         if "content_object" not in kwargs:
             kwargs["content_object"] = self._create_object(

--- a/openwisp_controller/subnet_division/rule_types/device.py
+++ b/openwisp_controller/subnet_division/rule_types/device.py
@@ -33,12 +33,6 @@ class DeviceSubnetDivisionRuleType(BaseSubnetDivisionRuleType):
 
     @classmethod
     def should_create_subnets_ips(cls, instance, **kwargs):
-        # Skip deactivated devices: provisioning subnets and IP addresses for a
-        # device that is no longer managed serves no purpose and wastes address
-        # space. This also covers configs created directly for a device that is
-        # already deactivated, not just the rule backfill path.
-        if instance.device.is_deactivated():
-            return False
         return kwargs.get("created", False)
 
     @staticmethod
@@ -52,11 +46,7 @@ class DeviceSubnetDivisionRuleType(BaseSubnetDivisionRuleType):
     def provision_for_existing_objects(cls, rule_obj):
         for config in (
             Config.objects.select_related("device", "device__organization")
-            # Skip deactivated devices: provisioning subnets and IP addresses
-            # for them serves no purpose and wastes address space.
-            .filter(
-                device__organization_id=rule_obj.organization_id,
-                device___is_deactivated=False,
-            ).iterator()
+            .filter(device__organization_id=rule_obj.organization_id)
+            .iterator()
         ):
             cls.provision_receiver(config, created=True, rule=rule_obj)

--- a/openwisp_controller/subnet_division/rule_types/device.py
+++ b/openwisp_controller/subnet_division/rule_types/device.py
@@ -33,6 +33,12 @@ class DeviceSubnetDivisionRuleType(BaseSubnetDivisionRuleType):
 
     @classmethod
     def should_create_subnets_ips(cls, instance, **kwargs):
+        # Skip deactivated devices: provisioning subnets and IP addresses for a
+        # device that is no longer managed serves no purpose and wastes address
+        # space. This also covers configs created directly for a device that is
+        # already deactivated, not just the rule backfill path.
+        if instance.device.is_deactivated():
+            return False
         return kwargs.get("created", False)
 
     @staticmethod
@@ -46,7 +52,11 @@ class DeviceSubnetDivisionRuleType(BaseSubnetDivisionRuleType):
     def provision_for_existing_objects(cls, rule_obj):
         for config in (
             Config.objects.select_related("device", "device__organization")
-            .filter(device__organization_id=rule_obj.organization_id)
-            .iterator()
+            # Skip deactivated devices: provisioning subnets and IP addresses
+            # for them serves no purpose and wastes address space.
+            .filter(
+                device__organization_id=rule_obj.organization_id,
+                device___is_deactivated=False,
+            ).iterator()
         ):
             cls.provision_receiver(config, created=True, rule=rule_obj)

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -815,22 +815,28 @@ class TestSubnetDivisionRule(
             self.ip_query.count(), (rule.number_of_subnets * rule.number_of_ips)
         )
 
-    def test_device_subnet_division_rule_existing_devices_skips_deactivated(self):
+    def test_device_subnet_division_rule_existing_devices_includes_deactivated(self):
         subnet_query = self.subnet_query.filter(organization_id=self.org.id).exclude(
             id=self.master_subnet.id
         )
         self.config.device.deactivate()
         self.assertEqual(subnet_query.count(), 0)
-        self._get_device_subdivision_rule()
+        rule = self._get_device_subdivision_rule()
         self.config.refresh_from_db()
         self.assertTrue(self.config.device.is_deactivated())
-        self.assertEqual(subnet_query.count(), 0)
-        self.assertEqual(self.ip_query.count(), 0)
-        self.assertEqual(self.config.subnetdivisionindex_set.count(), 0)
+        # Subnets are provisioned even for deactivated devices so re-activation
+        # does not require extra provisioning logic.
+        self.assertEqual(subnet_query.count(), rule.number_of_subnets)
+        self.assertEqual(
+            self.ip_query.count(), rule.number_of_subnets * rule.number_of_ips
+        )
+        self.assertGreater(self.config.subnetdivisionindex_set.count(), 0)
 
-    def test_device_subnet_division_rule_skips_deactivated_on_config_creation(self):
-        # A rule already exists; creating a config directly for a device that is
-        # already deactivated must not provision any subnet or IP.
+    def test_device_subnet_division_rule_provisions_deactivated_on_config_creation(
+        self,
+    ):
+        # A rule already exists; subnets must be provisioned even when the config
+        # is created for a device that is already deactivated.
         self._get_device_subdivision_rule()
         device = self._create_device(
             organization=self.org,
@@ -840,7 +846,7 @@ class TestSubnetDivisionRule(
         device.deactivate()
         config = self._create_config(device=device)
         self.assertTrue(config.device.is_deactivated())
-        self.assertEqual(config.subnetdivisionindex_set.count(), 0)
+        self.assertGreater(config.subnetdivisionindex_set.count(), 0)
 
     def test_vpn_subnet_division_rule_existing_devices(self):
         subnet_query = self.subnet_query.filter(organization_id=self.org.id).exclude(

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -815,6 +815,33 @@ class TestSubnetDivisionRule(
             self.ip_query.count(), (rule.number_of_subnets * rule.number_of_ips)
         )
 
+    def test_device_subnet_division_rule_existing_devices_skips_deactivated(self):
+        subnet_query = self.subnet_query.filter(organization_id=self.org.id).exclude(
+            id=self.master_subnet.id
+        )
+        self.config.device.deactivate()
+        self.assertEqual(subnet_query.count(), 0)
+        self._get_device_subdivision_rule()
+        self.config.refresh_from_db()
+        self.assertTrue(self.config.device.is_deactivated())
+        self.assertEqual(subnet_query.count(), 0)
+        self.assertEqual(self.ip_query.count(), 0)
+        self.assertEqual(self.config.subnetdivisionindex_set.count(), 0)
+
+    def test_device_subnet_division_rule_skips_deactivated_on_config_creation(self):
+        # A rule already exists; creating a config directly for a device that is
+        # already deactivated must not provision any subnet or IP.
+        self._get_device_subdivision_rule()
+        device = self._create_device(
+            organization=self.org,
+            name="deactivated-device",
+            mac_address="00:11:22:33:44:66",
+        )
+        device.deactivate()
+        config = self._create_config(device=device)
+        self.assertTrue(config.device.is_deactivated())
+        self.assertEqual(config.subnetdivisionindex_set.count(), 0)
+
     def test_vpn_subnet_division_rule_existing_devices(self):
         subnet_query = self.subnet_query.filter(organization_id=self.org.id).exclude(
             id=self.master_subnet.id


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1338


## Description of Changes

### Premise

- A **deactivated device** is treated as non-operational: no new configuration, management, or connectivity operations should target it, while controller state, security, and cleanup processes must continue to run so the system remains consistent.
- The transitional state **`Config.status == "deactivating"`** is a special case. A limited set of operations remain allowed long enough to complete deactivation cleanly (for example, delivering the final configuration and receiving the final status report). Once the configuration reaches the `deactivated` state, those operations are blocked as well.

### High-level behavior on deactivated devices

#### No new lifecycle or activation flows

- Device registration and re-registration are blocked for deactivated devices.
- Any workflow that would implicitly restore configuration state or make a deactivated device appear operational again is blocked.
- Automatic template assignment and template propagation from groups do not run for deactivated configurations.

#### No active management traffic

- Remote command execution is blocked.
- Configuration pushes and reachability checks are allowed only while a configuration is transitioning through `Config.status == "deactivating"`.
- Once a configuration is fully deactivated, no further controller-initiated communication should occur.

#### State-only and cleanup operations remain allowed

- Certificate revocation, cache invalidation, WHOIS cleanup, and similar backend maintenance operations remain allowed.
- VPN, addressing, and other deprovisioning workflows continue to run where necessary.
- Read-only operations remain available so operators can inspect historical state and the UI remains synchronized with already-persisted data.

### Configuration and controller behavior

#### Agent-facing configuration flows

- Configuration checksum requests, configuration downloads, and status reporting remain allowed while a configuration is in the `deactivating` state.
- These operations are blocked once the configuration becomes fully deactivated.
- This allows the device to fetch, apply, and acknowledge its final deactivation configuration while preventing ongoing polling after deactivation has completed.

#### Template propagation

- Automatic template assignment and template propagation from groups do not run for deactivated configurations.
- This prevents deactivated devices from appearing as though configuration has been re-applied after deactivation.
- Configuration fan-out workflows should consistently exclude deactivated configurations and devices.

#### Credentials and connectivity

- Automatic credential assignment does not itself generate network traffic, thus deactivated devices are not excluded from this operation.
- Configuration pushes and reachability checks remain allowed during `Config.status == "deactivating"` but are blocked once deactivation is complete.

### Geo and WHOIS behavior

#### Mutating versus read-only operations

- Updates to device coordinates and device-location mappings are blocked for deactivated devices.
- Reading coordinates, reading location information, and broadcasting already-known location updates remain allowed because they are read-only operations.

#### WHOIS and location enrichment

- WHOIS enrichment and estimated-location updates should not run for deactivated devices because they provide no operational value and may incorrectly suggest continued activity.
- WHOIS cleanup remains allowed and continues to remove stale metadata associated with deactivated devices.

### PKI and VPN behavior

#### PKI cleanup

- Certificate revocation and cache invalidation remain allowed and are considered part of the deactivation process.
- Configuration updates triggered by certificate changes are skipped for deactivated configurations to avoid unnecessary status changes for devices that are no longer active.

#### VPN clients and peers

- VPN client cleanup remains allowed during deactivation.
- New VPN clients must not be created for deactivated devices.
- VPN configuration updates that remove peers belonging to deactivated devices are allowed.
- VPN configuration updates must not add peers for deactivated devices.

### Subnet allocation behavior

#### Provisioning and deprovisioning

- IP and subnet provisioning using the "device" rule remain allowed even for deactivated devices.
- The rationale is to avoid introducing special reactivation logic; actual device usage of those resources remains blocked by the deactivated state.
- Deprovisioning operations always remain allowed to keep address allocation consistent.

