### PR TITLE
[ci] Enabled CI on gsoc26-mass-commands branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - master
       - "1.1"
       - "1.2"
+      - gsoc26-mass-commands
 
 jobs:
   build:


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes
Add `gsoc26-mass-commands` in ci to allow running ci jobs in pull requests
