### PR TITLE
[ci] Enabled CI on gsoc26-x509-certificate-generator-templates branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - master
       - "1.1"
       - "1.2"
+      - "gsoc26-x509-certificate-generator-templates"
 
 jobs:
   build:


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Description of Changes

Added `gsoc26-x509-certificate-generator-templates` to allow running of ci jobs in pull requests
