### PR TITLE
[chores:fix] Preserved text -> jsonb migration for JSONField fields #1370

### DIFF
--- a/openwisp_controller/config/migrations/0001_squashed_0002_config_settings_uuid.py
+++ b/openwisp_controller/config/migrations/0001_squashed_0002_config_settings_uuid.py
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "config",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text="configuration in NetJSON DeviceConfiguration format",
@@ -246,7 +246,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "config",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text="configuration in NetJSON DeviceConfiguration format",
@@ -341,7 +341,7 @@ class Migration(migrations.Migration):
                 ("name", models.CharField(max_length=64, unique=True)),
                 (
                     "config",
-                    models.JSONField(
+                    models.TextField(
                         default=dict,
                         help_text="configuration in NetJSON DeviceConfiguration format",
                         verbose_name="configuration",

--- a/openwisp_controller/config/migrations/0018_config_context.py
+++ b/openwisp_controller/config/migrations/0018_config_context.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="config",
             name="context",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 help_text=(
                     'Additional <a href="http://netjsonconfig.openwisp.org'

--- a/openwisp_controller/config/migrations/0023_update_context.py
+++ b/openwisp_controller/config/migrations/0023_update_context.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="config",
             name="context",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 default=dict,
                 help_text=(

--- a/openwisp_controller/config/migrations/0028_template_default_values.py
+++ b/openwisp_controller/config/migrations/0028_template_default_values.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="template",
             name="default_values",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 default=dict,
                 help_text=(

--- a/openwisp_controller/config/migrations/0036_device_group.py
+++ b/openwisp_controller/config/migrations/0036_device_group.py
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "meta_data",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(

--- a/openwisp_controller/config/migrations/0049_devicegroup_context.py
+++ b/openwisp_controller/config/migrations/0049_devicegroup_context.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="devicegroup",
             name="context",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 default=dict,
                 help_text=(

--- a/openwisp_controller/config/migrations/0051_organizationconfigsettings_context.py
+++ b/openwisp_controller/config/migrations/0051_organizationconfigsettings_context.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="organizationconfigsettings",
             name="context",
-            field=models.JSONField(
+            field=models.TextField(
                 blank=True,
                 default=dict,
                 help_text=(

--- a/openwisp_controller/connection/migrations/0001_initial.py
+++ b/openwisp_controller/connection/migrations/0001_initial.py
@@ -67,7 +67,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "params",
-                    models.JSONField(
+                    models.TextField(
                         default=dict,
                         help_text="global connection parameters",
                         verbose_name="parameters",
@@ -132,7 +132,7 @@ class Migration(migrations.Migration):
                 ("enabled", models.BooleanField(db_index=True, default=True)),
                 (
                     "params",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(

--- a/openwisp_controller/connection/migrations/0007_command.py
+++ b/openwisp_controller/connection/migrations/0007_command.py
@@ -74,7 +74,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "input",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         null=True,
                     ),

--- a/openwisp_controller/pki/migrations/0001_initial.py
+++ b/openwisp_controller/pki/migrations/0001_initial.py
@@ -109,7 +109,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "extensions",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=list,
                         help_text="additional x509 certificate extensions",
@@ -260,7 +260,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "extensions",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=list,
                         help_text="additional x509 certificate extensions",

--- a/tests/openwisp2/sample_config/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_config/migrations/0001_initial.py
@@ -73,7 +73,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "config",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text="configuration in NetJSON DeviceConfiguration format",
@@ -112,7 +112,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "context",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(
@@ -238,7 +238,7 @@ class Migration(migrations.Migration):
                 ("name", models.CharField(db_index=True, max_length=64, unique=True)),
                 (
                     "config",
-                    models.JSONField(
+                    models.TextField(
                         default=dict,
                         help_text="configuration in NetJSON DeviceConfiguration format",
                         verbose_name="configuration",
@@ -502,7 +502,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "config",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text="configuration in NetJSON DeviceConfiguration format",
@@ -565,7 +565,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "default_values",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(
@@ -694,7 +694,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "context",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(
@@ -747,7 +747,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "meta_data",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(
@@ -762,7 +762,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "context",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(

--- a/tests/openwisp2/sample_connection/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_connection/migrations/0001_initial.py
@@ -68,7 +68,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "params",
-                    models.JSONField(
+                    models.TextField(
                         default=dict,
                         help_text="global connection parameters",
                         verbose_name="parameters",
@@ -151,7 +151,7 @@ class Migration(migrations.Migration):
                 ("enabled", models.BooleanField(db_index=True, default=True)),
                 (
                     "params",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=dict,
                         help_text=(
@@ -250,7 +250,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "input",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         null=True,
                     ),

--- a/tests/openwisp2/sample_pki/migrations/0001_initial.py
+++ b/tests/openwisp2/sample_pki/migrations/0001_initial.py
@@ -126,7 +126,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "extensions",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=list,
                         help_text="additional x509 certificate extensions",
@@ -302,7 +302,7 @@ class Migration(migrations.Migration):
                 ),
                 (
                     "extensions",
-                    models.JSONField(
+                    models.TextField(
                         blank=True,
                         default=list,
                         help_text="additional x509 certificate extensions",


### PR DESCRIPTION




## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #1370

## Description of Changes

Historical migrations were updated to use models.TextField instead of models.JSONField for fields originally backed by the third-party jsonfield library.

The original jsonfield.fields.JSONField inherited from TextField and stored values as PostgreSQL text. Replacing historical migration definitions with models.JSONField caused Django to interpret the migration transition as JSONField -> JSONField, resulting in a no-op migration and preventing PostgreSQL columns from being converted to jsonb.

By preserving the historical field semantics as TextField, Django can correctly detect the transition from text -> jsonb and generate the required ALTER COLUMN ... TYPE jsonb migration SQL during upgrades.
