### PR TITLE
[fix] Fixed SSH disconnect in DeviceConnection.update_config()

### DIFF
--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -367,7 +367,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
                 self.connector_instance.update_config()
             except Exception as e:
                 logger.exception(e)
-            else:
+            finally:
                 self.disconnect()
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Moves `disconnect()` from `else` to `finally` so the SSH connection is always cleaned up when `update_config()` raises an exception.