### PR TITLE
fix: Secure OpenWrt change_password against OS command injection

### DIFF
--- a/openwisp_controller/connection/connectors/openwrt/ssh.py
+++ b/openwisp_controller/connection/connectors/openwrt/ssh.py
@@ -1,4 +1,5 @@
 import logging
+import shlex
 
 from packaging import version
 
@@ -46,8 +47,11 @@ class OpenWrt(Ssh):
         return self.exec_command("reboot")
 
     def change_password(self, password, confirm_password, user="root"):
+        safe_password = shlex.quote(password)
+        safe_confirm = shlex.quote(confirm_password)
+        safe_user = shlex.quote(user)
         return self.exec_command(
-            f'echo -e "{password}\n{confirm_password}" | passwd {user}'
+            f"printf '%s\\n%s\\n' {safe_password} {safe_confirm} | passwd {safe_user}"
         )
 
 

--- a/openwisp_controller/connection/tests/test_models.py
+++ b/openwisp_controller/connection/tests/test_models.py
@@ -714,7 +714,7 @@ HZAAAAgAhZz8ve4sK9Wbopq43Cu2kQDgX4NoA6W+FCmxCKf5AhYIzYQxIqyCazd7MrjCwS""",
             connect_mocked.assert_called_once()
             mocked_exec_command.assert_called_once()
             mocked_exec_command.assert_called_with(
-                'echo -e "Newpasswd@123\nNewpasswd@123" | passwd root',
+                "printf '%s\\n%s\\n' 'Newpasswd@123' 'Newpasswd@123' | passwd 'root'",
                 timeout=app_settings.SSH_COMMAND_TIMEOUT,
             )
         command.refresh_from_db()


### PR DESCRIPTION
# Security Fix for OS Command Injection

We have identified and resolved a critical OS Command Injection vulnerability in the OpenWrt connection connector (change_password method). 

## Changes Made

### 1. Hardened command building in ssh.py
- **File**: [ssh.py](file:///d:/openwisp-controller/openwisp_controller/connection/connectors/openwrt/ssh.py#L47-L56)
- **Problem**: The original change_password method accepted unescaped user inputs password, confirm_password, and user, interpolating them directly into a double-quoted shell string inside echo -e. This allowed authenticated users to inject arbitrary shell commands.
- **Solution**:
  - Imported shlex and sanitized all inputs (password, confirm_password, user) using shlex.quote().
  - Refactored the command execution to use printf '%s\n%s\n' instead of echo -e. This avoids backslash interpretation issues for passwords that might contain backslashes, ensuring standard POSIX-compliant piping to the passwd binary.

### 2. Updated corresponding test case
- **File**: [test_models.py](file:///d:/openwisp-controller/openwisp_controller/connection/tests/test_models.py#L713-L720)
- **Solution**: Updated the test assertion in test_execute_change_password to match the newly generated, securely escaped command format (printf '%s\n%s\n' 'Newpasswd@123' 'Newpasswd@123' | passwd 'root').