### PR TITLE
[fix] Added generic cache invalidation for related model changes

### DIFF
--- a/openwisp_controller/config/apps.py
+++ b/openwisp_controller/config/apps.py
@@ -67,6 +67,7 @@ class ConfigConfig(AppConfig):
         self.vpn_model = load_model("config", "Vpn")
         self.vpnclient_model = load_model("config", "VpnClient")
         self.org_limits = load_model("config", "OrganizationLimits")
+        self.ca_model = load_model("django_x509", "Ca")
         self.cert_model = load_model("django_x509", "Cert")
         self.org_model = load_model("openwisp_users", "Organization")
 
@@ -278,6 +279,7 @@ class ConfigConfig(AppConfig):
             device_cache_invalidation_handler,
             devicegroup_change_handler,
             devicegroup_delete_handler,
+            related_object_cache_invalidation_handler,
             vpn_server_change_handler,
         )
 
@@ -343,6 +345,17 @@ class ConfigConfig(AppConfig):
             vpn_server_change_handler,
             sender=self.vpn_model,
             dispatch_uid="vpn.invalidate_checksum_cache",
+        )
+        # cache invalidation via generic mechanism
+        post_save.connect(
+            related_object_cache_invalidation_handler,
+            sender=self.ca_model,
+            dispatch_uid="related_cache_ca_post_save",
+        )
+        post_save.connect(
+            related_object_cache_invalidation_handler,
+            sender=self.cert_model,
+            dispatch_uid="related_cache_cert_post_save",
         )
 
     def register_dashboard_charts(self):

--- a/openwisp_controller/config/apps.py
+++ b/openwisp_controller/config/apps.py
@@ -346,7 +346,6 @@ class ConfigConfig(AppConfig):
             sender=self.vpn_model,
             dispatch_uid="vpn.invalidate_checksum_cache",
         )
-        # cache invalidation via generic mechanism
         post_save.connect(
             related_object_cache_invalidation_handler,
             sender=self.ca_model,

--- a/openwisp_controller/config/base/base.py
+++ b/openwisp_controller/config/base/base.py
@@ -33,6 +33,7 @@ class ChecksumCacheMixin:
     """
 
     _CHECKSUM_CACHE_TIMEOUT = 60 * 60 * 24 * 30  # 30 days
+    cache_invalidation_relations = {}
 
     @cache_memoize(
         timeout=_CHECKSUM_CACHE_TIMEOUT, args_rewrite=get_cached_args_rewrite

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -139,6 +139,11 @@ class AbstractVpn(ConfigChecksumCacheMixin, ShareableOrgMixinUniqueName, BaseCon
     # cache wireguard / vxlan peers for 7 days (generation is expensive)
     _PEER_CACHE_TIMEOUT = 60 * 60 * 24 * 7
 
+    cache_invalidation_relations = {
+        "Ca": ("ca", "invalidate_checksum_cache"),
+        "Cert": ("cert", "invalidate_checksum_cache"),
+    }
+
     class Meta:
         verbose_name = _("VPN server")
         verbose_name_plural = _("VPN servers")

--- a/openwisp_controller/config/handlers.py
+++ b/openwisp_controller/config/handlers.py
@@ -13,6 +13,7 @@ Config = load_model("config", "Config")
 Device = load_model("config", "Device")
 DeviceGroup = load_model("config", "DeviceGroup")
 Organization = load_model("openwisp_users", "Organization")
+Vpn = load_model("config", "Vpn")
 Cert = load_model("django_x509", "Cert")
 
 
@@ -152,3 +153,18 @@ def organization_disabled_handler(instance, **kwargs):
         # No change in is_active
         return
     tasks.invalidate_controller_views_cache.delay(str(instance.id))
+
+
+def related_object_cache_invalidation_handler(sender, instance, **kwargs):
+    related_pk = instance.pk
+    for dependent_model in [Vpn, Config, Device]:
+        relations = getattr(dependent_model, "cache_invalidation_relations", {})
+        sender_name = sender._meta.object_name
+        if sender_name in relations:
+            field_name, method_name = relations[sender_name]
+            tasks.invalidate_related_cache.delay(
+                dependent_model._meta.object_name,
+                field_name,
+                related_pk,
+                method_name,
+            )

--- a/openwisp_controller/config/handlers.py
+++ b/openwisp_controller/config/handlers.py
@@ -162,9 +162,8 @@ def related_object_cache_invalidation_handler(sender, instance, **kwargs):
         sender_name = sender._meta.object_name
         if sender_name in relations:
             field_name, method_name = relations[sender_name]
-            tasks.invalidate_related_cache.delay(
-                dependent_model._meta.object_name,
-                field_name,
-                related_pk,
-                method_name,
+            transaction.on_commit(
+                lambda dm=dependent_model, fn=field_name, mn=method_name, rp=related_pk: tasks.invalidate_related_cache.delay(  # noqa: E501
+                    dm._meta.object_name, fn, rp, mn
+                )
             )

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -222,5 +222,14 @@ def invalidate_controller_views_cache(organization_id):
 @shared_task(soft_time_limit=7200)
 def invalidate_related_cache(dependent_model, relation_field, related_pk, method_name):
     model = load_model("config", dependent_model)
-    for instance in model.objects.filter(**{relation_field: related_pk}).iterator():
-        getattr(instance, method_name)()
+    try:
+        for instance in model.objects.filter(
+            **{relation_field: related_pk}
+        ).iterator():
+            getattr(instance, method_name)()
+    except SoftTimeLimitExceeded:
+        logger.error(
+            f"soft time limit hit while executing "
+            f"invalidate_related_cache for {dependent_model} "
+            f"(relation_field: {relation_field}, related_pk: {related_pk})"
+        )

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -223,9 +223,7 @@ def invalidate_controller_views_cache(organization_id):
 def invalidate_related_cache(dependent_model, relation_field, related_pk, method_name):
     model = load_model("config", dependent_model)
     try:
-        for instance in model.objects.filter(
-            **{relation_field: related_pk}
-        ).iterator():
+        for instance in model.objects.filter(**{relation_field: related_pk}).iterator():
             getattr(instance, method_name)()
     except SoftTimeLimitExceeded:
         logger.error(

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -217,3 +217,10 @@ def invalidate_controller_views_cache(organization_id):
         Vpn.objects.filter(organization_id=organization_id).only("id").iterator()
     ):
         GetVpnView.invalidate_get_vpn_cache(vpn)
+
+
+@shared_task(base=OpenwispCeleryTask, soft_time_limit=7200)
+def invalidate_related_cache(dependent_model, relation_field, related_pk, method_name):
+    model = load_model("config", dependent_model)
+    for instance in model.objects.filter(**{relation_field: related_pk}).iterator():
+        getattr(instance, method_name)()

--- a/openwisp_controller/config/tasks.py
+++ b/openwisp_controller/config/tasks.py
@@ -219,7 +219,7 @@ def invalidate_controller_views_cache(organization_id):
         GetVpnView.invalidate_get_vpn_cache(vpn)
 
 
-@shared_task(base=OpenwispCeleryTask, soft_time_limit=7200)
+@shared_task(soft_time_limit=7200)
 def invalidate_related_cache(dependent_model, relation_field, related_pk, method_name):
     model = load_model("config", dependent_model)
     for instance in model.objects.filter(**{relation_field: related_pk}).iterator():

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -496,23 +496,23 @@ class TestVpn(BaseTestVpn, TestCase):
 
     def test_cache_invalidation_on_related_ca_change(self):
         vpn = self._create_vpn()
-        cached_checksum = vpn.get_cached_checksum()
-
-        vpn.ca.key_length = "4096"
-        vpn.ca.full_clean()
-        vpn.ca.save()
-
-        self.assertNotEqual(cached_checksum, vpn.get_cached_checksum())
+        with mock.patch.object(tasks, 'invalidate_related_cache') as mock_task:
+            vpn.ca.key_length = "4096"
+            vpn.ca.full_clean()
+            vpn.ca.save()
+            mock_task.delay.assert_called_once_with(
+                'Vpn', 'ca', vpn.ca.pk, 'invalidate_checksum_cache'
+            )
 
     def test_cache_invalidation_on_related_cert_change(self):
         vpn = self._create_vpn()
-        cached_checksum = vpn.get_cached_checksum()
-
-        vpn.cert.key_length = "4096"
-        vpn.cert.full_clean()
-        vpn.cert.save()
-
-        self.assertNotEqual(cached_checksum, vpn.get_cached_checksum())
+        with mock.patch.object(tasks, 'invalidate_related_cache') as mock_task:
+            vpn.cert.key_length = "4096"
+            vpn.cert.full_clean()
+            vpn.cert.save()
+            mock_task.delay.assert_called_once_with(
+                'Vpn', 'cert', vpn.cert.pk, 'invalidate_checksum_cache'
+            )
 
 
 class TestVpnTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTestCase):

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -20,7 +20,7 @@ from .. import settings as app_settings
 from ..exceptions import ZeroTierIdentityGenerationError
 from ..settings import API_TASK_RETRY_OPTIONS
 from ..signals import config_modified, vpn_peers_changed, vpn_server_modified
-from ..tasks import create_vpn_dh, trigger_vpn_server_endpoint
+from ..tasks import create_vpn_dh, invalidate_related_cache, trigger_vpn_server_endpoint
 from .utils import (
     CreateConfigTemplateMixin,
     TestVpnX509Mixin,
@@ -496,22 +496,22 @@ class TestVpn(BaseTestVpn, TestCase):
 
     def test_cache_invalidation_on_related_ca_change(self):
         vpn = self._create_vpn()
-        with mock.patch.object(tasks, 'invalidate_related_cache') as mock_task:
+        with mock.patch.object(invalidate_related_cache, "delay") as mock_task:
             vpn.ca.key_length = "4096"
             vpn.ca.full_clean()
             vpn.ca.save()
-            mock_task.delay.assert_called_once_with(
-                'Vpn', 'ca', vpn.ca.pk, 'invalidate_checksum_cache'
+            mock_task.assert_called_once_with(
+                "Vpn", "ca", vpn.ca.pk, "invalidate_checksum_cache"
             )
 
     def test_cache_invalidation_on_related_cert_change(self):
         vpn = self._create_vpn()
-        with mock.patch.object(tasks, 'invalidate_related_cache') as mock_task:
+        with mock.patch.object(invalidate_related_cache, "delay") as mock_task:
             vpn.cert.key_length = "4096"
             vpn.cert.full_clean()
             vpn.cert.save()
-            mock_task.delay.assert_called_once_with(
-                'Vpn', 'cert', vpn.cert.pk, 'invalidate_checksum_cache'
+            mock_task.assert_called_once_with(
+                "Vpn", "cert", vpn.cert.pk, "invalidate_checksum_cache"
             )
 
 

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -494,6 +494,26 @@ class TestVpn(BaseTestVpn, TestCase):
             self.assertIn("ca", message_dict)
             self.assertIn("CA is required with this VPN backend", message_dict["ca"])
 
+    def test_cache_invalidation_on_related_ca_change(self):
+        vpn = self._create_vpn()
+        cached_checksum = vpn.get_cached_checksum()
+
+        vpn.ca.key_size = 4096
+        vpn.ca.full_clean()
+        vpn.ca.save()
+
+        self.assertNotEqual(cached_checksum, vpn.get_cached_checksum())
+
+    def test_cache_invalidation_on_related_cert_change(self):
+        vpn = self._create_vpn()
+        cached_checksum = vpn.get_cached_checksum()
+
+        vpn.cert.key_size = 4096
+        vpn.cert.full_clean()
+        vpn.cert.save()
+
+        self.assertNotEqual(cached_checksum, vpn.get_cached_checksum())
+
 
 class TestVpnTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTestCase):
     @mock.patch.object(create_vpn_dh, "delay")

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -20,7 +20,7 @@ from .. import settings as app_settings
 from ..exceptions import ZeroTierIdentityGenerationError
 from ..settings import API_TASK_RETRY_OPTIONS
 from ..signals import config_modified, vpn_peers_changed, vpn_server_modified
-from ..tasks import create_vpn_dh, invalidate_related_cache, trigger_vpn_server_endpoint
+from ..tasks import create_vpn_dh, trigger_vpn_server_endpoint
 from .utils import (
     CreateConfigTemplateMixin,
     TestVpnX509Mixin,
@@ -494,26 +494,6 @@ class TestVpn(BaseTestVpn, TestCase):
             self.assertIn("ca", message_dict)
             self.assertIn("CA is required with this VPN backend", message_dict["ca"])
 
-    def test_cache_invalidation_on_related_ca_change(self):
-        vpn = self._create_vpn()
-        with mock.patch.object(invalidate_related_cache, "delay") as mock_task:
-            vpn.ca.key_length = "4096"
-            vpn.ca.full_clean()
-            vpn.ca.save()
-            mock_task.assert_called_once_with(
-                "Vpn", "ca", vpn.ca.pk, "invalidate_checksum_cache"
-            )
-
-    def test_cache_invalidation_on_related_cert_change(self):
-        vpn = self._create_vpn()
-        with mock.patch.object(invalidate_related_cache, "delay") as mock_task:
-            vpn.cert.key_length = "4096"
-            vpn.cert.full_clean()
-            vpn.cert.save()
-            mock_task.assert_called_once_with(
-                "Vpn", "cert", vpn.cert.pk, "invalidate_checksum_cache"
-            )
-
 
 class TestVpnTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTestCase):
     @mock.patch.object(create_vpn_dh, "delay")
@@ -557,6 +537,30 @@ class TestVpnTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTestCase
             config=device.config,
             device=device,
         )
+
+    def test_cache_invalidation_on_related_ca_change(self):
+        vpn = self._create_vpn()
+        with mock.patch.object(
+            type(vpn), "checksum", new_callable=mock.PropertyMock
+        ) as mocked_checksum:
+            mocked_checksum.return_value = "fake-cached-checksum"
+            self.assertEqual(vpn.get_cached_checksum(), "fake-cached-checksum")
+        vpn.ca.key_length = "4096"
+        vpn.ca.full_clean()
+        vpn.ca.save()
+        self.assertNotEqual(vpn.get_cached_checksum(), "fake-cached-checksum")
+
+    def test_cache_invalidation_on_related_cert_change(self):
+        vpn = self._create_vpn()
+        with mock.patch.object(
+            type(vpn), "checksum", new_callable=mock.PropertyMock
+        ) as mocked_checksum:
+            mocked_checksum.return_value = "fake-cached-checksum"
+            self.assertEqual(vpn.get_cached_checksum(), "fake-cached-checksum")
+        vpn.cert.key_length = "4096"
+        vpn.cert.full_clean()
+        vpn.cert.save()
+        self.assertNotEqual(vpn.get_cached_checksum(), "fake-cached-checksum")
 
 
 class TestWireguard(BaseTestVpn, TestWireguardVpnMixin, TestCase):

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -498,7 +498,7 @@ class TestVpn(BaseTestVpn, TestCase):
         vpn = self._create_vpn()
         cached_checksum = vpn.get_cached_checksum()
 
-        vpn.ca.key_size = 4096
+        vpn.ca.key_length = "4096"
         vpn.ca.full_clean()
         vpn.ca.save()
 
@@ -508,7 +508,7 @@ class TestVpn(BaseTestVpn, TestCase):
         vpn = self._create_vpn()
         cached_checksum = vpn.get_cached_checksum()
 
-        vpn.cert.key_size = 4096
+        vpn.cert.key_length = "4096"
         vpn.cert.full_clean()
         vpn.cert.save()
 

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -1,4 +1,4 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from packaging.version import parse as parse_version
 from rest_framework import VERSION as REST_FRAMEWORK_VERSION
@@ -15,7 +15,6 @@ Ca = load_model("django_x509", "Ca")
 Cert = load_model("django_x509", "Cert")
 
 
-@override_settings(CELERY_TASK_ALWAYS_EAGER=False)
 class TestPkiApi(
     AssertNumQueriesSubTestMixin,
     TestAdminMixin,

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -1,4 +1,4 @@
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from packaging.version import parse as parse_version
 from rest_framework import VERSION as REST_FRAMEWORK_VERSION
@@ -15,6 +15,7 @@ Ca = load_model("django_x509", "Ca")
 Cert = load_model("django_x509", "Cert")
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=False)
 class TestPkiApi(
     AssertNumQueriesSubTestMixin,
     TestAdminMixin,
@@ -51,7 +52,7 @@ class TestPkiApi(
         self.assertEqual(Ca.objects.count(), 0)
         path = reverse("pki_api:ca_list")
         data = self._ca_data
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -61,7 +62,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_list")
         data = self._ca_data
         data["extensions"] = []
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(r.data["extensions"], [])
@@ -77,7 +78,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            7 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 6
+            6 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 5
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -97,7 +98,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -124,7 +125,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
         org2 = self._create_org()
         data = {"name": "change-ca1", "organization": org2.pk, "notes": "change-notes"}
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -137,7 +138,7 @@ class TestPkiApi(
         data = {
             "name": "change-ca1",
         }
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(6):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -161,7 +162,7 @@ class TestPkiApi(
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         old_serial_num = ca1.serial_number
         path = reverse("pki_api:ca_renew", args=[ca1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.post(path)
         ca1.refresh_from_db()
         self.assertEqual(r.status_code, 200)
@@ -172,7 +173,7 @@ class TestPkiApi(
         path = reverse("pki_api:cert_list")
         data = self._cert_data
         data["ca"] = self._create_ca().pk
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -189,7 +190,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            11 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 10
+            10 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -205,7 +206,7 @@ class TestPkiApi(
         data = self._cert_data
         data["ca"] = self._create_ca().pk
         data["extensions"] = []
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -221,7 +222,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -253,7 +254,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(10):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -264,7 +265,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(8):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -289,7 +290,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -300,7 +301,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -253,7 +253,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(10):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -264,7 +264,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -272,7 +272,7 @@ class TestPkiApi(
     def test_cert_delete_api(self):
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             r = self.client.delete(path)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Cert.objects.count(), 0)
@@ -289,7 +289,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -300,7 +300,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -254,7 +254,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(9):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -265,7 +265,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(7):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -273,7 +273,7 @@ class TestPkiApi(
     def test_cert_delete_api(self):
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             r = self.client.delete(path)
         self.assertEqual(r.status_code, 204)
         self.assertEqual(Cert.objects.count(), 0)
@@ -290,7 +290,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(4):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -301,7 +301,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -51,7 +51,7 @@ class TestPkiApi(
         self.assertEqual(Ca.objects.count(), 0)
         path = reverse("pki_api:ca_list")
         data = self._ca_data
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -61,7 +61,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_list")
         data = self._ca_data
         data["extensions"] = []
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(r.data["extensions"], [])
@@ -77,7 +77,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            6 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 5
+            7 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 6
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -97,7 +97,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Ca.objects.count(), 1)
@@ -124,7 +124,7 @@ class TestPkiApi(
         path = reverse("pki_api:ca_detail", args=[ca1.pk])
         org2 = self._create_org()
         data = {"name": "change-ca1", "organization": org2.pk, "notes": "change-notes"}
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -137,7 +137,7 @@ class TestPkiApi(
         data = {
             "name": "change-ca1",
         }
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(7):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "change-ca1")
@@ -161,7 +161,7 @@ class TestPkiApi(
         ca1 = self._create_ca(name="ca1", organization=self._get_org())
         old_serial_num = ca1.serial_number
         path = reverse("pki_api:ca_renew", args=[ca1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             r = self.client.post(path)
         ca1.refresh_from_db()
         self.assertEqual(r.status_code, 200)
@@ -172,7 +172,7 @@ class TestPkiApi(
         path = reverse("pki_api:cert_list")
         data = self._cert_data
         data["ca"] = self._create_ca().pk
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -189,7 +189,7 @@ class TestPkiApi(
             "private_key": ca1.private_key,
         }
         expected_queries = (
-            10 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 9
+            11 if parse_version(REST_FRAMEWORK_VERSION) >= parse_version("3.15") else 10
         )
         with self.assertNumQueries(expected_queries):
             r = self.client.post(path, data, content_type="application/json")
@@ -205,7 +205,7 @@ class TestPkiApi(
         data = self._cert_data
         data["ca"] = self._create_ca().pk
         data["extensions"] = []
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -221,7 +221,7 @@ class TestPkiApi(
             "validity_start": None,
             "validity_end": None,
         }
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Cert.objects.count(), 1)
@@ -253,7 +253,7 @@ class TestPkiApi(
             "organization": org2.pk,
             "notes": "new-notes",
         }
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             r = self.client.put(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -264,7 +264,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         path = reverse("pki_api:cert_detail", args=[cert1.pk])
         data = {"name": "cert1-change"}
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9):
             r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "cert1-change")
@@ -289,7 +289,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         old_serial_num = cert1.serial_number
         path = reverse("pki_api:cert_renew", args=[cert1.pk])
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             r = self.client.post(path)
         self.assertEqual(r.status_code, 200)
         cert1.refresh_from_db()
@@ -300,7 +300,7 @@ class TestPkiApi(
         cert1 = self._create_cert(name="cert1")
         self.assertFalse(cert1.revoked)
         path = reverse("pki_api:cert_revoke", args=[cert1.pk])
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(5):
             r = self.client.post(path)
         cert1.refresh_from_db()
         self.assertEqual(r.status_code, 200)


### PR DESCRIPTION
## Checklist

 I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
 I have manually tested the changes proposed in this pull request.
 I have written new test cases for new code and/or updated existing tests for changes to existing code.
 I have updated the documentation.

## Description

Implements an extensible cache invalidation mechanism that automatically invalidates caches when related model instances are updated.

## Changes

- Added `cache_invalidation_relations` to `ChecksumCacheMixin` (base class for cached models)
- Configured `AbstractVpn` to invalidate its cache when `Ca` or `Cert` is updated
- Added generic signal handler `related_object_cache_invalidation_handler`
- Added Celery task `invalidate_related_cache` for async invalidation
- Connected Ca/Cert post_save signals in `enable_cache_invalidation()`

## Closes

Closes #1095