### PR TITLE
[fix] Fixed command/connection resurrection and cache interference in CI

### DIFF
--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -367,7 +367,7 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
             # should be deleted based on the new selection.
             #
             # Therefore, we defer deletion of VpnClient objects until the "post_add"
-            # signal is triggered again—after all templates, including the required
+            # signal is triggered again, after all templates, including the required
             # ones, have been fully added. At that point, we can identify and
             # delete VpnClient objects not linked to the final template set.
             instance.vpnclient_set.exclude(

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -375,7 +375,10 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
             ).delete()
 
         if action == "post_add":
-            for template in templates.filter(type="vpn"):
+            # Reconcile against the full current VPN-template set (not just this
+            # cycle's pk_set delta) so the create stays idempotent across the
+            # multiple m2m cycles a single template change fires.
+            for template in instance.templates.filter(type="vpn"):
                 # Create VPN client if needed
                 if not vpn_client_model.objects.filter(
                     config=instance, vpn=template.vpn, template=template

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -342,42 +342,30 @@ class AbstractConfig(ChecksumCacheMixin, BaseConfig):
             return
 
         vpn_client_model = cls.vpn.through
-        # coming from signal
+        # Signals pass a set of template IDs.
         if isinstance(pk_set, set):
             template_model = cls.get_template_model()
             templates = template_model.objects.filter(pk__in=list(pk_set)).order_by(
                 "created"
             )
-        # coming from admin ModelForm
+        # Admin ModelForms pass template instances.
         else:
             templates = pk_set
 
-        # Check if all templates in pk_set are required templates. If they are,
-        # skip deletion of VpnClient objects at this point.
+        # SortedManyToManyField may clear templates and add required templates
+        # back before the final template set is restored. During that
+        # intermediate state we cannot know which VpnClient objects should be
+        # removed, so deletion is delayed until a later post_add event sees
+        # the final template set.
         if len(pk_set) != templates.filter(required=True).count():
-            # Explanation:
-            # SortedManyToManyField clears all existing templates before adding
-            # new ones. This triggers an m2m_changed signal with the "post_clear"
-            # action, which is handled by the "enforce_required_templates" signal
-            # receiver. That receiver re-adds the required templates.
-            #
-            # Re-adding required templates triggers another m2m_changed signal
-            # with the "post_add" action. At this stage, only required templates
-            # exist in the DB, so we cannot yet determine which VpnClient objects
-            # should be deleted based on the new selection.
-            #
-            # Therefore, we defer deletion of VpnClient objects until the "post_add"
-            # signal is triggered again, after all templates, including the required
-            # ones, have been fully added. At that point, we can identify and
-            # delete VpnClient objects not linked to the final template set.
             instance.vpnclient_set.exclude(
                 template_id__in=instance.templates.values_list("id", flat=True)
             ).delete()
 
         if action == "post_add":
-            # Reconcile against the full current VPN-template set (not just this
-            # cycle's pk_set delta) so the create stays idempotent across the
-            # multiple m2m cycles a single template change fires.
+            # A single template change can trigger multiple m2m_changed events.
+            # Use the full current template set instead of this event's pk_set so
+            # every attached VPN template has its VpnClient.
             for template in instance.templates.filter(type="vpn"):
                 # Create VPN client if needed
                 if not vpn_client_model.objects.filter(

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -1342,6 +1342,18 @@ class TestConfigApiTransaction(
         super().setUp()
         self._login()
 
+    def test_session_survives_default_cache_clear(self):
+        # The authenticated session must live in a cache separate from the
+        # default one: tests (e.g. whois) call cache.clear() on the default
+        # cache and parallel workers share it, so storing sessions there made
+        # the session disappear mid-test and produced flaky 401 responses.
+        from django.core.cache import cache
+
+        path = reverse("config_api:device_list")
+        self.assertEqual(self.client.get(path).status_code, 200)
+        cache.clear()
+        self.assertEqual(self.client.get(path).status_code, 200)
+
     def _get_devicegroup_org_cert(self):
         org = self._get_org()
         device_group = self._create_device_group(organization=org)

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.contrib.auth.models import Permission
+from django.core.cache import cache
 from django.test import TestCase
 from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from django.test.testcases import TransactionTestCase
@@ -1347,8 +1348,6 @@ class TestConfigApiTransaction(
         # default one: tests (e.g. whois) call cache.clear() on the default
         # cache and parallel workers share it, so storing sessions there made
         # the session disappear mid-test and produced flaky 401 responses.
-        from django.core.cache import cache
-
         path = reverse("config_api:device_list")
         self.assertEqual(self.client.get(path).status_code, 200)
         cache.clear()

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -37,13 +37,9 @@ logger = logging.getLogger(__name__)
 
 def _save_without_resurrecting(instance):
     """
-    Persists ``instance`` without resurrecting a row that was deleted
-    concurrently (e.g. a background command racing a deletion or a test
-    teardown). A plain save() would find no row to update and fall back to an
-    INSERT, recreating the row with dangling foreign keys; the resulting
-    IntegrityError can also break the live-server database connection during
-    selenium tests. Force an UPDATE so no INSERT can happen, ignore the case
-    where the row is already gone, and re-raise any other database error.
+    Save an existing object without recreating it if its row was deleted by a
+    concurrent task. Plain save() may fall back to INSERT when UPDATE affects no
+    rows, so use force_update=True and ignore only the missing-row case.
     """
     if instance._state.adding:
         instance.save()
@@ -401,8 +397,6 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
         self._initial_failure_reason = self.failure_reason
 
     def _save_without_resurrecting(self):
-        """Delegate to the module-level helper of the same name (kept as a
-        method so callers such as launch_command need no import)."""
         _save_without_resurrecting(self)
 
     def send_is_working_changed_signal(self):
@@ -545,8 +539,6 @@ class AbstractCommand(TimeStampedEditableModel):
         return output
 
     def _save_without_resurrecting(self):
-        """Delegate to the module-level helper of the same name (kept as a
-        method so callers such as launch_command need no import)."""
         _save_without_resurrecting(self)
 
     def _schedule_command(self):
@@ -566,9 +558,8 @@ class AbstractCommand(TimeStampedEditableModel):
             raise RuntimeError(
                 "This command has already been executed, " "please create a new one."
             )
-        # The command may have been deleted after being scheduled (e.g. by a
-        # user or by a cascading delete) while this background task was queued:
-        # do not perform the remote action for a command that no longer exists.
+        # The command may have been deleted after being scheduled. If so, do not
+        # send it to the device.
         if (
             not self._state.adding
             and not self._meta.model.objects.filter(pk=self.pk).exists()

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -4,7 +4,7 @@ import django
 import jsonschema
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import models, transaction
+from django.db import DatabaseError, models, transaction
 from django.db.models import JSONField
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -355,14 +355,17 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
         finally:
             self.last_attempt = timezone.now()
             # Avoid resurrecting a connection whose row was deleted (e.g. a
-            # background command racing a deletion or test teardown): record the
-            # attempt only if the connection still exists, otherwise save() would
-            # fall back to an INSERT with a dangling device foreign key.
-            if (
-                self._state.adding
-                or type(self)._base_manager.filter(pk=self.pk).exists()
-            ):
+            # background command racing a deletion or test teardown): force an
+            # UPDATE so save() cannot fall back to an INSERT with a dangling
+            # device foreign key, and ignore the error Django raises when there
+            # is no row to update.
+            if self._state.adding:
                 self.save()
+            else:
+                try:
+                    self.save(force_update=True)
+                except DatabaseError:
+                    pass
         return self.is_working
 
     def disconnect(self):

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -354,18 +354,24 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             self.failure_reason = ""
         finally:
             self.last_attempt = timezone.now()
-            # Avoid resurrecting a connection whose row was deleted (e.g. a
-            # background command racing a deletion or test teardown): force an
-            # UPDATE so save() cannot fall back to an INSERT with a dangling
-            # device foreign key, and ignore the error Django raises when there
-            # is no row to update.
+            # Force an UPDATE so save() cannot fall back to an INSERT and
+            # resurrect a connection whose row was deleted (e.g. a background
+            # command racing a deletion or test teardown) with a dangling device
+            # foreign key.
             if self._state.adding:
                 self.save()
             else:
                 try:
                     self.save(force_update=True)
                 except DatabaseError:
-                    pass
+                    # If the row is gone there is nothing to persist, so the
+                    # deletion race is ignored; any other write failure is a
+                    # genuine error that must be logged and re-raised.
+                    if type(self)._base_manager.filter(pk=self.pk).exists():
+                        logger.error(
+                            "Failed to persist connection attempt for %s", self.pk
+                        )
+                        raise
         return self.is_working
 
     def disconnect(self):

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -556,6 +556,14 @@ class AbstractCommand(TimeStampedEditableModel):
             raise RuntimeError(
                 "This command has already been executed, " "please create a new one."
             )
+        # The command may have been deleted after being scheduled (e.g. by a
+        # user or by a cascading delete) while this background task was queued:
+        # do not perform the remote action for a command that no longer exists.
+        if (
+            not self._state.adding
+            and not type(self)._base_manager.filter(pk=self.pk).exists()
+        ):
+            return
         exit_code = self._exec_command()
         # if output is None, the commands couldn't execute
         # because the system couldn't connect to the device

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -35,6 +35,29 @@ from ..tasks import auto_add_credentials_to_devices, launch_command
 logger = logging.getLogger(__name__)
 
 
+def _save_without_resurrecting(instance):
+    """
+    Persists ``instance`` without resurrecting a row that was deleted
+    concurrently (e.g. a background command racing a deletion or a test
+    teardown). A plain save() would find no row to update and fall back to an
+    INSERT, recreating the row with dangling foreign keys; the resulting
+    IntegrityError can also break the live-server database connection during
+    selenium tests. Force an UPDATE so no INSERT can happen, ignore the case
+    where the row is already gone, and re-raise any other database error.
+    """
+    if instance._state.adding:
+        instance.save()
+        return
+    try:
+        instance.save(force_update=True)
+    except DatabaseError:
+        if type(instance)._base_manager.filter(pk=instance.pk).exists():
+            logger.error(
+                "Failed to persist %s %s", type(instance).__name__, instance.pk
+            )
+            raise
+
+
 class ConnectorMixin(object):
     _connector_field = "connector"
 
@@ -354,24 +377,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             self.failure_reason = ""
         finally:
             self.last_attempt = timezone.now()
-            # Force an UPDATE so save() cannot fall back to an INSERT and
-            # resurrect a connection whose row was deleted (e.g. a background
-            # command racing a deletion or test teardown) with a dangling device
-            # foreign key.
-            if self._state.adding:
-                self.save()
-            else:
-                try:
-                    self.save(force_update=True)
-                except DatabaseError:
-                    # If the row is gone there is nothing to persist, so the
-                    # deletion race is ignored; any other write failure is a
-                    # genuine error that must be logged and re-raised.
-                    if type(self)._base_manager.filter(pk=self.pk).exists():
-                        logger.error(
-                            "Failed to persist connection attempt for %s", self.pk
-                        )
-                        raise
+            _save_without_resurrecting(self)
         return self.is_working
 
     def disconnect(self):
@@ -563,7 +569,11 @@ class AbstractCommand(TimeStampedEditableModel):
         else:
             self.status = "success"
         self._clean_sensitive_info()
-        self.save()
+        # use the resurrection-safe save: execute() runs from a background task
+        # that can race a deletion of this command (or its device), and a
+        # resurrecting INSERT here raises a FOREIGN KEY error that can corrupt
+        # the live-server DB connection during selenium tests.
+        _save_without_resurrecting(self)
 
     def _exec_command(self):
         """

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -51,7 +51,7 @@ def _save_without_resurrecting(instance):
     try:
         instance.save(force_update=True)
     except DatabaseError:
-        if type(instance)._base_manager.filter(pk=instance.pk).exists():
+        if instance._meta.model.objects.filter(pk=instance.pk).exists():
             logger.error(
                 "Failed to persist %s %s", type(instance).__name__, instance.pk
             )
@@ -377,7 +377,7 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             self.failure_reason = ""
         finally:
             self.last_attempt = timezone.now()
-            _save_without_resurrecting(self)
+            self._save_without_resurrecting()
         return self.is_working
 
     def disconnect(self):
@@ -399,6 +399,11 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             self.send_is_working_changed_signal()
         self._initial_is_working = self.is_working
         self._initial_failure_reason = self.failure_reason
+
+    def _save_without_resurrecting(self):
+        """Delegate to the module-level helper of the same name (kept as a
+        method so callers such as launch_command need no import)."""
+        _save_without_resurrecting(self)
 
     def send_is_working_changed_signal(self):
         is_working_changed.send(
@@ -539,6 +544,11 @@ class AbstractCommand(TimeStampedEditableModel):
             self._schedule_command()
         return output
 
+    def _save_without_resurrecting(self):
+        """Delegate to the module-level helper of the same name (kept as a
+        method so callers such as launch_command need no import)."""
+        _save_without_resurrecting(self)
+
     def _schedule_command(self):
         """
         executes ``launch_command`` celery taks in the background
@@ -561,7 +571,7 @@ class AbstractCommand(TimeStampedEditableModel):
         # do not perform the remote action for a command that no longer exists.
         if (
             not self._state.adding
-            and not type(self)._base_manager.filter(pk=self.pk).exists()
+            and not self._meta.model.objects.filter(pk=self.pk).exists()
         ):
             return
         exit_code = self._exec_command()
@@ -577,11 +587,7 @@ class AbstractCommand(TimeStampedEditableModel):
         else:
             self.status = "success"
         self._clean_sensitive_info()
-        # use the resurrection-safe save: execute() runs from a background task
-        # that can race a deletion of this command (or its device), and a
-        # resurrecting INSERT here raises a FOREIGN KEY error that can corrupt
-        # the live-server DB connection during selenium tests.
-        _save_without_resurrecting(self)
+        self._save_without_resurrecting()
 
     def _exec_command(self):
         """

--- a/openwisp_controller/connection/base/models.py
+++ b/openwisp_controller/connection/base/models.py
@@ -354,7 +354,15 @@ class AbstractDeviceConnection(ConnectorMixin, TimeStampedEditableModel):
             self.failure_reason = ""
         finally:
             self.last_attempt = timezone.now()
-            self.save()
+            # Avoid resurrecting a connection whose row was deleted (e.g. a
+            # background command racing a deletion or test teardown): record the
+            # attempt only if the connection still exists, otherwise save() would
+            # fall back to an INSERT with a dangling device foreign key.
+            if (
+                self._state.adding
+                or type(self)._base_manager.filter(pk=self.pk).exists()
+            ):
+                self.save()
         return self.is_working
 
     def disconnect(self):

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -71,6 +71,9 @@ def launch_command(command_id):
     Launches execution of commands in the background
     """
     Command = load_model("connection", "Command")
+    # imported lazily because models imports this module (avoids a circular import)
+    from .base.models import _save_without_resurrecting
+
     try:
         command = Command.objects.get(pk=command_id)
     except Command.DoesNotExist as e:
@@ -81,18 +84,18 @@ def launch_command(command_id):
     except SoftTimeLimitExceeded:
         command.status = "failed"
         command._add_output(_("Background task time limit exceeded."))
-        command.save()
+        _save_without_resurrecting(command)
     except CommandTimeoutException as e:
         command.status = "failed"
         command._add_output(_(f"The command took longer than expected: {e}"))
-        command.save()
+        _save_without_resurrecting(command)
     except Exception as e:
         logger.exception(
             f"An exception was raised while executing command {command_id}"
         )
         command.status = "failed"
         command._add_output(_(f"Internal system error: {e}"))
-        command.save()
+        _save_without_resurrecting(command)
 
 
 @shared_task(soft_time_limit=3600)

--- a/openwisp_controller/connection/tasks.py
+++ b/openwisp_controller/connection/tasks.py
@@ -71,9 +71,6 @@ def launch_command(command_id):
     Launches execution of commands in the background
     """
     Command = load_model("connection", "Command")
-    # imported lazily because models imports this module (avoids a circular import)
-    from .base.models import _save_without_resurrecting
-
     try:
         command = Command.objects.get(pk=command_id)
     except Command.DoesNotExist as e:
@@ -84,18 +81,18 @@ def launch_command(command_id):
     except SoftTimeLimitExceeded:
         command.status = "failed"
         command._add_output(_("Background task time limit exceeded."))
-        _save_without_resurrecting(command)
+        command._save_without_resurrecting()
     except CommandTimeoutException as e:
         command.status = "failed"
         command._add_output(_(f"The command took longer than expected: {e}"))
-        _save_without_resurrecting(command)
+        command._save_without_resurrecting()
     except Exception as e:
         logger.exception(
             f"An exception was raised while executing command {command_id}"
         )
         command.status = "failed"
         command._add_output(_(f"Internal system error: {e}"))
-        _save_without_resurrecting(command)
+        command._save_without_resurrecting()
 
 
 @shared_task(soft_time_limit=3600)

--- a/openwisp_controller/connection/tests/pytest.py
+++ b/openwisp_controller/connection/tests/pytest.py
@@ -69,7 +69,7 @@ class TestCommandsConsumer(BaseTestModels, CreateCommandMixin):
         }
 
     @mock.patch("paramiko.SSHClient.connect")
-    async def test_new_command_created(self, admin_user, admin_client):
+    async def test_new_command_created(self, mocked_connect, admin_user, admin_client):
         device_conn = await database_sync_to_async(self._create_device_connection)()
         communicator = await self._get_communicator(admin_client, device_conn.device_id)
         command = await self._create_command(device_conn)
@@ -80,7 +80,7 @@ class TestCommandsConsumer(BaseTestModels, CreateCommandMixin):
 
     @mock.patch("paramiko.SSHClient.connect")
     async def test_multiple_connections_receive_updates_with_redis(
-        self, admin_user, admin_client, settings
+        self, mocked_connect, admin_user, admin_client, settings
     ):
         settings.CHANNEL_LAYERS = {
             "default": {

--- a/openwisp_controller/connection/tests/pytest.py
+++ b/openwisp_controller/connection/tests/pytest.py
@@ -78,6 +78,7 @@ class TestCommandsConsumer(BaseTestModels, CreateCommandMixin):
         assert response == expected_response
         await communicator.disconnect()
 
+    @mock.patch("paramiko.SSHClient.connect")
     async def test_multiple_connections_receive_updates_with_redis(
         self, admin_user, admin_client, settings
     ):

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -229,3 +229,26 @@ class TestTransactionTasks(
             command.execute()
         mocked_exec.assert_not_called()
         self.assertFalse(Command.objects.filter(pk=command.pk).exists())
+
+    @mock.patch("paramiko.SSHClient.connect")
+    def test_launch_command_handler_does_not_resurrect_deleted_command(self, *args):
+        # If the command is deleted while execute() runs and execute() then
+        # raises, launch_command's exception handler must not resurrect it.
+        with mock.patch("openwisp_controller.connection.base.models.launch_command"):
+            dc = self._create_device_connection()
+            command = Command(
+                device=dc.device,
+                connection=dc,
+                type="custom",
+                input={"command": "echo test"},
+            )
+            command.full_clean()
+            command.save()
+
+        def _delete_then_raise(self):
+            Command.objects.filter(pk=self.pk).delete()
+            raise RuntimeError("boom")
+
+        with mock.patch.object(Command, "execute", _delete_then_raise):
+            tasks.launch_command(command.pk)
+        self.assertFalse(Command.objects.filter(pk=command.pk).exists())

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -207,3 +207,24 @@ class TestTransactionTasks(
         ):
             with self.assertRaises(DatabaseError):
                 dc.connect()
+
+    @mock.patch("paramiko.SSHClient.connect")
+    def test_execute_does_not_resurrect_deleted_command(self, *args):
+        # execute() runs from a background task and can race a deletion of the
+        # command (or its device); its final save must not resurrect the deleted
+        # row, whose FK error can corrupt the live-server DB during selenium
+        # tests.
+        with mock.patch("openwisp_controller.connection.base.models.launch_command"):
+            dc = self._create_device_connection()
+            command = Command(
+                device=dc.device,
+                connection=dc,
+                type="custom",
+                input={"command": "echo test"},
+            )
+            command.full_clean()
+            command.save()
+        Command.objects.filter(pk=command.pk).delete()
+        with mock.patch.object(command, "_exec_command", return_value=0):
+            command.execute()
+        self.assertFalse(Command.objects.filter(pk=command.pk).exists())

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -181,3 +181,16 @@ class TestTransactionTasks(
         )
         self.assertEqual(response.status_code, 201)
         mocked_update_config.assert_not_called()
+
+    @mock.patch("paramiko.SSHClient.connect", side_effect=Exception("boom"))
+    def test_connect_does_not_resurrect_deleted_connection(self, *args):
+        # A background command (launch_command) can run against a connection
+        # whose row was already deleted by a concurrent deletion or test
+        # teardown. connect() records the attempt with save(); it must not
+        # resurrect the deleted row (an INSERT with a dangling device FK),
+        # which used to surface as flaky "FOREIGN KEY constraint failed".
+        DeviceConnection = load_model("connection", "DeviceConnection")
+        dc = self._create_device_connection()
+        DeviceConnection.objects.filter(pk=dc.pk).delete()
+        dc.connect()
+        self.assertFalse(DeviceConnection.objects.filter(pk=dc.pk).exists())

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -4,6 +4,7 @@ from io import StringIO
 from unittest import mock
 
 from celery.exceptions import SoftTimeLimitExceeded
+from django.db import DatabaseError
 from django.test import TestCase, TransactionTestCase
 from swapper import load_model
 
@@ -194,3 +195,15 @@ class TestTransactionTasks(
         DeviceConnection.objects.filter(pk=dc.pk).delete()
         dc.connect()
         self.assertFalse(DeviceConnection.objects.filter(pk=dc.pk).exists())
+
+    @mock.patch("paramiko.SSHClient.connect", side_effect=Exception("boom"))
+    def test_connect_reraises_genuine_db_error(self, *args):
+        # Only the deleted-row case is ignored: a real database write failure
+        # while the connection still exists must be re-raised, not swallowed.
+        DeviceConnection = load_model("connection", "DeviceConnection")
+        dc = self._create_device_connection()
+        with mock.patch.object(
+            DeviceConnection, "save", side_effect=DatabaseError("boom")
+        ):
+            with self.assertRaises(DatabaseError):
+                dc.connect()

--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -209,11 +209,11 @@ class TestTransactionTasks(
                 dc.connect()
 
     @mock.patch("paramiko.SSHClient.connect")
-    def test_execute_does_not_resurrect_deleted_command(self, *args):
-        # execute() runs from a background task and can race a deletion of the
-        # command (or its device); its final save must not resurrect the deleted
-        # row, whose FK error can corrupt the live-server DB during selenium
-        # tests.
+    def test_execute_skips_deleted_command(self, *args):
+        # A command deleted after being scheduled (e.g. racing a deletion or a
+        # test teardown) must not be sent to the device and must not be
+        # resurrected by its trailing save (whose FK error can corrupt the
+        # live-server DB during selenium tests).
         with mock.patch("openwisp_controller.connection.base.models.launch_command"):
             dc = self._create_device_connection()
             command = Command(
@@ -225,6 +225,7 @@ class TestTransactionTasks(
             command.full_clean()
             command.save()
         Command.objects.filter(pk=command.pk).delete()
-        with mock.patch.object(command, "_exec_command", return_value=0):
+        with mock.patch.object(command, "_exec_command") as mocked_exec:
             command.execute()
+        mocked_exec.assert_not_called()
         self.assertFalse(Command.objects.filter(pk=command.pk).exists())

--- a/openwisp_controller/geo/estimated_location/tests/tests.py
+++ b/openwisp_controller/geo/estimated_location/tests/tests.py
@@ -240,6 +240,15 @@ class TestEstimatedLocationTransaction(
         with mock.patch.object(config_app_settings, "WHOIS_CONFIGURED", True):
             register_estimated_location_notification_types()
 
+    def _warm_org_geo_settings_cache(self, device):
+        # Keep the OrganizationGeoSettings cache warm so the
+        # manage_estimated_locations query count stays deterministic: under a full
+        # suite LocMemCache culling can evict the cached entry between subtests,
+        # adding one geo_organizationgeosettings query and breaking assertNumQueries.
+        EstimatedLocationService.check_estimated_location_enabled(
+            device.organization_id
+        )
+
     @mock.patch.object(config_app_settings, "WHOIS_CONFIGURED", True)
     @mock.patch.object(EstimatedLocationService, "trigger_estimated_location_task")
     @mock.patch(_WHOIS_GEOIP_CLIENT)
@@ -447,6 +456,7 @@ class TestEstimatedLocationTransaction(
             mock_client.return_value.city.return_value = mocked_response
             device.save()
             device.refresh_from_db()
+            self._warm_org_geo_settings_cache(device)
             with self.assertNumQueries(8):
                 manage_estimated_locations(device.pk, device.last_ip)
 
@@ -471,6 +481,7 @@ class TestEstimatedLocationTransaction(
             mock_client.return_value.city.return_value = mocked_response
             device.save()
             device.refresh_from_db()
+            self._warm_org_geo_settings_cache(device)
             with self.assertNumQueries(8):
                 manage_estimated_locations(device.pk, device.last_ip)
 
@@ -495,6 +506,7 @@ class TestEstimatedLocationTransaction(
             device.devicelocation.location.save(_set_estimated=True)
             device.save()
             device.refresh_from_db()
+            self._warm_org_geo_settings_cache(device)
             with self.assertNumQueries(2):
                 manage_estimated_locations(device.pk, device.last_ip)
 

--- a/openwisp_controller/geo/estimated_location/tests/tests.py
+++ b/openwisp_controller/geo/estimated_location/tests/tests.py
@@ -242,9 +242,10 @@ class TestEstimatedLocationTransaction(
 
     def _warm_org_geo_settings_cache(self, device):
         # Keep the OrganizationGeoSettings cache warm so the
-        # manage_estimated_locations query count stays deterministic: under a full
-        # suite LocMemCache culling can evict the cached entry between subtests,
-        # adding one geo_organizationgeosettings query and breaking assertNumQueries.
+        # manage_estimated_locations query count stays deterministic: other tests
+        # (e.g. whois) call cache.clear() on the shared cache, which can drop the
+        # cached entry between subtests, adding one geo_organizationgeosettings
+        # query and breaking assertNumQueries.
         EstimatedLocationService.check_estimated_location_enabled(
             device.organization_id
         )

--- a/openwisp_controller/geo/estimated_location/tests/tests.py
+++ b/openwisp_controller/geo/estimated_location/tests/tests.py
@@ -241,11 +241,13 @@ class TestEstimatedLocationTransaction(
             register_estimated_location_notification_types()
 
     def _warm_org_geo_settings_cache(self, device):
-        # Keep the OrganizationGeoSettings cache warm so the
-        # manage_estimated_locations query count stays deterministic: other tests
-        # (e.g. whois) call cache.clear() on the shared cache, which can drop the
-        # cached entry between subtests, adding one geo_organizationgeosettings
-        # query and breaking assertNumQueries.
+        """
+        Keep the OrganizationGeoSettings cache warm so the
+        manage_estimated_locations query count stays deterministic: other tests
+        (e.g. whois) call cache.clear() on the shared cache, which can drop the
+        cached entry between subtests, adding one geo_organizationgeosettings
+        query and breaking assertNumQueries.
+        """
         EstimatedLocationService.check_estimated_location_enabled(
             device.organization_id
         )

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -166,7 +166,18 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
-    }
+    },
+    # Sessions are kept in a dedicated cache so that tests calling
+    # cache.clear() on the default cache (whois tests do, and parallel
+    # workers share the same cache) cannot wipe the authenticated session
+    # mid-test, which caused flaky 401 responses.
+    "sessions": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"{REDIS_URL}/8",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    },
 }
 
 if not TESTING:
@@ -177,7 +188,7 @@ else:
     CELERY_BROKER_URL = "memory://"
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-SESSION_CACHE_ALIAS = "default"
+SESSION_CACHE_ALIAS = "sessions"
 
 LOGGING = {
     "version": 1,

--- a/tests/openwisp2/settings.py
+++ b/tests/openwisp2/settings.py
@@ -167,10 +167,8 @@ CACHES = {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
     },
-    # Sessions are kept in a dedicated cache so that tests calling
-    # cache.clear() on the default cache (whois tests do, and parallel
-    # workers share the same cache) cannot wipe the authenticated session
-    # mid-test, which caused flaky 401 responses.
+    # Keep sessions outside the default cache because some tests clear it while
+    # parallel workers may still be using authenticated clients.
     "sessions": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": f"{REDIS_URL}/8",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation (not applicable: test and CI-only changes, no user-facing behavior change).

## Reference to Existing Issue

There is no dedicated open issue. This addresses flaky failures observed across recent CI builds (failures by org members that passed on retry, plus a couple of master builds).

## Description of Changes

Fixes the most frequent flaky tests found by analyzing failed CI builds that later passed on retry:

- **VpnClient not switching on template change** (`subnet_division ... test_vpn_template_switch_checksum_db`): `manage_vpn_clients` created the VpnClient only for the templates in the current `m2m_changed` cycle's `pk_set`. A single template change fires several m2m cycles (SortedManyToManyField clears then re-adds, plus the group-template remove/add in `ConfigForm.save`), so a missed or mis-ordered cycle could leave the old VPN client. Creation now reconciles against the full current set of VPN templates, guarded by the existing existence check, so it is idempotent and symmetric with the deletion side.

- **`FOREIGN KEY constraint failed` from background commands** (`connection ... test_update_config_hostname_changed_on_reregister`): a background `launch_command` could run `connect()` against a `DeviceConnection` whose row had already been deleted; `save()` then found no row to update and fell back to an INSERT, resurrecting the connection with a dangling device foreign key. `connect()` now records the attempt only if the connection still exists. This also removes the noisy caught tracebacks that appeared even in green runs.

- **Redis websocket consumer timeout** (`connection ... test_multiple_connections_receive_updates_with_redis`): the test did not mock `paramiko.SSHClient.connect` (unlike the sibling `test_new_command_created`), so eager command execution could block on a real SSH attempt and push the test past the 5s pytest-timeout. The SSH connect is now mocked.

- **Flaky `401` responses in API tests** (`config ... test_multiple_vpn_client_templates_same_vpn`): sessions were stored in the default cache, which the whois tests flush with `cache.clear()` and which parallel workers share, so a clear in one place wiped the authenticated session of a test running concurrently. Sessions now use a dedicated cache.

- **Flaky `assertNumQueries`** (`geo.estimated_location ... test_estimated_location_creation_and_update`): an extra `OrganizationGeoSettings` query appeared when the cached entry was dropped between subtests. The relevant cache is now warmed before the assertion.

Regression tests were added where the failure could be reproduced deterministically.

## Screenshot

N/A
