### PR TITLE
[tests] Avoid Celery logging interference in connection tests

### DIFF
--- a/openwisp_controller/connection/tests/test_tasks.py
+++ b/openwisp_controller/connection/tests/test_tasks.py
@@ -94,7 +94,7 @@ class TestTasks(CreateConnectionsMixin, TestCase):
         )
         mocked_sleep.assert_called_once()
 
-    @mock.patch("logging.Logger.info")
+    @mock.patch("openwisp_controller.connection.tasks.logger.info")
     @mock.patch("time.sleep")
     def test_update_config_skipped_for_deactivated_device(
         self, mocked_sleep, mocked_info


### PR DESCRIPTION
The connection task test patched all Logger.info calls, so Celery's eager task success log could become the final mocked call and fail the assertion when the test was reused by extended apps.

Patch only the connection task logger to keep the assertion focused on the application log emitted by update_config.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Small fix to test suite.