### PR TITLE
Fix #1397: prevent changing VPN field of assigned template

### DIFF
--- a/openwisp_controller/config/base/template.py
+++ b/openwisp_controller/config/base/template.py
@@ -235,6 +235,23 @@ class AbstractTemplate(ShareableOrgMixinUniqueName, BaseConfig):
         elif self.type != "vpn":
             self.vpn = None
             self.auto_cert = False
+            
+        if self.pk and self.type == "vpn":
+            try:
+                current = self.__class__.objects.get(pk=self.pk)
+                if current.vpn_id and current.vpn_id != getattr(self.vpn, 'id', None):
+                    if self.config_relations.exists():
+                        raise ValidationError(
+                            {"vpn": _(
+                                "This VPN template is currently assigned to active devices. "
+                                "Changing the VPN server may cause certificate and CA mismatches. "
+                                "Detach the template and re-provision affected devices before "
+                                "changing the VPN server."
+                            )}
+                        )
+            except self.__class__.DoesNotExist:
+                pass
+                
         if self.type == "vpn" and not self.config:
             self.config = self.vpn.auto_client(
                 auto_cert=self.auto_cert, template_backend_class=self.backend_class

--- a/openwisp_controller/config/tests/test_template.py
+++ b/openwisp_controller/config/tests/test_template.py
@@ -110,6 +110,49 @@ class TestTemplate(CreateConfigTemplateMixin, TestVpnX509Mixin, TestCase):
         else:
             self.fail("ValidationError not raised")
 
+    def test_vpn_template_change_vpn_when_assigned(self):
+        org = self._get_org()
+        vpn1 = self._create_vpn(name="vpn1", organization=org)
+        vpn2 = self._create_vpn(name="vpn2", organization=org)
+        t = self._create_template(
+            name="vpn-template",
+            organization=org,
+            type="vpn",
+            vpn=vpn1,
+            config={}
+        )
+        c = self._create_config(organization=org)
+        c.templates.add(t)
+        
+        # Try changing VPN
+        t.vpn = vpn2
+        try:
+            t.full_clean()
+        except ValidationError as err:
+            self.assertIn("vpn", err.message_dict)
+            self.assertIn("This VPN template is currently assigned to active devices.", err.message_dict["vpn"][0])
+        else:
+            self.fail("ValidationError not raised when changing VPN of an assigned template")
+            
+    def test_vpn_template_change_vpn_when_not_assigned(self):
+        org = self._get_org()
+        vpn1 = self._create_vpn(name="vpn1", organization=org)
+        vpn2 = self._create_vpn(name="vpn2", organization=org)
+        t = self._create_template(
+            name="vpn-template-unassigned",
+            organization=org,
+            type="vpn",
+            vpn=vpn1,
+            config={}
+        )
+        
+        # Try changing VPN
+        t.vpn = vpn2
+        try:
+            t.full_clean()
+        except ValidationError:
+            self.fail("ValidationError raised when changing VPN of an unassigned template")
+
     def test_generic_has_no_vpn(self):
         t = self._create_template(vpn=self._create_vpn())
         self.assertIsNone(t.vpn)


### PR DESCRIPTION
Implement server-side validation to prevent changing the vpn field of a VPN-client template when the template is already attached to one or more devices. Adds tests to cover this scenario.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Fixes #1397.

Please [open a new issue](https://github.com/openwisp/openwisp-controller/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

This PR implements server-side validation to prevent changing the `vpn` field of a VPN-client template when the template is already attached to one or more devices. 

If an admin attempts to change the VPN server of a template that is currently assigned to active devices, the system will now reject the update and return the following validation error:

> "This VPN template is currently assigned to active devices. Changing the VPN server may cause certificate and CA mismatches. Detach the template and re-provision affected devices before changing the VPN server."

This prevents silent VPN connectivity failures by ensuring devices don't end up with certificates signed by an untrusted CA.

Changes:
* Added validation logic to the `clean()` method of the `AbstractTemplate` class in `openwisp_controller/config/base/template.py`.
* Added test cases `test_vpn_template_change_vpn_when_assigned` and `test_vpn_template_change_vpn_when_not_assigned` to `openwisp_controller/config/tests/test_template.py` to ensure this behaviour functions as intended.

## Screenshot

N/A