### PR TITLE
[tests] Used browser error helper in WHOIS test

### DIFF
--- a/openwisp_controller/config/whois/tests/tests.py
+++ b/openwisp_controller/config/whois/tests/tests.py
@@ -1177,14 +1177,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
     @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
     def test_whois_device_admin(self):
         def _assert_no_js_errors():
-            browser_logs = []
-            for log in self.get_browser_logs() or []:
-                if self.browser == "chrome" and log["source"] != "console-api":
-                    continue
-                elif log["message"] in ["wrong event specified: touchleave"]:
-                    continue
-                browser_logs.append(log)
-            self.assertEqual(browser_logs, [])
+            self.assertEqual(self.get_browser_errors(), [])
 
         whois_obj = self._create_whois_info()
         device = self._create_device(last_ip=whois_obj.ip_address)

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -16,8 +16,6 @@ logo: "openwisp-logo-black.svg"
 categories:
   - network-management
 roadmap: "https://openwisp.io/docs/dev/general/roadmap-2030.html"
-supports:
-  - id: alias:gdpr
 maintenance:
   type: internal
   contacts:


### PR DESCRIPTION
## Summary

This updates the WHOIS Selenium test to use the shared browser error helper for no-JavaScript-error assertions. The test no longer needs local filtering for unrelated browser logs.