### PR TITLE
[fix] Reassign shared default templates on org change #1334

### DIFF
--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -341,6 +341,10 @@ class DeviceDetailSerializer(WHOISMixin, DeviceConfigSerializer):
                     pk_set=None,
                     raw_data=raw_data_for_signal_handlers,
                 )
+                # re-assign the default templates of the new organization
+                # (including shared defaults), mirroring the behavior applied
+                # when a device is first registered
+                instance.config.add_default_templates()
         return super().update(instance, validated_data)
 
 

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -543,6 +543,44 @@ class TestConfigApi(
         self.assertEqual(config.templates.count(), 1)
         self.assertEqual(config.templates.first(), org2_template)
 
+    def test_device_change_organization_default_templates(self):
+        org1 = self._create_org(name="org1")
+        org2 = self._create_org(name="org2")
+        shared_default = self._create_template(
+            name="shared-default", organization=None, default=True
+        )
+        org1_default = self._create_template(
+            name="org1-default", organization=org1, default=True
+        )
+        org2_default = self._create_template(
+            name="org2-default", organization=org2, default=True
+        )
+        device = self._create_device(organization=org1)
+        config = self._create_config(device=device)
+        # on registration the device receives the shared default and the
+        # defaults of its own organization
+        self.assertEqual(set(config.templates.all()), {shared_default, org1_default})
+
+        path = reverse("config_api:device_detail", args=[device.pk])
+        data = {"organization": org2.pk}
+        response = self.client.patch(path, data=data, content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        device.refresh_from_db()
+        config.refresh_from_db()
+        self.assertEqual(device.organization, org2)
+        # after the org change the shared default and the new organization's
+        # default are assigned, the previous organization's default is removed
+        self.assertEqual(set(config.templates.all()), {shared_default, org2_default})
+
+        # moving the device back reassigns the original organization's default
+        data = {"organization": org1.pk}
+        response = self.client.patch(path, data=data, content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        device.refresh_from_db()
+        config.refresh_from_db()
+        self.assertEqual(device.organization, org1)
+        self.assertEqual(set(config.templates.all()), {shared_default, org1_default})
+
     def test_device_patch_api(self):
         d1 = self._create_device(name="test-device")
         path = reverse("config_api:device_detail", args=[d1.pk])


### PR DESCRIPTION
Fixes #1334

### Problem

When a device's organization is changed via the REST API, `DeviceDetailSerializer.update()` clears the config templates and re-adds only the **required** templates of the new organization. The **default** templates (shared defaults and the new organization's own defaults) are not re-assigned. This is inconsistent with device registration, where `add_default_templates()` is applied, so a device moved to a new organization ends up missing that organization's default templates.

### Change

Add `instance.config.add_default_templates()` in the organization-change branch, right after the required templates are enforced. The organization is already set on the config before the templates are cleared, so the default queryset resolves against the new organization. `add()` is idempotent, so there is no duplication with the required templates that were just re-added.

### Tests

Adds `test_device_change_organization_default_templates`, covering a shared default plus per-organization defaults across an organization change, and confirming the previous organization's default is removed. The existing `test_device_change_organization_required_templates` still passes.

### Note

Opening this as a draft to confirm the intended behavior: changing a device's organization should re-assign the new organization's default templates, matching what happens on registration. If the current required-only behavior is intentional, I am happy to close this. The change is scoped to the REST API path only; the admin path is left unchanged.