### PR TITLE
[fix] Decoupled ZeroTier network name from VPN name #1426

### DIFF
--- a/openwisp_controller/config/api/zerotier_service.py
+++ b/openwisp_controller/config/api/zerotier_service.py
@@ -38,7 +38,6 @@ class ZerotierService:
             "rulesSource",
             "ssoEnabled",
             "creationTime",
-            "name",
             "nwid",
             "objtype",
             "revision",

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -261,8 +261,8 @@ class AbstractVpn(ConfigChecksumCacheMixin, ShareableOrgMixinUniqueName, BaseCon
             self.ip = self._auto_create_ip()
         if self._is_backend_type("zerotier"):
             config = deepcopy(self.config["zerotier"][0])
-            config["name"] = self.name
             if created:
+                config["name"] = self.name
                 self._create_zt_server(config)
         try:
             super().save(*args, **kwargs)
@@ -500,7 +500,9 @@ class AbstractVpn(ConfigChecksumCacheMixin, ShareableOrgMixinUniqueName, BaseCon
             )
             context[context_keys["vpn_subnet"]] = str(self.subnet.subnet)
         if self._is_backend_type("zerotier") and self.network_id:
-            context[context_keys["network_name"]] = self.name
+            context[context_keys["network_name"]] = (
+                self.config.get("zerotier", [{}])[0].get("name") or self.name
+            )
             context[context_keys["node_id"]] = self.node_id
             context[context_keys["network_id"]] = self.network_id
         return context

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -1440,6 +1440,39 @@ class TestZeroTier(BaseTestVpn, TestZeroTierVpnMixin, TestCase):
                 expected_error_dict, context_manager.exception.message_dict
             )
 
+    @mock.patch(_ZT_SERVICE_REQUESTS)
+    def test_zerotier_network_name_independent_of_vpn_name(self, mock_requests):
+        mock_requests.get.side_effect = [
+            self._get_mock_response(200, response=self._TEST_ZT_NODE_CONFIG)
+        ]
+        mock_requests.post.side_effect = [self._get_mock_response(200)]
+        template = self._create_template(
+            name="test-zerotier-template",
+            type="vpn",
+            vpn=self._create_zerotier_vpn(name="original-name"),
+            organization=self._get_org(),
+        )
+        pk = template.vpn.pk.hex
+        network_name_key = f"network_name_{pk}"
+        original_context = template.get_context()
+        original_network_name = original_context[network_name_key]
+        self.assertEqual(
+            original_network_name,
+            template.vpn.config.get("zerotier", [{}])[0].get("name"),
+        )
+        vpn = template.vpn
+        vpn.name = "renamed-vpn"
+        mock_requests.reset_mock()
+        mock_requests.get.side_effect = [
+            self._get_mock_response(200, response=self._TEST_ZT_NODE_CONFIG)
+        ]
+        vpn.full_clean()
+        vpn.save()
+        template.vpn.refresh_from_db()
+        updated_context = template.get_context()
+        self.assertEqual(updated_context[network_name_key], original_network_name)
+        self.assertNotEqual(updated_context[network_name_key], template.vpn.name)
+
     def test_zerotier_change_vpn_backend_with_vpnclient(self):
         vpn = self._create_vpn(name="new", backend=self._BACKENDS["openvpn"])
         subnet = self._create_subnet(


### PR DESCRIPTION
Preserve the ZeroTier network name returned by the API and use it
for configuration context variables. VPN name changes no longer
alter the machine-facing ZeroTier network name.

Closes #1426

## Checklist

* [x] I have read the OpenWISP Contributing Guidelines and OpenWISP Anti AI Spam Policy.
* [x] I have manually tested the changes proposed in this pull request.
* [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
* [N/A] I have updated the documentation.

## Reference to Existing Issue

Closes #1426.

## Description of Changes

This change decouples the human-facing `Vpn.name` field from the
machine-facing ZeroTier network name used in configuration context
variables.

The changes:

* Preserve the ZeroTier network name returned by the API in the stored
  VPN configuration instead of treating `name` as a redundant response
  field.
* Use the stored ZeroTier network name for the `network_name`
  configuration context variable, with `Vpn.name` as a fallback for
  backward compatibility with existing VPN configurations.
* Set the initial ZeroTier network name from `Vpn.name` only when the
  VPN is created, preventing subsequent administrative renames from
  being propagated to the ZeroTier controller.
* Add a regression test verifying that renaming `Vpn.name` does not
  change the machine-facing ZeroTier network name used in configuration
  context variables.

This prevents administrative VPN renames from unnecessarily changing
client configuration context and invalidating configuration caches.

## Screenshot

N/A — this change does not affect the user interface.
