### PR TITLE
[fix] Make VpnClient objects immutable after creation

### DIFF
--- a/docs/partials/vpn-client-immutability.rst
+++ b/docs/partials/vpn-client-immutability.rst
@@ -1,0 +1,13 @@
+.. important::
+
+    VPN clients are immutable: once OpenWISP has provisioned the VPN
+    tunnel of a device (x509 certificate, IP address, cryptographic keys),
+    the generated VPN client cannot be modified anymore. The only
+    exception is the provisioned IP address, which may be updated
+    internally by OpenWISP (e.g.: by :doc:`subnet division rules
+    </controller/user/subnet-division-rules>`).
+
+    To re-provision the VPN tunnel of a device, remove the VPN client
+    template from the device configuration, save the device, then add the
+    template again: the old VPN client is deleted and a new one is
+    provisioned from scratch.

--- a/docs/user/openvpn.rst
+++ b/docs/user/openvpn.rst
@@ -214,6 +214,8 @@ configuration.
 
 Finally you can add the new template to your devices.
 
+.. include:: ../partials/vpn-client-immutability.rst
+
 .. tip::
 
     If you need to troubleshoot any issue, increase the verbosity of the

--- a/docs/user/vxlan-wireguard.rst
+++ b/docs/user/vxlan-wireguard.rst
@@ -100,6 +100,8 @@ should be the same as the VPN server configuration in OpenWISP.
     :target: https://raw.githubusercontent.com/openwisp/openwisp-controller/docs/docs/wireguard-vxlan-tutorial/template.png
     :alt: WireGuard VXLAN VPN client template example
 
+.. include:: ../partials/vpn-client-immutability.rst
+
 4. Apply Wireguard VXLAN VPN Template to Devices
 ------------------------------------------------
 

--- a/docs/user/wireguard.rst
+++ b/docs/user/wireguard.rst
@@ -99,6 +99,8 @@ server configuration in OpenWISP.
     :target: https://raw.githubusercontent.com/openwisp/openwisp-controller/docs/docs/wireguard-tutorial/template.png
     :alt: WireGuard VPN client template example
 
+.. include:: ../partials/vpn-client-immutability.rst
+
 4. Apply WireGuard VPN Template to Devices
 ------------------------------------------
 

--- a/docs/user/zerotier.rst
+++ b/docs/user/zerotier.rst
@@ -120,6 +120,8 @@ installing ZeroTier on your server from the `official website
     :target: https://raw.githubusercontent.com/openwisp/openwisp-controller/docs/docs/zerotier-tutorial/template.png
     :alt: ZeroTier VPN client template example
 
+.. include:: ../partials/vpn-client-immutability.rst
+
 4. Apply ZeroTier VPN Template to Devices
 -----------------------------------------
 

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -883,12 +883,18 @@ class AbstractVpnClient(models.Model):
         is applied to a configuration and deleted when it is removed;
         allowing updates would desynchronize the provisioned artifacts
         (certificate, IP, keys) from the VPN server.
+
+        Returns the persisted instance, or ``None`` when no row with
+        this pk exists in the database (i.e. the save is a creation).
+        ``_state.adding`` alone is not reliable here: a freshly
+        constructed instance carrying the pk of an existing row still
+        has ``_state.adding=True`` but updates that row when saved.
         """
-        if self._state.adding:
-            return
+        if self.pk is None:
+            return None
         current = self._meta.model.objects.filter(pk=self.pk).first()
         if current is None:
-            return
+            return None
         changed_fields = [
             field.name
             for field in self._meta.concrete_fields
@@ -907,20 +913,20 @@ class AbstractVpnClient(models.Model):
                     for field in changed_fields
                 }
             )
+        return current
 
     def save(self, *args, **kwargs):
         """Performs automatic provisioning if ``auto_cert`` is True."""
-        if self._state.adding:
+        # the immutability check is not called automatically by save():
+        # it must run here too so direct ORM saves which skip
+        # full_clean() cannot modify a persisted row
+        if self._check_immutable_fields() is None:
             if self.auto_cert:
                 self._auto_x509()
                 self._auto_ip()
                 self._auto_wireguard()
                 self._auto_vxlan()
                 self._auto_secret()
-        else:
-            # not called automatically by save(): enforce immutability
-            # also for direct ORM saves which skip full_clean()
-            self._check_immutable_fields()
         super().save(*args, **kwargs)
 
     def _auto_x509(self):

--- a/openwisp_controller/config/base/vpn.py
+++ b/openwisp_controller/config/base/vpn.py
@@ -831,6 +831,11 @@ class AbstractVpnClient(models.Model):
         db_index=True,
     )
     _auto_ip_stopper_funcs = []
+    # Fields which the internal provisioning machinery may legitimately
+    # update after creation (subnet_division reassigns the provisioned IP
+    # asynchronously); every other field is immutable once persisted:
+    # to change a VPN client, remove the VPN template and add it again.
+    _updatable_fields = ("ip",)
 
     class Meta:
         abstract = True
@@ -867,14 +872,55 @@ class AbstractVpnClient(models.Model):
             unique_checks.append((self.__class__, ("vpn", "vni")))
         return unique_checks, date_checks
 
+    def clean(self):
+        super().clean()
+        self._check_immutable_fields()
+
+    def _check_immutable_fields(self):
+        """Raises ValidationError if fields of a persisted instance changed.
+
+        VPN clients are immutable: they are created when a VPN template
+        is applied to a configuration and deleted when it is removed;
+        allowing updates would desynchronize the provisioned artifacts
+        (certificate, IP, keys) from the VPN server.
+        """
+        if self._state.adding:
+            return
+        current = self._meta.model.objects.filter(pk=self.pk).first()
+        if current is None:
+            return
+        changed_fields = [
+            field.name
+            for field in self._meta.concrete_fields
+            if not field.primary_key
+            and field.name not in self._updatable_fields
+            and getattr(self, field.attname) != getattr(current, field.attname)
+        ]
+        if changed_fields:
+            raise ValidationError(
+                {
+                    field: _(
+                        "VPN clients cannot be modified after creation. "
+                        "To change this VPN client, remove the VPN template "
+                        "and add it again."
+                    )
+                    for field in changed_fields
+                }
+            )
+
     def save(self, *args, **kwargs):
         """Performs automatic provisioning if ``auto_cert`` is True."""
-        if self.auto_cert:
-            self._auto_x509()
-            self._auto_ip()
-            self._auto_wireguard()
-            self._auto_vxlan()
-            self._auto_secret()
+        if self._state.adding:
+            if self.auto_cert:
+                self._auto_x509()
+                self._auto_ip()
+                self._auto_wireguard()
+                self._auto_vxlan()
+                self._auto_secret()
+        else:
+            # not called automatically by save(): enforce immutability
+            # also for direct ORM saves which skip full_clean()
+            self._check_immutable_fields()
         super().save(*args, **kwargs)
 
     def _auto_x509(self):

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -272,19 +272,34 @@ class TestVpn(BaseTestVpn, TestCase):
             _assert_vpn_client_cert(cert, vpnclient, 0, 0)
 
         with self.subTest(
-            'Test VpnClient post_delete handler when "auto_cert" field is set to "False"'  # noqa
+            'Changing "auto_cert" after creation is rejected (immutability)'
         ):
             t = self._create_template(
                 name="vpn-test-2", type="vpn", vpn=vpn, auto_cert=True
             )
             c.templates.add(t)
             vpnclient = c.vpnclient_set.first()
-            cert = vpnclient.cert
-            # Set auto_cert field to false
             vpnclient.auto_cert = False
+            with self.assertRaises(ValidationError) as context_manager:
+                vpnclient.full_clean()
+            self.assertIn("auto_cert", context_manager.exception.message_dict)
+            c.templates.remove(t)
+
+        with self.subTest(
+            'Test VpnClient post_delete handler when "auto_cert" field is set to "False"'  # noqa
+        ):
+            t = self._create_template(
+                name="vpn-test-3", type="vpn", vpn=vpn, auto_cert=False
+            )
+            cert = self._create_cert(name="manual-cert", ca=vpn.ca, organization=org)
+            vpnclient = VpnClient(
+                config=c, vpn=vpn, template=t, cert=cert, auto_cert=False
+            )
             vpnclient.full_clean()
             vpnclient.save()
-            _assert_vpn_client_cert(cert, vpnclient, 1, 0)
+            vpnclient.delete()
+            # the certificate must not be revoked because auto_cert is False
+            self.assertEqual(Cert.objects.filter(pk=cert.pk, revoked=False).count(), 1)
 
     def test_vpn_client_get_common_name(self):
         vpn = self._create_vpn()
@@ -493,6 +508,79 @@ class TestVpn(BaseTestVpn, TestCase):
             message_dict = context_manager.exception.message_dict
             self.assertIn("ca", message_dict)
             self.assertIn("CA is required with this VPN backend", message_dict["ca"])
+
+    def _create_vpn_client_via_template(self):
+        vpn = self._create_vpn()
+        template = self._create_template(
+            name="vpn-immutability", type="vpn", vpn=vpn, auto_cert=True
+        )
+        config = self._create_config(device=self._create_device())
+        config.templates.add(template)
+        return config.vpnclient_set.select_related("vpn", "cert", "config").first()
+
+    def test_vpn_client_creation_allowed(self):
+        client = self._create_vpn_client_via_template()
+        self.assertIsNotNone(client)
+        self.assertIsNotNone(client.cert)
+        self.assertTrue(client.auto_cert)
+
+    def test_vpn_client_noop_save_allowed(self):
+        client = self._create_vpn_client_via_template()
+        cert_count = Cert.objects.count()
+        client.full_clean()
+        client.save()
+        self.assertEqual(VpnClient.objects.count(), 1)
+        self.assertEqual(Cert.objects.count(), cert_count)
+
+    def test_vpn_client_immutable_after_creation(self):
+        client = self._create_vpn_client_via_template()
+        vpn2 = self._create_vpn(name="immutability-vpn2", ca=client.vpn.ca)
+        for field, value in (
+            ("auto_cert", False),
+            ("vpn", vpn2),
+            ("public_key", "changed-key"),
+            ("secret", "changed-secret"),
+            ("vni", 42),
+        ):
+            with self.subTest(field=field):
+                client.refresh_from_db()
+                setattr(client, field, value)
+                with self.assertRaises(ValidationError) as context_manager:
+                    client.full_clean()
+                self.assertIn(field, context_manager.exception.message_dict)
+
+    def test_vpn_client_direct_save_rejected(self):
+        # save() without full_clean() must also enforce immutability
+        client = self._create_vpn_client_via_template()
+        client.auto_cert = False
+        with self.assertRaises(ValidationError):
+            client.save()
+        client.refresh_from_db()
+        self.assertTrue(client.auto_cert)
+
+    def test_vpn_client_ip_update_allowed(self):
+        # internal machinery (subnet_division) must be able to
+        # reassign the provisioned IP after creation
+        client = self._create_vpn_client_via_template()
+        subnet = Subnet(name="immutability-subnet", subnet="10.99.0.0/24")
+        subnet.full_clean()
+        subnet.save()
+        ip = subnet.request_ip()
+        client.ip = ip
+        client.full_clean()
+        client.save(update_fields=["ip"])
+        client.refresh_from_db()
+        self.assertEqual(client.ip, ip)
+
+    def test_vpn_client_delete_recreate_flow(self):
+        client = self._create_vpn_client_via_template()
+        config, template = client.config, client.template
+        config.templates.remove(template)
+        self.assertEqual(config.vpnclient_set.count(), 0)
+        config.templates.add(template)
+        new_client = config.vpnclient_set.first()
+        self.assertIsNotNone(new_client)
+        self.assertNotEqual(new_client.pk, client.pk)
 
 
 class TestVpnTransaction(BaseTestVpn, TestWireguardVpnMixin, TransactionTestCase):

--- a/openwisp_controller/config/tests/test_vpn.py
+++ b/openwisp_controller/config/tests/test_vpn.py
@@ -558,6 +558,29 @@ class TestVpn(BaseTestVpn, TestCase):
         client.refresh_from_db()
         self.assertTrue(client.auto_cert)
 
+    def test_vpn_client_pk_reuse_update_rejected(self):
+        # a freshly constructed instance carrying the pk of an existing
+        # row has _state.adding=True but updates that row on save():
+        # immutability must be enforced in this case too
+        client = self._create_vpn_client_via_template()
+        rogue = VpnClient(
+            pk=client.pk,
+            config=client.config,
+            template=client.template,
+            vpn=client.vpn,
+            cert=client.cert,
+            ip=client.ip,
+            public_key=client.public_key,
+            private_key=client.private_key,
+            secret=client.secret,
+            vni=client.vni,
+            auto_cert=False,
+        )
+        with self.assertRaises(ValidationError):
+            rogue.save()
+        client.refresh_from_db()
+        self.assertTrue(client.auto_cert)
+
     def test_vpn_client_ip_update_allowed(self):
         # internal machinery (subnet_division) must be able to
         # reassign the provisioned IP after creation

--- a/openwisp_controller/locale/en/LC_MESSAGES/django.po
+++ b/openwisp_controller/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,21 @@
+# OpenWISP
+# Copyright (C) 2026
+# This file is distributed under the same license as the
+# openwisp-controller package.
+#
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-08-03 00:00+0000\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: config/base/vpn.py:903
+msgid ""
+"VPN clients cannot be modified after creation. To change this VPN client, "
+"remove the VPN template and add it again."
+msgstr ""
+"VPN clients cannot be modified after creation. To change this VPN client, "
+"remove the VPN template and add it again."

--- a/openwisp_controller/subnet_division/rule_types/vpn.py
+++ b/openwisp_controller/subnet_division/rule_types/vpn.py
@@ -52,7 +52,8 @@ class VpnSubnetDivisionRuleType(BaseSubnetDivisionRuleType):
                 instance.ip.delete()
             instance.ip = provisioned["ip_addresses"][0]
             instance.full_clean()
-            instance.save()
+            # "ip" is the only field VpnClient allows updating after creation
+            instance.save(update_fields=["ip"])
 
     @classmethod
     def destroy_provisioned_subnets_ips(cls, instance, **kwargs):


### PR DESCRIPTION
## Summary

Fixes #1428 by making `VpnClient` objects immutable after creation while allowing the internally managed `ip` field to be updated.

## Changes

- Prevent updates to persisted `VpnClient` identity fields by enforcing immutability in both `clean()` and `save()`.
- Restrict auto-provisioning to object creation, preventing reprovisioning on subsequent saves.
- Explicitly allow `ip` updates required by the asynchronous subnet provisioning workflow.
- Add regression tests covering:
  - Immutability of persisted `VpnClient` objects.
  - Allowed `ip` updates.
  - Create, delete, and recreate workflows.

## Validation

- Added regression tests for all newly introduced behaviors.
- Verified that all new and existing VPN-related test suites pass, including the `subnet_division` and swapped-model test suites.
- Confirmed existing create/delete workflows remain unchanged.
- No database migrations are required.
<img width="478" height="389" alt="image" src="https://github.com/user-attachments/assets/76f8f2b2-49a2-4e8c-ab5e-95efe89df164" />
