### PR TITLE
[change] Add test_connection_command_timeout_with_output

### DIFF
--- a/openwisp_controller/connection/tests/test_ssh.py
+++ b/openwisp_controller/connection/tests/test_ssh.py
@@ -80,7 +80,34 @@ class TestSsh(CreateConnectionsMixin, TestCase):
             # timeout of 0.0 is a special case in paramiko -> we check for 0.01 instead
             dc.connector_instance.exec_command("sleep 1", timeout=0.01)
         log_message = "Command timed out after 0.01 seconds."
-        mocked_info.assert_has_calls([mock.call(log_message)])
+        mocked_info.assert_has_calls(
+            [mock.call("Executing command: sleep 1"), mock.call(log_message)]
+        )
+        self.assertEqual(str(ctx.exception), log_message)
+
+    @mock.patch.object(ssh_logger, "info")
+    @mock.patch.object(ssh_logger, "debug")
+    def test_connection_command_timeout_with_output(self, mocked_debug, mocked_info):
+        ckey = self._create_credentials_with_key(port=self.ssh_server.port)
+        dc = self._create_device_connection(credentials=ckey)
+        dc.connector_instance.connect()
+        with self.assertRaises(Exception) as ctx:
+            # timeout of 0.0 is a special case in paramiko -> we check for 0.01 instead
+            dc.connector_instance.exec_command(
+                "echo fake_output && echo fake_error 1>&2 && sleep 1", timeout=0.01
+            )
+        log_message = "Command timed out after 0.01 seconds."
+        mocked_info.assert_has_calls(
+            [
+                mock.call(
+                    "Executing command: echo fake_output &&"
+                    " echo fake_error 1>&2 && sleep 1"
+                ),
+                mock.call("fake_output\n"),
+                mock.call(log_message),
+            ]
+        )
+        self.assertEqual(ctx.exception.output, "fake_output\nfake_error\n")
         self.assertEqual(str(ctx.exception), log_message)
 
     @mock.patch.object(ssh_logger, "info")


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Demonstrate #1424 and (TODO) propose a solution

## Description of Changes

- [X] Added a test to demonstrate the issue
- [ ] Add helpers to drain stdout / stderr from the paramiko channel, whether the command completes or not
- [ ] Add CommandTimeoutWithPartialOutput Exception (containing the actual output - seems necessary for fallback logic with sysupgrade disconnection)
- [ ] reraise original socket.timeout exception with traceback
- [ ] Add channel.close() on timeout