### PR TITLE
Fixed SubnetDivisionIndex foreign keys saved as NULL

### DIFF
--- a/openwisp_controller/subnet_division/rule_types/base.py
+++ b/openwisp_controller/subnet_division/rule_types/base.py
@@ -256,7 +256,7 @@ class BaseSubnetDivisionRuleType(object):
             generated_indexes.append(
                 SubnetDivisionIndex(
                     keyword=f"{division_rule.label}_subnet{subnet_id}",
-                    subnet_id=subnet_obj.id,
+                    subnet=subnet_obj,
                     rule_id=division_rule.id,
                     config=config,
                 )
@@ -294,8 +294,8 @@ class BaseSubnetDivisionRuleType(object):
                 generated_indexes.append(
                     SubnetDivisionIndex(
                         keyword=f"{subnet_obj.name}_ip{keyword_index}",
-                        subnet_id=subnet_obj.id,
-                        ip_id=ip_obj.id,
+                        subnet=subnet_obj,
+                        ip=ip_obj,
                         rule_id=division_rule.id,
                         config=config,
                     )

--- a/openwisp_controller/subnet_division/tasks.py
+++ b/openwisp_controller/subnet_division/tasks.py
@@ -118,7 +118,7 @@ def provision_extra_ips(rule_id, old_number_of_ips):
                 SubnetDivisionIndex(
                     keyword=f"{division_rule.label}_subnet{subnet.id}_ip{ip_id}",
                     subnet_id=subnet.id,
-                    ip_id=ip.id,
+                    ip=ip,
                     rule_id=division_rule.id,
                     config_id=index.config_id,
                 )

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -1050,6 +1050,48 @@ class TestSubnetDivisionRule(
             e.message_dict.get("master_subnet", []),
         )
 
+    def test_subnet_division_index_integrity(self):
+        rule = self._get_vpn_subdivision_rule()
+        self.config.templates.add(self.template)
+
+        # Verify initial indexes have non-NULL subnet_id and ip_id
+        # (if they are IP indexes)
+        indexes = rule.subnetdivisionindex_set.all()
+        self.assertTrue(indexes.exists())
+        initial_count = indexes.count()
+        for index in indexes:
+            self.assertIsNotNone(
+                index.subnet_id,
+                f"SubnetDivisionIndex {index.keyword} has NULL subnet_id",
+            )
+            if "_ip" in index.keyword:
+                self.assertIsNotNone(
+                    index.ip_id,
+                    f"SubnetDivisionIndex {index.keyword} has NULL ip_id",
+                )
+
+        # Update number of IPs to trigger tasks.provision_extra_ips
+        rule.number_of_ips = rule.number_of_ips + 2
+        rule.save()
+        rule.refresh_from_db()
+
+        # Verify count increased and all indexes, including new ones,
+        # have non-NULL subnet_id and ip_id
+        new_indexes = rule.subnetdivisionindex_set.all()
+        self.assertEqual(
+            new_indexes.count(), initial_count + (rule.number_of_subnets * 2)
+        )
+        for index in new_indexes:
+            self.assertIsNotNone(
+                index.subnet_id,
+                f"SubnetDivisionIndex {index.keyword} has NULL subnet_id after update",
+            )
+            if "_ip" in index.keyword:
+                self.assertIsNotNone(
+                    index.ip_id,
+                    f"SubnetDivisionIndex {index.keyword} has NULL ip_id after update",
+                )
+
 
 class TestOpenVPNSubnetDivisionRule(
     SubnetDivisionTestMixin,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

Closes #1435 

## Description of Changes

This PR fixes a bug where `SubnetDivisionIndex` records were created with `subnet_id = NULL` and/or `ip_id = NULL` in the database. 

### Why the bug occurred:
The code was instantiating `SubnetDivisionIndex` instances by copying the `.id` properties directly (e.g., `subnet_id=subnet_obj.id` and `ip_id=ip.id`) **before** the subnets or IP addresses were bulk-saved. At the time of copy, these values were `None`. Although `bulk_create` subsequently populated the primary keys on the model instances, the primitive values copied earlier remained `None` and were saved as `NULL` in the database.

### The Fix:
We now pass the model instances themselves (`subnet=subnet_obj` and `ip=ip`) instead of copying the `.id` properties. Since the index instances hold object references, Django correctly resolves their primary keys once the parent objects are bulk-saved in the database.

### Test Coverage:
Added a new unit test method `test_subnet_division_index_integrity()` in `openwisp_controller/subnet_division/tests/test_models.py`. It asserts that:
1. Every initially created `SubnetDivisionIndex` has a non-NULL `subnet_id` and correct `ip_id` (for IP indexes).
2. The newly generated indexes after updating the `number_of_ips` (which triggers celery tasks) also have correct non-NULL foreign key fields.

## Screenshot

**Logical proof of the bug and fix (Python simulation):**
```text
[Buggy Way] After bulk_create, index_buggy.ip_id is: None (Expected: 42, Actual: None)
[Fixed Way] After bulk_create and save, index_fixed.ip_id is: 42 (Expected: 42, Actual: 42)