### PR TITLE
[fix] Block deleting a certificate or CA in use by a VPN #1419

### DIFF
--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -1727,6 +1727,38 @@ class TestAdmin(
             response, 'value="openwisp_controller.vpn_backends.OpenVpn" selected'
         )
 
+    def test_delete_cert_in_use_is_blocked(self):
+        # regression test for issue #1419: deleting a certificate that is
+        # still assigned to a VPN client must be blocked from the admin,
+        # otherwise the device configuration is left corrupted.
+        from django.contrib.admin.sites import site as admin_site
+        from django.test import RequestFactory
+
+        org = self._get_org()
+        vpn = self._create_vpn()
+        config = self._create_config(organization=org)
+        vpn_template = self._create_template(
+            name="vpn-1419", type="vpn", vpn=vpn, auto_cert=True
+        )
+        config.templates.add(vpn_template)
+        vpnclient = config.vpnclient_set.first()
+        cert = vpnclient.cert
+        self.assertIsNotNone(cert)
+
+        User = get_user_model()
+        try:
+            admin = User.objects.get(username="admin")
+        except User.DoesNotExist:
+            admin = User.objects.create_superuser("admin", "admin@test.org", "tester")
+        request = RequestFactory().get("/")
+        request.user = admin
+        cert_admin = admin_site._registry[Cert]
+        _, _, _, protected = cert_admin.get_deleted_objects([cert], request)
+        self.assertTrue(
+            any("remove the VPN template" in str(p) for p in protected),
+            f"cert in use should be protected from deletion, got: {protected}",
+        )
+
     def test_vpn_clients_deleted(self):
         def _update_template(templates):
             params.update(

--- a/openwisp_controller/pki/admin.py
+++ b/openwisp_controller/pki/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.translation import gettext_lazy as _
 from django_x509.base.admin import AbstractCaAdmin, AbstractCertAdmin
 from reversion.admin import VersionAdmin
 from swapper import load_model
@@ -11,9 +12,71 @@ Ca = load_model("django_x509", "Ca")
 Cert = load_model("django_x509", "Cert")
 
 
+def _cert_in_use_message(cert):
+    """Returns a message if ``cert`` is in use by a VPN, otherwise ``None``.
+
+    Deleting a certificate that is still assigned to a VPN client cascades
+    the deletion of the client and leaves the device configuration in a
+    corrupted state (issue #1419), so deletion is blocked from the admin.
+    """
+    VpnClient = load_model("config", "VpnClient")
+    Vpn = load_model("config", "Vpn")
+    vpn_client = (
+        VpnClient.objects.filter(cert=cert).select_related("config__device").first()
+    )
+    if vpn_client:
+        device = vpn_client.config.device
+        return _(
+            'the certificate "%(cert)s" is currently used by the device '
+            '"%(device)s"; remove the VPN template from the device before '
+            "deleting this certificate."
+        ) % {"cert": cert, "device": device}
+    vpn = Vpn.objects.filter(cert=cert).first()
+    if vpn:
+        return _(
+            'the certificate "%(cert)s" is currently used by the VPN server '
+            '"%(vpn)s"; change the VPN certificate before deleting this one.'
+        ) % {"cert": cert, "vpn": vpn}
+    return None
+
+
+def _ca_in_use_message(ca):
+    """Returns a message if ``ca`` is in use by a VPN, otherwise ``None``."""
+    VpnClient = load_model("config", "VpnClient")
+    Vpn = load_model("config", "Vpn")
+    vpn = Vpn.objects.filter(ca=ca).first()
+    if vpn:
+        return _(
+            'the CA "%(ca)s" is currently used by the VPN server "%(vpn)s"; '
+            "change the VPN CA before deleting this one."
+        ) % {"ca": ca, "vpn": vpn}
+    vpn_client = (
+        VpnClient.objects.filter(cert__ca=ca).select_related("config__device").first()
+    )
+    if vpn_client:
+        device = vpn_client.config.device
+        return _(
+            'the CA "%(ca)s" issued a certificate used by the device '
+            '"%(device)s"; remove the VPN template from the device before '
+            "deleting this CA."
+        ) % {"ca": ca, "device": device}
+    return None
+
+
 @admin.register(Ca)
 class CaAdmin(MultitenantAdminMixin, AbstractCaAdmin, VersionAdmin):
     history_latest_first = True
+
+    def get_deleted_objects(self, objs, request):
+        deletable, model_count, perms_needed, protected = super().get_deleted_objects(
+            objs, request
+        )
+        protected = list(protected)
+        for ca in objs:
+            message = _ca_in_use_message(ca)
+            if message:
+                protected.append(message)
+        return deletable, model_count, perms_needed, protected
 
 
 CaAdmin.fields.insert(2, "organization")
@@ -26,6 +89,17 @@ CaAdmin.Media.js += ("admin/pki/js/show-org-field.js",)
 class CertAdmin(MultitenantAdminMixin, AbstractCertAdmin, VersionAdmin):
     multitenant_shared_relations = ("ca",)
     history_latest_first = True
+
+    def get_deleted_objects(self, objs, request):
+        deletable, model_count, perms_needed, protected = super().get_deleted_objects(
+            objs, request
+        )
+        protected = list(protected)
+        for cert in objs:
+            message = _cert_in_use_message(cert)
+            if message:
+                protected.append(message)
+        return deletable, model_count, perms_needed, protected
 
 
 CertAdmin.fields.insert(2, "organization")


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #1419.

## Description of Changes

Deleting a `Cert` or `Ca` that is still assigned to a VPN client cascaded the deletion of the `VpnClient` and left the device configuration corrupted: status stayed at `applied` while the certificate context could no longer be resolved.

`CertAdmin` and `CaAdmin` now override `get_deleted_objects` and report such objects as protected, so the admin blocks the deletion and tells the user what to remove first. This covers both the single delete view and the bulk `delete_selected` action, since both route through `get_deleted_objects`.

Cases handled:

- a certificate assigned to a `VpnClient`, pointing at the device that uses it
- a certificate used by a VPN server
- a CA used by a VPN server, which would otherwise orphan the certificates issued under it

Deleting a certificate or CA that is not in use is unaffected, and removing the VPN template from a device still cascades normally.

### Testing

Added a regression test in `openwisp_controller/config/tests/test_admin.py`. It fails without the change and passes with it.

```
$ python manage.py test openwisp_controller.config.tests.test_admin
Ran 126 tests in 121.577s
OK

$ python manage.py test openwisp_controller.pki
Ran 40 tests in 16.681s
OK
```

`black`, `isort` and `flake8` are clean on both changed files.

### Note on a previous pull request

This supersedes #1432, which I closed. That branch had been created without shared history with `master`, so GitHub rendered the diff as the entire repository rather than these two files. This branch is built directly on current `master` and the diff is the intended 106 lines across 2 files.

## Screenshot

N/A, the change surfaces as the standard Django admin "protected objects" message on the delete confirmation page.