### PR TITLE
[tests] Removed problematic import of tests in geo app

### DIFF
--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -37,6 +37,7 @@ from .utils import (
     CreateConfigTemplateMixin,
     CreateDeviceGroupMixin,
     CreateDeviceMixin,
+    TestDeviceAdminMixin,
     TestVpnX509Mixin,
 )
 
@@ -53,47 +54,6 @@ User = get_user_model()
 Location = load_model("geo", "Location")
 DeviceLocation = load_model("geo", "DeviceLocation")
 Group = load_model("openwisp_users", "Group")
-
-
-class TestDeviceAdminMixin:
-    _device_params = {
-        "name": "test-device",
-        "hardware_id": "1234",
-        "mac_address": CreateConfigTemplateMixin.TEST_MAC_ADDRESS,
-        "key": CreateConfigTemplateMixin.TEST_KEY,
-        "model": "",
-        "os": "",
-        "notes": "",
-        "config-0-id": "",
-        "config-0-device": "",
-        "config-0-backend": "netjsonconfig.OpenWrt",
-        "config-0-templates": "",
-        "config-0-config": json.dumps({}),
-        "config-0-context": "",
-        "config-TOTAL_FORMS": 1,
-        "config-INITIAL_FORMS": 0,
-        "config-MIN_NUM_FORMS": 0,
-        "config-MAX_NUM_FORMS": 1,
-        # openwisp_controller.connection
-        "deviceconnection_set-TOTAL_FORMS": 0,
-        "deviceconnection_set-INITIAL_FORMS": 0,
-        "deviceconnection_set-MIN_NUM_FORMS": 0,
-        "deviceconnection_set-MAX_NUM_FORMS": 1000,
-        "command_set-TOTAL_FORMS": 0,
-        "command_set-INITIAL_FORMS": 0,
-        "command_set-MIN_NUM_FORMS": 0,
-        "command_set-MAX_NUM_FORMS": 1000,
-    }
-    # WARNING - WATCHOUT
-    # this class attribute is changed dynamically
-    # by other apps which add inlines to DeviceAdmin
-    _additional_params = {}
-
-    def _get_device_params(self, org):
-        p = self._device_params.copy()
-        p.update(self._additional_params)
-        p["organization"] = org.pk
-        return p
 
 
 class TestImportExportMixin:
@@ -293,34 +253,6 @@ class TestAdmin(
     object_model = Device
     object_location_model = DeviceLocation
     maxDiff = None
-    _device_params = {
-        "name": "test-device",
-        "hardware_id": "1234",
-        "mac_address": CreateConfigTemplateMixin.TEST_MAC_ADDRESS,
-        "key": CreateConfigTemplateMixin.TEST_KEY,
-        "model": "",
-        "os": "",
-        "notes": "",
-        "config-0-id": "",
-        "config-0-device": "",
-        "config-0-backend": "netjsonconfig.OpenWrt",
-        "config-0-templates": "",
-        "config-0-config": json.dumps({}),
-        "config-0-context": "",
-        "config-TOTAL_FORMS": 1,
-        "config-INITIAL_FORMS": 0,
-        "config-MIN_NUM_FORMS": 0,
-        "config-MAX_NUM_FORMS": 1,
-        # openwisp_controller.connection
-        "deviceconnection_set-TOTAL_FORMS": 0,
-        "deviceconnection_set-INITIAL_FORMS": 0,
-        "deviceconnection_set-MIN_NUM_FORMS": 0,
-        "deviceconnection_set-MAX_NUM_FORMS": 1000,
-        "command_set-TOTAL_FORMS": 0,
-        "command_set-INITIAL_FORMS": 0,
-        "command_set-MIN_NUM_FORMS": 0,
-        "command_set-MAX_NUM_FORMS": 1000,
-    }
 
     def setUp(self):
         self.client.force_login(self._get_admin())

--- a/openwisp_controller/config/tests/utils.py
+++ b/openwisp_controller/config/tests/utils.py
@@ -9,6 +9,7 @@ from unittest import mock
 from uuid import uuid4
 
 from django.db.utils import DEFAULT_DB_ALIAS
+from django.urls import reverse
 from openwisp_ipam.tests import CreateModelsMixin as CreateIpamModelsMixin
 from swapper import load_model
 
@@ -416,3 +417,44 @@ class CreateDeviceGroupMixin(TestOrganizationMixin):
         device_group.full_clean()
         device_group.save()
         return device_group
+
+
+class TestDeviceAdminMixin:
+    _device_params = {
+        "name": "test-device",
+        "hardware_id": "1234",
+        "mac_address": CreateConfigTemplateMixin.TEST_MAC_ADDRESS,
+        "key": CreateConfigTemplateMixin.TEST_KEY,
+        "model": "",
+        "os": "",
+        "notes": "",
+        "config-0-id": "",
+        "config-0-device": "",
+        "config-0-backend": "netjsonconfig.OpenWrt",
+        "config-0-templates": "",
+        "config-0-config": "{}",
+        "config-0-context": "",
+        "config-TOTAL_FORMS": 1,
+        "config-INITIAL_FORMS": 0,
+        "config-MIN_NUM_FORMS": 0,
+        "config-MAX_NUM_FORMS": 1,
+        "deviceconnection_set-TOTAL_FORMS": 0,
+        "deviceconnection_set-INITIAL_FORMS": 0,
+        "deviceconnection_set-MIN_NUM_FORMS": 0,
+        "deviceconnection_set-MAX_NUM_FORMS": 1000,
+        "command_set-TOTAL_FORMS": 0,
+        "command_set-INITIAL_FORMS": 0,
+        "command_set-MIN_NUM_FORMS": 0,
+        "command_set-MAX_NUM_FORMS": 1000,
+    }
+
+    def _get_device_params(self, org):
+        params = self._device_params.copy()
+        url = reverse(f"admin:{Device._meta.app_label}_{Device._meta.model_name}_add")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        for inline_admin_formset in response.context["inline_admin_formsets"]:
+            for field in inline_admin_formset.formset.management_form:
+                params.setdefault(field.html_name, field.value())
+        params["organization"] = org.pk
+        return params

--- a/openwisp_controller/connection/tests/test_admin.py
+++ b/openwisp_controller/connection/tests/test_admin.py
@@ -9,7 +9,6 @@ from swapper import load_model
 from openwisp_controller.connection.commands import ORGANIZATION_ENABLED_COMMANDS
 
 from ... import settings as module_settings
-from ...config.tests.test_admin import TestAdmin as TestConfigAdmin
 from ...tests import _get_updated_templates_settings
 from ...tests.utils import TestAdminMixin
 from ..connectors.ssh import Ssh
@@ -28,12 +27,6 @@ Group = load_model("openwisp_users", "Group")
 class TestConnectionAdmin(TestAdminMixin, CreateConnectionsMixin, TestCase):
     config_app_label = "config"
     app_label = "connection"
-    _device_params = TestConfigAdmin._device_params.copy()
-
-    def _get_device_params(self, org):
-        p = self._device_params.copy()
-        p["organization"] = org.pk
-        return p
 
     def _create_multitenancy_test_env(self):
         org1 = self._create_org(name="test1org")
@@ -287,6 +280,3 @@ class TestCommandInlines(TestAdminMixin, CreateConnectionsMixin, TestCase):
             response = self.client.get(url)
             self.assertContains(response, "https://example.com")
             self.assertNotContains(response, "owControllerApiHost = window.location")
-
-
-del TestConfigAdmin

--- a/openwisp_controller/geo/apps.py
+++ b/openwisp_controller/geo/apps.py
@@ -3,7 +3,6 @@ import json
 import channels.layers
 import swapper
 from asgiref.sync import async_to_sync
-from django.conf import settings
 from django.db import transaction
 from django.db.models import Case, Count, Sum, When
 from django.db.models.signals import post_delete, post_save
@@ -42,8 +41,6 @@ class GeoConfig(LociConfig):
         self.register_menu_groups()
         self.connect_receivers()
         register_estimated_location_notification_types()
-        if getattr(settings, "TESTING", False):
-            self._add_params_to_test_config()
 
     def connect_receivers(self):
         post_save.connect(
@@ -72,30 +69,6 @@ class GeoConfig(LociConfig):
             whois_lookup_skipped_handler,
             dispatch_uid="whois_lookup_skipped_estimated_location_handler",
         )
-
-    def _add_params_to_test_config(self):
-        """
-        this methods adds the management fields of DeviceLocationInline
-        to the parameters used in config.tests.test_admin.TestAdmin
-        this hack is needed for the following reasons:
-            - avoids breaking config.tests.test_admin.TestAdmin
-            - avoids adding logic of geo app in config, this
-              way config doesn't know anything about geo, keeping
-              complexity down to a sane level
-        """
-        from ..config.tests.test_admin import TestAdmin as TestConfigAdmin
-        from .tests.test_admin_inline import TestAdminInline
-
-        params = TestAdminInline._get_params()
-        delete_keys = []
-        # delete unnecessary fields
-        # leave only management fields
-        for key in params.keys():
-            if "_FORMS" not in key:
-                delete_keys.append(key)
-        for key in delete_keys:
-            del params[key]
-        TestConfigAdmin._additional_params.update(params)
 
     def register_dashboard_charts(self):
         register_dashboard_chart(

--- a/openwisp_controller/geo/tests/test_admin_inline.py
+++ b/openwisp_controller/geo/tests/test_admin_inline.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django_loci.tests.base.test_admin_inline import BaseTestAdminInline
 from swapper import load_model
 
-from ...config.tests.test_admin import TestAdmin as TestConfigAdmin
+from ...config.tests.utils import TestDeviceAdminMixin
 from .utils import TestGeoMixin
 
 Device = load_model("config", "Device")
@@ -14,18 +14,10 @@ Location = load_model("geo", "Location")
 FloorPlan = load_model("geo", "FloorPlan")
 DeviceLocation = load_model("geo", "DeviceLocation")
 
-# ConfigInline management fields
-_device_params = TestConfigAdmin._device_params.copy()
-_device_params["config-TOTAL_FORMS"] = 0
-_delete_keys = []
-for key in _device_params.keys():
-    if "config-0-" in key:
-        _delete_keys.append(key)
-for key in _delete_keys:
-    del _device_params[key]
 
-
-class TestAdminInline(TestGeoMixin, BaseTestAdminInline, TestCase):
+class TestAdminInline(
+    TestDeviceAdminMixin, TestGeoMixin, BaseTestAdminInline, TestCase
+):
     app_label = "geo"
     object_model = Device
     location_model = Location
@@ -45,8 +37,13 @@ class TestAdminInline(TestGeoMixin, BaseTestAdminInline, TestCase):
     @property
     def params(self):
         params = self.__class__._get_params()
-        params.update(_device_params)
-        params["organization"] = self.organization.pk
+        device_params = self._device_params.copy()
+        device_params["config-TOTAL_FORMS"] = 0
+        device_params["organization"] = self.organization.pk
+        for key in list(device_params):
+            if key.startswith("config-0-"):
+                del device_params[key]
+        params.update(device_params)
         return params
 
     @mock.patch("openwisp_controller.config.settings.HARDWARE_ID_AS_NAME", False)
@@ -77,5 +74,4 @@ class TestAdminInline(TestGeoMixin, BaseTestAdminInline, TestCase):
         self.assertEqual(loc.name, params["name"])
 
 
-del TestConfigAdmin
 del BaseTestAdminInline

--- a/openwisp_controller/subnet_division/tests/test_admin.py
+++ b/openwisp_controller/subnet_division/tests/test_admin.py
@@ -4,8 +4,8 @@ from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 from swapper import load_model
 
-from openwisp_controller.config.tests.test_admin import TestDeviceAdminMixin
 from openwisp_controller.config.tests.utils import (
+    TestDeviceAdminMixin,
     TestVpnX509Mixin,
     TestWireguardVpnMixin,
 )


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Small clean up. No issue needed.

## Description of Changes

The geo app was importing test classes in the `ready()` method, which caused some circular import issues in new development branches we're working on.

This patch refactors internal testing logic to avoid that.
