### PR TITLE
[chores] Show estimated location warning only in map tab

### DIFF
--- a/openwisp_controller/config/static/config/css/admin.css
+++ b/openwisp_controller/config/static/config/css/admin.css
@@ -363,6 +363,9 @@ button.show-sc {
   background-position: 17px 17px;
   margin-bottom: 0;
 }
+#device_form .messagelist.map {
+  display: none;
+}
 #main .field-management_ip .readonly {
   padding: 7px 0px;
   display: inline-block;

--- a/openwisp_controller/config/static/config/js/tabs.js
+++ b/openwisp_controller/config/static/config/js/tabs.js
@@ -17,6 +17,11 @@ django.jQuery(function ($) {
       $(".tab-content").removeClass("current");
       menuLink.addClass("current");
       $(tabId).addClass("current");
+      // show estimated location warning when "map" tab is open
+      $(".messagelist.map").css(
+        "display",
+        tabId === "#devicelocation-group" ? "block" : "",
+      );
       triggerResize();
       $.event.trigger({
         type: "tabshown",

--- a/openwisp_controller/geo/templates/admin/geo/device_location_inline.html
+++ b/openwisp_controller/geo/templates/admin/geo/device_location_inline.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% for inline_admin_form in inline_admin_formset %}
     {% if inline_admin_formset.formset.estimated_location_enabled and inline_admin_form.original.location.is_estimated %}
-    <ul class="messagelist">
+    <ul class="messagelist map">
         <li class="warning device-location-estimated">
             {% trans "This location is estimated based on the device's last IP address. Edit the coordinates or address to increase accuracy and clear the estimated flag." %}
         </li>

--- a/openwisp_controller/geo/tests/pytest.py
+++ b/openwisp_controller/geo/tests/pytest.py
@@ -108,6 +108,7 @@ class TestChannels(TestGeoMixin, TestChannelsMixin, TestOrganizationMixin):
 
     @pytest.mark.asyncio
     @pytest.mark.django_db(transaction=True)
+    @pytest.mark.timeout(10)
     async def test_common_location_org_isolation(self):
         administrator = await Group.objects.acreate(name="Administrator")
         perm = await Permission.objects.filter(

--- a/openwisp_controller/geo/tests/test_admin.py
+++ b/openwisp_controller/geo/tests/test_admin.py
@@ -204,6 +204,7 @@ class TestDeviceAdmin(
             "Edit the coordinates or address to increase accuracy and clear the "
             "estimated flag.",
         )
+        self.assertContains(response, 'class="messagelist map"', html=False)
         org.geo_settings.estimated_location_enabled = False
         org.geo_settings.save()
         response = self.client.get(path)

--- a/openwisp_controller/geo/tests/test_selenium.py
+++ b/openwisp_controller/geo/tests/test_selenium.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from channels.testing import ChannelsLiveServerTestCase
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
@@ -11,6 +13,7 @@ from swapper import load_model
 from openwisp_users.tests.utils import TestOrganizationMixin
 from openwisp_utils.tests import SeleniumTestMixin
 
+from ...config import settings as config_app_settings
 from .utils import TestGeoMixin
 
 Device = load_model("config", "Device")
@@ -39,6 +42,19 @@ class TestDeviceAdminGeoSelenium(
     def _get_prefix(cls):
         return cls.inline_field_prefix
 
+    @classmethod
+    def setUpClass(cls):
+        cls.whois_configured = mock.patch.object(
+            config_app_settings, "WHOIS_CONFIGURED", True
+        )
+        cls.whois_configured.start()
+        super().setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.whois_configured.stop()
+        super().tearDownClass()
+
     # set timeout to 5 seconds to allow enough time for presence of elements
     def wait_for_presence(self, by, value, timeout=5, driver=None):
         return super().wait_for_presence(by, value, timeout, driver)
@@ -62,6 +78,33 @@ class TestDeviceAdminGeoSelenium(
         )
         self.find_element(by=By.CLASS_NAME, value="select2-results__option").click()
         super()._fill_device_form()
+
+    def test_estimated_location_warning(self):
+        org = self._get_org()
+        org.geo_settings.estimated_location_enabled = True
+        org.geo_settings.save()
+        location = self._create_location(organization=org, is_estimated=True)
+        device = self._create_object(
+            name="test",
+            organization=org,
+            mac_address="00:11:22:33:44:66",
+        )
+        self._create_object_location(location=location, content_object=device)
+        self.login()
+        self.open(reverse("admin:config_device_change", args=[device.pk]))
+        self.hide_loading_overlay()
+        warning_selector = ".messagelist.map"
+        self.wait_for_presence(By.CSS_SELECTOR, warning_selector)
+        self.assertFalse(
+            self.web_driver.find_element(
+                By.CSS_SELECTOR, warning_selector
+            ).is_displayed(),
+            "The estimated location warning must be hidden outside the Map tab.",
+        )
+        self.find_element(By.CSS_SELECTOR, 'a[href="#devicelocation-group"]').click()
+        self.wait_for_visibility(By.CSS_SELECTOR, warning_selector)
+        self.find_element(By.CSS_SELECTOR, 'a[href="#overview-group"]').click()
+        self.wait_for_invisibility(By.CSS_SELECTOR, warning_selector)
 
 
 @tag("selenium_tests")


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

- Hide estimated-location warnings by default and show them only while the Map tab is active.
- Add admin and Selenium coverage for the warning visibility.
- Increase the organization-isolation Channels test timeout to accommodate its intentional receive timeouts.

## Screenshot

Fixes this issue:

<img width="960" height="514" alt="image" src="https://github.com/user-attachments/assets/a0219606-531a-4320-8cc7-ab5a7d191b76" />
