### PR TITLE
[ci] Update PR validation workflow

### DIFF
--- a/.github/workflows/bot-autoassign-pr-issue-link.yml
+++ b/.github/workflows/bot-autoassign-pr-issue-link.yml
@@ -1,13 +1,13 @@
 name: PR Issue Auto-Assignment
 on:
   pull_request_target:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, edited, ready_for_review]
 permissions:
   contents: read
   issues: write
   pull-requests: read
 concurrency:
-  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}-${{ github.event.action }}
+  group: bot-autoassign-pr-link-${{ github.repository }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 jobs:
   auto-assign-issue:


### PR DESCRIPTION
## Checklist

- [x] I have read the OpenWISP Contributing Guidelines and OpenWISP Anti AI Spam Policy.
- N/A. This GitHub Actions caller-workflow change has no local manual execution path.
- N/A. No application code changed.
- N/A. No user-facing behavior or documentation changed.

## Reference to Existing Issue

Related to https://github.com/openwisp/openwisp-utils/pull/716

## Description of Changes

Adds `edited` and `ready_for_review` pull request events so the shared workflow promptly revalidates changed descriptions. Makes the concurrency key PR-specific so newer events cancel outdated validation runs.

## Screenshot

N/A. This is a GitHub Actions workflow-only change.