### PR TITLE
[change] Allowed deleting organization with active devices

### DIFF
--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -38,6 +38,7 @@ from openwisp_users.admin import OrganizationAdmin
 from openwisp_users.multitenancy import MultitenantOrgFilter
 from openwisp_utils.admin import (
     AlwaysHasChangedMixin,
+    BlockDeleteAllowCascadeMixin,
     CopyableFieldsAdmin,
     TimeReadonlyAdminMixin,
 )
@@ -609,7 +610,65 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, CopyableFieldsAdmin):
         perm = super().has_delete_permission(request)
         if not obj:
             return perm
+        if BlockDeleteAllowCascadeMixin.is_admin_cascade_delete_request(self, request):
+            self._add_active_device_delete_warning(request, obj)
+            return perm
         return perm and obj.is_deactivated()
+
+    def _add_active_device_delete_warning(self, request, obj):
+        if getattr(request, "_active_device_delete_warning", False):
+            return
+        resolver_match = getattr(request, "resolver_match", None)
+        url_name = getattr(resolver_match, "url_name", None)
+        opts = Organization._meta
+        organization_delete_url_name = f"{opts.app_label}_{opts.model_name}_delete"
+        organization_changelist_url_name = (
+            f"{opts.app_label}_{opts.model_name}_changelist"
+        )
+        active_organizations = 0
+        if request.method == "GET" and url_name == organization_delete_url_name:
+            active_organizations = (
+                Device.objects.filter(
+                    organization_id=obj.organization_id,
+                    _is_deactivated=False,
+                )
+                .values("organization_id")
+                .distinct()
+                .count()
+            )
+        elif (
+            url_name == organization_changelist_url_name
+            and request.POST.get("action") == "delete_selected"
+            and not request.POST.get("post")
+        ):
+            active_organizations = (
+                Device.objects.filter(
+                    organization_id__in=request.POST.getlist(
+                        helpers.ACTION_CHECKBOX_NAME
+                    ),
+                    _is_deactivated=False,
+                )
+                .values("organization_id")
+                .distinct()
+                .count()
+            )
+        if not active_organizations:
+            return
+        self.message_user(
+            request,
+            ngettext_lazy(
+                "This organization contains active devices. It is highly "
+                "recommended to deactivate them before deleting the organization "
+                "to ensure sensitive configuration data is disposed of safely.",
+                "%(count)d organizations contain active devices. It is highly "
+                "recommended to deactivate them before deleting the organizations "
+                "to ensure sensitive configuration data is disposed of safely.",
+                active_organizations,
+            )
+            % {"count": active_organizations},
+            messages.WARNING,
+        )
+        request._active_device_delete_warning = True
 
     def save_form(self, request, form, change):
         self._state_adding = form.instance._state.adding

--- a/openwisp_controller/config/admin.py
+++ b/openwisp_controller/config/admin.py
@@ -616,7 +616,7 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, CopyableFieldsAdmin):
         return perm and obj.is_deactivated()
 
     def _add_active_device_delete_warning(self, request, obj):
-        if getattr(request, "_active_device_delete_warning", False):
+        if getattr(request, "_active_device_delete_warning_checked", False):
             return
         resolver_match = getattr(request, "resolver_match", None)
         url_name = getattr(resolver_match, "url_name", None)
@@ -627,6 +627,7 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, CopyableFieldsAdmin):
         )
         active_organizations = 0
         if request.method == "GET" and url_name == organization_delete_url_name:
+            request._active_device_delete_warning_checked = True
             active_organizations = (
                 Device.objects.filter(
                     organization_id=obj.organization_id,
@@ -641,10 +642,14 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, CopyableFieldsAdmin):
             and request.POST.get("action") == "delete_selected"
             and not request.POST.get("post")
         ):
+            request._active_device_delete_warning_checked = True
+            organizations = self.admin_site.get_model_admin(Organization).get_queryset(
+                request
+            )
             active_organizations = (
                 Device.objects.filter(
-                    organization_id__in=request.POST.getlist(
-                        helpers.ACTION_CHECKBOX_NAME
+                    organization_id__in=organizations.filter(
+                        pk__in=request.POST.getlist(helpers.ACTION_CHECKBOX_NAME)
                     ),
                     _is_deactivated=False,
                 )
@@ -668,7 +673,6 @@ class DeviceAdmin(MultitenantAdminMixin, BaseConfigAdmin, CopyableFieldsAdmin):
             % {"count": active_organizations},
             messages.WARNING,
         )
-        request._active_device_delete_warning = True
 
     def save_form(self, request, form, change):
         self._state_adding = form.instance._state.adding

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -2814,6 +2814,82 @@ class TestTransactionAdmin(
                 self.assertEqual(template2.default_values["ifname"], "eth3")
                 mocked_signal.assert_called_once()
 
+    def test_delete_organization_with_active_device(self):
+        org = self._create_org(name="organization-delete", slug="organization-delete")
+        first_device = self._create_device(organization=org)
+        second_device = self._create_device(
+            name="second-device",
+            organization=org,
+            mac_address="00:11:22:33:44:56",
+        )
+        url = reverse(
+            f"admin:{org._meta.app_label}_{org._meta.model_name}_delete",
+            args=[org.pk],
+        )
+        warning = (
+            "This organization contains active devices. It is highly recommended "
+            "to deactivate them before deleting the organization to ensure "
+            "sensitive configuration data is disposed of safely."
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(
+            response, "your account doesn't have permission to delete"
+        )
+        self.assertContains(response, warning, count=1)
+        response = self.client.post(url, {"post": "yes"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(org.__class__.objects.filter(pk=org.pk).exists())
+        self.assertFalse(Device.objects.filter(pk=first_device.pk).exists())
+        self.assertFalse(Device.objects.filter(pk=second_device.pk).exists())
+
+    def test_delete_organization_with_deactivated_device(self):
+        org = self._create_org(name="organization-delete", slug="organization-delete")
+        device = self._create_device(organization=org)
+        device.deactivate()
+        url = reverse(
+            f"admin:{org._meta.app_label}_{org._meta.model_name}_delete",
+            args=[org.pk],
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "This organization contains active devices.")
+        response = self.client.post(url, {"post": "yes"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(org.__class__.objects.filter(pk=org.pk).exists())
+        self.assertFalse(Device.objects.filter(pk=device.pk).exists())
+
+    def test_delete_organizations_with_multiple_active_devices(self):
+        first_org = self._create_org(name="first-organization", slug="first-org")
+        second_org = self._create_org(name="second-organization", slug="second-org")
+        first_device = self._create_device(organization=first_org)
+        second_device = self._create_device(
+            name="second-device",
+            organization=second_org,
+            mac_address="00:11:22:33:44:56",
+        )
+        url = reverse(
+            f"admin:{first_org._meta.app_label}_{first_org._meta.model_name}_changelist"
+        )
+        data = {
+            "action": "delete_selected",
+            "_selected_action": [first_org.pk, second_org.pk],
+        }
+        warning = (
+            "2 organizations contain active devices. It is highly recommended to "
+            "deactivate them before deleting the organizations to ensure sensitive "
+            "configuration data is disposed of safely."
+        )
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, warning, count=1)
+        response = self.client.post(url, {**data, "post": "yes"}, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(first_org.__class__.objects.filter(pk=first_org.pk).exists())
+        self.assertFalse(second_org.__class__.objects.filter(pk=second_org.pk).exists())
+        self.assertFalse(Device.objects.filter(pk=first_device.pk).exists())
+        self.assertFalse(Device.objects.filter(pk=second_device.pk).exists())
+
 
 class TestDeviceGroupAdmin(
     CreateDeviceGroupMixin,

--- a/openwisp_controller/config/tests/test_admin.py
+++ b/openwisp_controller/config/tests/test_admin.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import django
+from django.contrib import admin
 from django.contrib.admin.models import LogEntry
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -13,8 +14,8 @@ from django.core.files.base import ContentFile
 from django.core.management import call_command
 from django.db import IntegrityError
 from django.db.models.signals import post_save
-from django.test import TestCase, TransactionTestCase
-from django.urls import reverse
+from django.test import RequestFactory, TestCase, TransactionTestCase
+from django.urls import resolve, reverse
 from reversion.models import Version
 from swapper import load_model
 
@@ -2889,6 +2890,59 @@ class TestTransactionAdmin(
         self.assertFalse(second_org.__class__.objects.filter(pk=second_org.pk).exists())
         self.assertFalse(Device.objects.filter(pk=first_device.pk).exists())
         self.assertFalse(Device.objects.filter(pk=second_device.pk).exists())
+
+    def test_organization_delete_warning_uses_authorized_organizations(self):
+        first_org = self._create_org(name="first-organization", slug="first-org")
+        second_org = self._create_org(name="second-organization", slug="second-org")
+        first_device = self._create_device(organization=first_org)
+        self._create_device(
+            name="second-device",
+            organization=second_org,
+            mac_address="00:11:22:33:44:56",
+        )
+        user = self._create_operator(organizations=[first_org])
+        url = reverse(
+            f"admin:{first_org._meta.app_label}_{first_org._meta.model_name}_changelist"
+        )
+        request = RequestFactory().post(
+            url,
+            {
+                "action": "delete_selected",
+                "_selected_action": [first_org.pk, second_org.pk],
+            },
+        )
+        request.resolver_match = resolve(url)
+        request.user = user
+        device_admin = admin.site.get_model_admin(Device)
+        with patch.object(device_admin, "message_user") as message_user:
+            device_admin._add_active_device_delete_warning(request, first_device)
+        message = str(message_user.call_args.args[1])
+        self.assertIn("This organization contains active devices.", message)
+        self.assertNotIn("organizations contain active devices.", message)
+
+    def test_organization_delete_warning_is_checked_once(self):
+        org = self._create_org(name="organization-delete", slug="organization-delete")
+        first_device = self._create_device(organization=org)
+        second_device = self._create_device(
+            name="second-device",
+            organization=org,
+            mac_address="00:11:22:33:44:56",
+        )
+        first_device.deactivate()
+        second_device.deactivate()
+        url = reverse(
+            f"admin:{org._meta.app_label}_{org._meta.model_name}_delete",
+            args=[org.pk],
+        )
+        request = RequestFactory().get(url)
+        request.resolver_match = resolve(url)
+        device_admin = admin.site.get_model_admin(Device)
+        with patch.object(
+            Device.objects, "filter", wraps=Device.objects.filter
+        ) as filter_:
+            device_admin._add_active_device_delete_warning(request, first_device)
+            device_admin._add_active_device_delete_warning(request, second_device)
+        self.assertEqual(filter_.call_count, 1)
 
 
 class TestDeviceGroupAdmin(


### PR DESCRIPTION
## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Related to https://github.com/openwisp/openwisp-firmware-upgrader/issues/256.

## Description of Changes

Trying to delete an organization with active devices was prevented due to `DeviceAdmin.has_delete_permission` returning `False`. The error message shown to users was pretty vague as it says the user doesn't have permission to perform this action.
  
Deletion is now allowed, but a warning message about active devices still lingering around is shown in the admini UI.

## Screenshot

Before:

<img width="1093" height="191" alt="image" src="https://github.com/user-attachments/assets/cff30548-3a82-42c8-8246-223308219cda" />

After:

<img width="1100" height="283" alt="image" src="https://github.com/user-attachments/assets/493b3301-d06e-4518-b076-ed0c019c434f" />
