### PR TITLE
[tests] Refactored Selenium test logic to use new helpers

### DIFF
--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -12,7 +12,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.utils import free_port
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select, WebDriverWait
+from selenium.webdriver.support.ui import Select
 from swapper import load_model
 
 from openwisp_utils.tests import SeleniumTestMixin as BaseSeleniumTestMixin
@@ -92,7 +92,7 @@ class TestDeviceAdmin(
             'document.querySelector("#ow-user-tools").style.display="none"'
         )
         self.find_element(by=By.NAME, value="_save").click()
-        self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success", timeout=5)
+        self.wait_for_admin_success_message()
 
     def test_create_new_device(self):
         required_template = self._create_template(name="Required", required=True)
@@ -121,22 +121,13 @@ class TestDeviceAdmin(
             by=By.XPATH, value='//*[@id="config-group"]/fieldset/div[2]/a'
         ).click()
         try:
-            WebDriverWait(self.web_driver, 2).until(
-                # This WebDriverWait ensures that Selenium waits until the
-                # "config-0-templates" input field on the page gets updated
-                # with the IDs of the default and required templates after
-                # the user clicks on the "Add another config" link. This update
-                # is essential because it signifies that the logic in
-                # relevant_template.js has executed successfully, selecting
-                # the appropriate default and required templates. This logic
-                # also changes the ordering of the templates.
-                # Failing to wait for this update could lead to
-                # StaleElementReferenceException like in
-                # https://github.com/openwisp/openwisp-controller/issues/834
+            # Wait for relevant_template.js to select and order the templates.
+            # This avoids StaleElementReferenceException: issue #834.
+            self.wait_until(
                 EC.text_to_be_present_in_element_value(
                     (By.CSS_SELECTOR, 'input[name="config-0-templates"]'),
                     f"{required_template.id},{default_template.id}",
-                )
+                ),
             )
         except TimeoutException:
             self.fail("Relevant templates logic was not executed")
@@ -155,7 +146,7 @@ class TestDeviceAdmin(
             'document.querySelector("#ow-user-tools").style.display="none"'
         )
         self.find_element(by=By.NAME, value="_save").click()
-        self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success", timeout=5)
+        self.wait_for_admin_success_message()
         self.assertEqual(
             self.find_elements(by=By.CLASS_NAME, value="success")[0].text,
             "The Device “11:22:33:44:55:66” was added successfully.",
@@ -484,7 +475,7 @@ class TestDeviceAdmin(
             # Scroll to the top of the page to ensure the save button is visible
             self.web_driver.execute_script("window.scrollTo(0, 0);")
             self.find_element(by=By.NAME, value="_save").click()
-            self.wait_for_presence(By.CSS_SELECTOR, ".messagelist .success", timeout=5)
+            self.wait_for_admin_success_message()
 
 
 @tag("selenium_tests")
@@ -700,14 +691,14 @@ class TestDeviceAdminUnsavedChanges(
         )
         self.hide_loading_overlay()
         try:
-            WebDriverWait(self.web_driver, 2).until(
+            self.wait_until(
                 EC.text_to_be_present_in_element_value(
                     (
                         By.XPATH,
                         '//*[@id="flat-json-config-0-context"]/div[2]/div/div/input[1]',
                     ),
                     "vni",
-                )
+                ),
             )
         except TimeoutException:
             self.fail("Timed out waiting for configuration variables to get loaded")

--- a/openwisp_controller/config/whois/tests/tests.py
+++ b/openwisp_controller/config/whois/tests/tests.py
@@ -1255,7 +1255,7 @@ class TestWHOISSelenium(CreateWHOISMixin, SeleniumTestMixin, StaticLiveServerTes
     @mock.patch.object(app_settings, "WHOIS_CONFIGURED", True)
     def test_device_admin(self):
         def _assert_no_js_errors():
-            self.assertEqual(self.get_browser_errors(), [])
+            self.assert_no_browser_errors()
 
         whois_obj = self._create_whois_info()
         device = self._create_device(last_ip=whois_obj.ip_address)

--- a/openwisp_controller/connection/tests/test_selenium.py
+++ b/openwisp_controller/connection/tests/test_selenium.py
@@ -47,7 +47,7 @@ class TestDeviceAdmin(
         self.hide_loading_overlay()
         # Send reboot command to the device
         self.find_element(
-            by=By.CSS_SELECTOR, value="ul.object-tools a#send-command", timeout=5
+            by=By.CSS_SELECTOR, value="ul.object-tools a#send-command"
         ).click()
         self.find_element(
             by=By.CSS_SELECTOR, value='button.ow-command-btn[data-command="reboot"]'

--- a/openwisp_controller/geo/tests/test_selenium.py
+++ b/openwisp_controller/geo/tests/test_selenium.py
@@ -55,10 +55,6 @@ class TestDeviceAdminGeoSelenium(
         cls.whois_configured.stop()
         super().tearDownClass()
 
-    # set timeout to 5 seconds to allow enough time for presence of elements
-    def wait_for_presence(self, by, value, timeout=5, driver=None):
-        return super().wait_for_presence(by, value, timeout, driver)
-
     def _fill_device_form(self):
         org = self._get_org()
         self.find_element(by=By.NAME, value="mac_address").send_keys(

--- a/openwisp_controller/tests/test_selenium.py
+++ b/openwisp_controller/tests/test_selenium.py
@@ -8,7 +8,6 @@ from reversion.models import Version
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 from swapper import load_model
 
 from openwisp_controller.connection.tests.utils import CreateConnectionsMixin
@@ -98,11 +97,11 @@ class TestDevice(
             by=By.XPATH, value='//*[@id="device_form"]/div/div[1]/input[1]'
         ).click()
         try:
-            WebDriverWait(self.web_driver, 5).until(
+            self.wait_until(
                 EC.url_to_be(
                     self.live_server_url
                     + reverse(f"admin:{self.config_app_label}_device_changelist")
-                )
+                ),
             )
         except TimeoutException:
             self.fail("Deleted device was not restored")


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [N/A] I have updated the documentation.

## Reference to Existing Issue

N/A. This small test-maintenance change does not require a related issue.

## Description of Changes

Refactors Selenium tests to use `wait_until()`, `assert_no_browser_errors()`, and `wait_for_admin_success_message()`. Removes redundant timeout overrides and keeps the standard two-second wait by default.

## Screenshot

N/A. This change affects test code only.