### PR TITLE
[feature] Reconciled device templates and credentials on organization…

### DIFF
--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -318,29 +318,8 @@ class DeviceDetailSerializer(WHOISMixin, DeviceConfigSerializer):
 
     def update(self, instance, validated_data):
         config_data = validated_data.pop("config", {})
-        raw_data_for_signal_handlers = {
-            "organization": validated_data.get("organization", instance.organization)
-        }
         if config_data:
             self._update_config(instance, config_data)
-
-        elif instance._has_config() and validated_data.get("organization"):
-            if instance.organization != validated_data.get("organization"):
-                # config.device.organization is used for validating
-                # the organization of templates. It is also used for adding
-                # default and required templates configured for an organization.
-                # The value of the organization field is set here to
-                # prevent access of the old value stored in the database
-                # while performing above operations.
-                instance.config.device.organization = validated_data.get("organization")
-                instance.config.templates.clear()
-                Config.enforce_required_templates(
-                    action="post_clear",
-                    instance=instance.config,
-                    sender=instance.config.templates,
-                    pk_set=None,
-                    raw_data=raw_data_for_signal_handlers,
-                )
         return super().update(instance, validated_data)
 
 

--- a/openwisp_controller/config/apps.py
+++ b/openwisp_controller/config/apps.py
@@ -22,6 +22,7 @@ from .signals import (
     device_group_changed,
     device_name_changed,
     group_templates_changed,
+    organization_changed,
     vpn_peers_changed,
     vpn_server_modified,
 )
@@ -368,9 +369,15 @@ class ConfigConfig(AppConfig):
         * refreshing the configs of a VPN server's clients when the server
           changes. ``vpn_server_change_handler`` recomputes each client's
           checksum and emits ``config_modified`` for it, but only when that
-          checksum actually changed.
+          checksum actually changed;
+        * reconciling config templates when a device's organization changes
+          (``device_organization_changed_handler``).
         """
-        from .handlers import devicegroup_change_handler, vpn_server_change_handler
+        from .handlers import (
+            device_organization_changed_handler,
+            devicegroup_change_handler,
+            vpn_server_change_handler,
+        )
 
         config_deactivated.connect(
             self.device_model.config_deactivated_clear_management_ip,
@@ -385,6 +392,11 @@ class ConfigConfig(AppConfig):
             vpn_server_change_handler,
             sender=self.vpn_model,
             dispatch_uid="vpn.invalidate_checksum_cache",
+        )
+        organization_changed.connect(
+            device_organization_changed_handler,
+            sender=self.device_model,
+            dispatch_uid="device_organization_changed_reconcile",
         )
 
     def register_dashboard_charts(self):

--- a/openwisp_controller/config/base/config.py
+++ b/openwisp_controller/config/base/config.py
@@ -563,10 +563,16 @@ class AbstractConfig(CacheInvalidationMixin, ChecksumCacheMixin, BaseConfig):
             return
         raw_data = raw_data or {}
         template_query = models.Q(required=True, backend=instance.backend)
-        # trying to remove a required template will raise PermissionDenied
         if action == "pre_remove":
+            organization = raw_data.get("organization", instance.device.organization)
             templates = cls._get_templates_from_pk_set(pk_set)
-            if templates.filter(template_query).exists():
+            if (
+                templates.filter(template_query)
+                .filter(
+                    models.Q(organization=organization) | models.Q(organization=None)
+                )
+                .exists()
+            ):
                 raise PermissionDenied(
                     _("Required templates cannot be removed from the configuration")
                 )
@@ -983,7 +989,9 @@ class AbstractConfig(CacheInvalidationMixin, ChecksumCacheMixin, BaseConfig):
 
     def get_vpn_context(self):
         context = {}
-        for vpnclient in self.vpnclient_set.all().select_related("vpn", "cert"):
+        for vpnclient in self.vpnclient_set.filter(
+            template__in=self.templates.all()
+        ).select_related("vpn", "cert"):
             vpn = vpnclient.vpn
             vpn_id = vpn.pk.hex
             context.update(vpn.get_vpn_server_context())

--- a/openwisp_controller/config/base/device.py
+++ b/openwisp_controller/config/base/device.py
@@ -17,6 +17,7 @@ from ..signals import (
     device_group_changed,
     device_name_changed,
     management_ip_changed,
+    organization_changed,
 )
 from ..validators import device_name_validator, mac_address_validator
 from ..whois.service import WHOISService
@@ -239,9 +240,9 @@ class AbstractDevice(OrgMixin, BaseModel):
             return KeyField.default_callable()
 
     def _validate_org_device_limit(self):
-        if not self._state.adding and not self._check_organization_id_changed():
+        if not self._state.adding and not self._has_organization_id_changed():
             # This check is only executed when a new device
-            # is created.
+            # is created or when organization is changed.
             return
         if (
             not hasattr(self, "organization")
@@ -383,7 +384,7 @@ class AbstractDevice(OrgMixin, BaseModel):
 
         self._initial_management_ip = self.management_ip
 
-    def _check_organization_id_changed(self):
+    def _has_organization_id_changed(self):
         """
         Returns "True" if the device's organization has changed.
         """
@@ -391,6 +392,18 @@ class AbstractDevice(OrgMixin, BaseModel):
             self._initial_organization_id != models.DEFERRED
             and self.organization_id != self._initial_organization_id
         )
+
+    def _check_organization_id_changed(self):
+        if self._initial_organization_id == models.DEFERRED:
+            return
+        if self.organization_id != self._initial_organization_id:
+            organization_changed.send(
+                sender=self.__class__,
+                instance=self,
+                old_organization_id=self._initial_organization_id,
+                organization_id=self.organization_id,
+            )
+            self._initial_organization_id = self.organization_id
 
     @classmethod
     def _send_device_group_changed_signal(cls, instance, group_id, old_group_id):

--- a/openwisp_controller/config/handlers.py
+++ b/openwisp_controller/config/handlers.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import models, transaction
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 from openwisp_notifications.signals import notify
@@ -12,6 +12,38 @@ Device = load_model("config", "Device")
 DeviceGroup = load_model("config", "DeviceGroup")
 Organization = load_model("openwisp_users", "Organization")
 Cert = load_model("django_x509", "Cert")
+
+
+def device_organization_changed_handler(
+    sender, instance, old_organization_id, organization_id, **kwargs
+):
+    """Reconcile Config templates when a Device changes organization.
+
+    Removes templates that belong to other organizations, removes shared VPN/client
+    templates (type != 'generic'), and adds required templates for the new
+    organization.
+    """
+    if not hasattr(instance, "config"):
+        return
+    config = instance.config
+    # 1. Templates owned by a different organization.
+    # 2. Shared templates (organization is None) that are not generic.
+    to_remove = config.templates.filter(
+        (models.Q(organization__isnull=False) & ~models.Q(organization_id=organization_id))
+        | (models.Q(organization__isnull=True) & ~models.Q(type="generic"))
+    )
+    if to_remove.exists():
+        config.templates.remove(*to_remove)
+    # Add required templates for the destination organization.
+    Template = load_model("config", "Template")
+    required_templates = Template.objects.filter(
+        required=True,
+        backend=config.backend,
+    ).filter(
+        models.Q(organization_id=organization_id) | models.Q(organization__isnull=True)
+    )
+    if required_templates.exists():
+        config.templates.add(*required_templates)
 
 
 @receiver(

--- a/openwisp_controller/config/signals.py
+++ b/openwisp_controller/config/signals.py
@@ -1,5 +1,13 @@
 from django.dispatch import Signal
 
+try:
+    from openwisp_users.signals import organization_changed
+except ImportError:
+    organization_changed = Signal()
+    organization_changed.__doc__ = """
+    Providing arguments: ['instance', 'old_organization_id', 'organization_id']
+    """
+
 checksum_requested = Signal()
 checksum_requested.__doc__ = """
 Providing arguments: ['instance', 'request']

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -543,6 +543,51 @@ class TestConfigApi(
         self.assertEqual(config.templates.count(), 1)
         self.assertEqual(config.templates.first(), org2_template)
 
+    def test_device_change_organization_reconciles_templates_and_vpn(self):
+        org1 = self._create_org(name="org1")
+        org2 = self._create_org(name="org2")
+        org1_template = self._create_template(
+            name="org1-template", organization=org1, config={"interfaces": []}
+        )
+        shared_generic = self._create_template(
+            name="shared-generic", organization=None, type="generic", config={"general": {}}
+        )
+        shared_vpn = self._create_vpn(name="shared-vpn", organization=None)
+        shared_vpn_template = self._create_template(
+            name="shared-vpn-template",
+            type="vpn",
+            vpn=shared_vpn,
+            organization=None,
+            auto_cert=True,
+            config={},
+        )
+        org2_template = self._create_template(
+            name="org2-template", organization=org2, required=True
+        )
+        device = self._create_device(organization=org1)
+        config = self._create_config(device=device)
+        config.templates.add(org1_template, shared_generic, shared_vpn_template)
+        self.assertEqual(config.templates.count(), 3)
+        self.assertEqual(config.vpnclient_set.count(), 1)
+        cert = config.vpnclient_set.first().cert
+        self.assertFalse(cert.revoked)
+
+        path = reverse("config_api:device_detail", args=[device.pk])
+        data = {"organization": org2.pk}
+        response = self.client.patch(path, data=data, content_type="application/json")
+        self.assertEqual(response.status_code, 200)
+        device.refresh_from_db()
+        config.refresh_from_db()
+        self.assertEqual(device.organization, org2)
+        self.assertEqual(
+            set(config.templates.values_list("id", flat=True)),
+            {shared_generic.pk, org2_template.pk},
+        )
+        self.assertEqual(config.vpnclient_set.count(), 0)
+        cert.refresh_from_db()
+        self.assertTrue(cert.revoked)
+        self.assertEqual(config.get_vpn_context(), {})
+
     def test_device_patch_api(self):
         d1 = self._create_device(name="test-device")
         path = reverse("config_api:device_detail", args=[d1.pk])

--- a/openwisp_controller/config/tests/test_device.py
+++ b/openwisp_controller/config/tests/test_device.py
@@ -16,9 +16,15 @@ from ..signals import (
     device_group_changed,
     device_name_changed,
     management_ip_changed,
+    organization_changed,
 )
 from ..validators import device_name_validator, mac_address_validator
-from .utils import CreateConfigTemplateMixin, CreateDeviceGroupMixin
+from ...pki.tests.utils import TestPkiMixin
+from .utils import (
+    CreateConfigTemplateMixin,
+    CreateDeviceGroupMixin,
+    CreateVpnMixin,
+)
 
 TEST_ORG_SHARED_SECRET = "functional_testing_secret"
 
@@ -30,9 +36,11 @@ _original_context = app_settings.CONTEXT.copy()
 
 
 class TestDevice(
+    TestPkiMixin,
     CreateConfigTemplateMixin,
     AssertNumQueriesSubTestMixin,
     CreateDeviceGroupMixin,
+    CreateVpnMixin,
     TestCase,
 ):
     """
@@ -583,6 +591,77 @@ class TestDevice(
         self.assertEqual(device.config.context, {"ssid": "test"})
         self.assertEqual(device.config.config, {"general": {}})
 
+    def test_organization_changed_signal_emitted(self):
+        org1 = self._get_org()
+        org2 = self._create_org(name="org2")
+        device = self._create_device(organization=org1)
+
+        with catch_signal(organization_changed) as mocked_signal:
+            device.name = "new-name"
+            device.save()
+            mocked_signal.assert_not_called()
+
+        with catch_signal(organization_changed) as mocked_signal:
+            device.organization = org2
+            device.save()
+            mocked_signal.assert_called_once_with(
+                sender=Device,
+                instance=device,
+                old_organization_id=org1.pk,
+                organization_id=org2.pk,
+                signal=organization_changed,
+            )
+
+    def test_organization_changed_reconciles_templates_and_credentials(self):
+        org1 = self._get_org()
+        org2 = self._create_org(name="org2")
+        org1_template = self._create_template(
+            name="org1-template", organization=org1, config={"interfaces": []}
+        )
+        shared_generic_template = self._create_template(
+            name="shared-generic", organization=None, type="generic", config={"general": {}}
+        )
+        shared_vpn = self._create_vpn(name="shared-vpn", organization=None)
+        shared_vpn_template = self._create_template(
+            name="shared-vpn-template",
+            type="vpn",
+            vpn=shared_vpn,
+            organization=None,
+            auto_cert=True,
+            config={},
+        )
+        org2_required_template = self._create_template(
+            name="org2-required", organization=org2, required=True, config={"general": {}}
+        )
+
+        device = self._create_device(organization=org1)
+        config = self._create_config(device=device)
+        config.templates.add(org1_template, shared_generic_template, shared_vpn_template)
+
+        self.assertEqual(config.templates.count(), 3)
+        self.assertEqual(config.vpnclient_set.count(), 1)
+        vpn_client = config.vpnclient_set.first()
+        cert = vpn_client.cert
+        self.assertIsNotNone(cert)
+        self.assertFalse(cert.revoked)
+        self.assertNotEqual(config.get_vpn_context(), {})
+
+        device.organization = org2
+        device.full_clean()
+        device.save()
+
+        config.refresh_from_db()
+        assigned_template_ids = set(config.templates.values_list("id", flat=True))
+        self.assertEqual(
+            assigned_template_ids,
+            {shared_generic_template.pk, org2_required_template.pk},
+        )
+        self.assertEqual(config.vpnclient_set.count(), 0)
+        cert.refresh_from_db()
+        self.assertTrue(cert.revoked)
+        self.assertEqual(config.get_vpn_context(), {})
+        self.assertEqual(config.status, "modified")
+
 
 class TestTransactionDevice(
     CreateConfigTemplateMixin,
@@ -735,3 +814,4 @@ class TestTransactionDevice(
         device.refresh_from_db()
         self.assertEqual(device._has_config(), False)
         self.assertEqual(device.is_deactivated(), False)
+


### PR DESCRIPTION
… change #1459

When a device is moved to a different organization, its configuration is now automatically reconciled in the same transaction:

- Templates owned by the previous organization are removed.
- Shared non-generic templates (VPN client, certificate-generator) are removed, since their provisioned credentials are bound to the previous organization.
- Shared generic templates are preserved.
- Required templates belonging to the new organization are added automatically.

The VPN context renderer is also scoped to the config's current templates, preventing stale VpnClient entries from leaking credentials from the old organization into the rendered configuration.

Fixes #1459

## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

<!-- Please [open a new issue](https://github.com/openwisp/openwisp-controller/issues/new/choose) if there isn't an existing issue yet. -->

Closes #<issue-number>.

## Description of Changes

Please describe these changes.

## Screenshot

Please include any relevant screenshots.
