### PR TITLE
[fix] Fixed duplicate IP allocation in subnet division #1464

### DIFF
--- a/docs/user/subnet-division-rules.rst
+++ b/docs/user/subnet-division-rules.rst
@@ -136,9 +136,10 @@ Important notes for using Subnet Division
   the *default values* template field (mainly used for validation).
 - The Subnet Division Rule automatically creates a reserved subnet, which
   can be utilized to provision any IP addresses that need to be created
-  manually. The remaining address space of the master subnet must not be
-  interfered with, or the automation implemented in this module will not
-  function.
+  manually. Do not create child subnets manually in the remaining address
+  space of the master subnet. If an IP address is already allocated in the
+  master subnet hierarchy, the rule skips child subnet candidates that
+  would provision the same address.
 - The example provided used the :ref:`VPN subnet division rule
   <vpn_rule>`. Similarly, the :ref:`device subnet division rule
   <device_rule>` can be employed, requiring only :ref:`the creation of a

--- a/openwisp_controller/config/tests/test_selenium.py
+++ b/openwisp_controller/config/tests/test_selenium.py
@@ -72,7 +72,9 @@ class TestDeviceAdmin(
             reverse(f"admin:{self.config_app_label}_device_change", args=[device_id])
             + "#config-group"
         )
-        self.wait_for_presence(By.CSS_SELECTOR, 'input[name="config-0-templates"]')
+        self.wait_for_presence(
+            By.CSS_SELECTOR, 'input[name="config-0-templates"]', timeout=10
+        )
 
         # if not is_enabled:
         self.hide_loading_overlay()

--- a/openwisp_controller/subnet_division/rule_types/base.py
+++ b/openwisp_controller/subnet_division/rule_types/base.py
@@ -220,10 +220,18 @@ class BaseSubnetDivisionRuleType(object):
     @staticmethod
     def create_subnets(config, division_rule, max_subnet, generated_indexes):
         master_subnet = division_rule.master_subnet
+        # IPAM forbids an address from being assigned more than once in a subnet
+        # hierarchy, including the master subnet and its child subnets.
+        allocated_ips = set(
+            IpAddress.objects.filter(
+                subnet_id__in=master_subnet.get_related_subnet_pks()
+            ).values_list("ip_address", flat=True)
+        )
         required_subnet = IPNetwork(str(max_subnet)).next()
         generated_subnets = []
 
-        for subnet_id in range(1, division_rule.number_of_subnets + 1):
+        while len(generated_subnets) < division_rule.number_of_subnets:
+            subnet_id = len(generated_subnets) + 1
             if not ip_network(str(required_subnet)).subnet_of(master_subnet.subnet):
                 notify.send(
                     sender=config,
@@ -242,6 +250,16 @@ class BaseSubnetDivisionRuleType(object):
                 )
                 logger.info(f"Cannot create more subnets of {master_subnet}")
                 break
+            # Avoid a child subnet when its provisioned addresses would conflict
+            # with an existing assignment in the related hierarchy.
+            if any(
+                str(required_subnet[ip_index]) in allocated_ips
+                for ip_index in BaseSubnetDivisionRuleType.get_ip_indexes(
+                    required_subnet, division_rule.number_of_ips
+                )
+            ):
+                required_subnet = required_subnet.next()
+                continue
             subnet_obj = Subnet(
                 name=f"{division_rule.label}_subnet{subnet_id}",
                 subnet=str(required_subnet),
@@ -266,23 +284,25 @@ class BaseSubnetDivisionRuleType(object):
         return generated_subnets
 
     @staticmethod
+    def get_ip_indexes(subnet, number_of_ips):
+        number_of_addresses = (
+            subnet.num_addresses if hasattr(subnet, "num_addresses") else subnet.size
+        )
+        # Reserve the first address unless the rule consumes the entire subnet,
+        # which is necessary for /32 and /128 subnets.
+        if number_of_addresses != number_of_ips:
+            return range(1, number_of_ips + 1)
+        return range(number_of_ips)
+
+    @staticmethod
     def create_ips(config, division_rule, generated_subnets, generated_indexes):
         generated_ips = []
         for subnet_obj in generated_subnets:
-            # don't assign first ip address of a subnet,
-            # unless the rule is designed to use the whole
-            # address space of the subnet
-            if subnet_obj.subnet.num_addresses != division_rule.number_of_ips:
-                index_start = 1
-                index_end = division_rule.number_of_ips + 1
-            # this allows handling /32, /128 or cases in which
-            # the number of requested ip addresses matches exactly
-            # what is available in the subnet
-            else:
-                index_start = 0
-                index_end = division_rule.number_of_ips
             # generate IPs and indexes accordingly
-            for ip_index in range(index_start, index_end):
+            ip_indexes = BaseSubnetDivisionRuleType.get_ip_indexes(
+                subnet_obj.subnet, division_rule.number_of_ips
+            )
+            for ip_index in ip_indexes:
                 ip_obj = IpAddress(
                     subnet_id=subnet_obj.id,
                     ip_address=str(subnet_obj.subnet[ip_index]),
@@ -290,7 +310,7 @@ class BaseSubnetDivisionRuleType(object):
                 ip_obj.full_clean()
                 generated_ips.append(ip_obj)
                 # ensure human friendly labels (starting from 1 instead of 0)
-                keyword_index = ip_index if index_start == 1 else ip_index + 1
+                keyword_index = ip_index if ip_indexes.start == 1 else ip_index + 1
                 generated_indexes.append(
                     SubnetDivisionIndex(
                         keyword=f"{subnet_obj.name}_ip{keyword_index}",

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -295,8 +295,23 @@ class TestSubnetDivisionRule(
         )
         self.assertEqual(index_queryset.count(), 1)
         index = index_queryset.first()
-        self.assertEqual(str(index.subnet.subnet), "10.0.0.1/32")
-        self.assertEqual(index.ip.ip_address, "10.0.0.1")
+        self.assertEqual(self.vpn_server.ip.ip_address, "10.0.0.1")
+        self.assertEqual(str(index.subnet.subnet), "10.0.0.2/32")
+        self.assertEqual(index.ip.ip_address, "10.0.0.2")
+
+    def test_slash_32_rule_ipv4_skips_parent_allocations(self):
+        self.master_subnet.request_ip()
+        self.master_subnet.request_ip()
+        rule = self._get_vpn_subdivision_rule(
+            size=32, number_of_ips=1, number_of_subnets=1
+        )
+        self.config.templates.add(self.template)
+        index = rule.subnetdivisionindex_set.get(
+            config_id=self.config.id, subnet_id__isnull=False, ip_id__isnull=False
+        )
+        self.assertEqual(self.vpn_server.ip.ip_address, "10.0.0.1")
+        self.assertEqual(str(index.subnet.subnet), "10.0.0.4/32")
+        self.assertEqual(index.ip.ip_address, "10.0.0.4")
 
     def test_slash_32_rule_ipv4_error(self):
         master_ipv4 = self._get_master_subnet(subnet="192.168.1.1/32")
@@ -317,6 +332,8 @@ class TestSubnetDivisionRule(
 
     def test_slash_128_rule_ipv6(self):
         master_ipv6 = self._get_master_subnet(subnet="fd12:3456:7890::/48")
+        self.vpn_server.ip.delete()
+        self.vpn_server.ip = None
         self.vpn_server.subnet = master_ipv6
         self.vpn_server.save()
         rule = self._get_vpn_subdivision_rule(
@@ -328,8 +345,9 @@ class TestSubnetDivisionRule(
         )
         self.assertEqual(index_queryset.count(), 1)
         index = index_queryset.first()
-        self.assertEqual(str(index.subnet.subnet), "fd12:3456:7890::1/128")
-        self.assertEqual(index.ip.ip_address, "fd12:3456:7890::1")
+        self.assertEqual(self.vpn_server.ip.ip_address, "fd12:3456:7890::1")
+        self.assertEqual(str(index.subnet.subnet), "fd12:3456:7890::2/128")
+        self.assertEqual(index.ip.ip_address, "fd12:3456:7890::2")
 
     def test_slash_128_rule_ipv6_error(self):
         master_ipv6 = self._get_master_subnet(subnet="fd12:3456:7890::/128")


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] Browser testing was performed.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1464.

## Description of Changes

Prevents subnet division from selecting child prefixes whose provisioned addresses are already assigned in the master subnet hierarchy. Updates the IPv4 and IPv6 host-prefix regressions and adds coverage for multiple parent allocations.

Extends the Selenium wait for the dynamically created template field so the test waits for widget initialization instead of assuming the default two-second timeout.

## Screenshot

N/A