### PR TITLE
[change] Added VPN subnet and IP details to API #1003

### DIFF
--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -1201,10 +1201,6 @@ List VPNs
 
     GET /api/v1/controller/vpn/
 
-Each VPN list response includes the IDs of its associated ``subnet`` and
-read-only ``ip``, when available. The list response excludes
-``webhook_endpoint`` and ``auth_token``.
-
 **Available filters**
 
 You can filter a list of vpns based on their backend using the ``backend``
@@ -1246,9 +1242,6 @@ Get VPN detail
 .. code-block:: text
 
     GET /api/v1/controller/vpn/{id}/
-
-VPN detail and write responses include ``subnet``, read-only ``ip``,
-``webhook_endpoint`` and ``auth_token``.
 
 Download VPN Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -1201,6 +1201,10 @@ List VPNs
 
     GET /api/v1/controller/vpn/
 
+Each VPN list response includes the IDs of its associated ``subnet`` and
+read-only ``ip``, when available. The list response excludes
+``webhook_endpoint`` and ``auth_token``.
+
 **Available filters**
 
 You can filter a list of vpns based on their backend using the ``backend``
@@ -1242,6 +1246,9 @@ Get VPN detail
 .. code-block:: text
 
     GET /api/v1/controller/vpn/{id}/
+
+VPN detail and write responses include ``subnet``, read-only ``ip``,
+``webhook_endpoint`` and ``auth_token``.
 
 Download VPN Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -72,6 +72,7 @@ class TemplateSerializer(BaseSerializer):
 
 class VpnSerializer(BaseSerializer):
     config = serializers.JSONField(initial={})
+    ip = serializers.PrimaryKeyRelatedField(read_only=True)
     include_shared = True
 
     class Meta(BaseMeta):

--- a/openwisp_controller/config/api/serializers.py
+++ b/openwisp_controller/config/api/serializers.py
@@ -85,6 +85,10 @@ class VpnSerializer(BaseSerializer):
             "ca",
             "cert",
             "backend",
+            "subnet",
+            "ip",
+            "webhook_endpoint",
+            "auth_token",
             "notes",
             "dh",
             "config",
@@ -106,6 +110,13 @@ class VpnSerializer(BaseSerializer):
             if data["ca"] and self.instance.cert.ca != data["ca"]:
                 data["cert"] = None
         return super().validate(data)
+
+
+class VpnListSerializer(VpnSerializer):
+    class Meta(VpnSerializer.Meta):
+        fields = VpnSerializer.Meta.fields[:]
+        fields.remove("webhook_endpoint")
+        fields.remove("auth_token")
 
 
 class FilterTemplatesByOrganization(serializers.PrimaryKeyRelatedField):

--- a/openwisp_controller/config/api/views.py
+++ b/openwisp_controller/config/api/views.py
@@ -30,6 +30,7 @@ from .serializers import (
     DeviceGroupSerializer,
     DeviceListSerializer,
     TemplateSerializer,
+    VpnListSerializer,
     VpnSerializer,
 )
 
@@ -57,10 +58,15 @@ class TemplateDetailView(ProtectedAPIMixin, RetrieveUpdateDestroyAPIView):
 
 class VpnListCreateView(ProtectedAPIMixin, ListCreateAPIView):
     serializer_class = VpnSerializer
-    queryset = Vpn.objects.select_related("subnet").order_by("-created")
+    queryset = Vpn.objects.order_by("-created")
     pagination_class = OpenWispPagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = VPNListFilter
+
+    def get_serializer_class(self):
+        if self.request.method == "GET":
+            return VpnListSerializer
+        return super().get_serializer_class()
 
 
 class VpnDetailView(ProtectedAPIMixin, RetrieveUpdateDestroyAPIView):

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -867,9 +867,13 @@ class TestConfigApi(
         ca1 = self._create_ca()
         data = self._vpn_data
         data["ca"] = ca1.pk
+        data["webhook_endpoint"] = "https://vpn.testing.com/webhook"
+        data["auth_token"] = "test-auth-token"
         r = self.client.post(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 201)
         self.assertEqual(Vpn.objects.count(), 1)
+        self.assertEqual(r.data["webhook_endpoint"], data["webhook_endpoint"])
+        self.assertEqual(r.data["auth_token"], data["auth_token"])
 
     def test_vpn_create_with_shared_objects(self):
         org1 = self._get_org()
@@ -887,11 +891,13 @@ class TestConfigApi(
 
     def test_vpn_list_api(self):
         org = self._get_org()
-        self._create_vpn(organization=org)
+        vpn = self._create_wireguard_vpn(organization=org)
         path = reverse("config_api:vpn_list")
         with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.data["results"][0]["subnet"], vpn.subnet.pk)
+        self.assertEqual(r.data["results"][0]["ip"], vpn.ip.pk)
 
     def test_vpn_list_api_filter(self):
         org1 = self._create_org()
@@ -904,10 +910,12 @@ class TestConfigApi(
             self.assertEqual(response.status_code, 200)
             data = response.data
             self.assertEqual(data["count"], 1)
-            self.assertEqual(len(data["results"][0]), 13)
+            self.assertEqual(len(data["results"][0]), 15)
             self.assertEqual(data["results"][0]["id"], str(vpn.pk))
             self.assertEqual(data["results"][0]["name"], str(vpn.name))
             self.assertEqual(data["results"][0]["organization"], vpn.organization.pk)
+            self.assertEqual(data["results"][0]["subnet"], vpn.subnet_id)
+            self.assertEqual(data["results"][0]["ip"], vpn.ip_id)
 
         with self.subTest("Test filtering using VPN backend"):
             r1 = self.client.get(
@@ -959,12 +967,20 @@ class TestConfigApi(
     # VPN detail having Org
     def test_vpn_detail_with_org_api(self):
         org = self._get_org()
-        vpn1 = self._create_vpn(name="test-vpn", organization=org)
+        vpn1 = self._create_wireguard_vpn(name="test-vpn", organization=org)
+        vpn1.webhook_endpoint = "https://vpn.testing.com/webhook"
+        vpn1.auth_token = "test-auth-token"
+        vpn1.full_clean()
+        vpn1.save()
         path = reverse("config_api:vpn_detail", args=[vpn1.pk])
         with self.assertNumQueries(2):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["organization"], org.pk)
+        self.assertEqual(r.data["subnet"], vpn1.subnet.pk)
+        self.assertEqual(r.data["ip"], vpn1.ip.pk)
+        self.assertEqual(r.data["webhook_endpoint"], vpn1.webhook_endpoint)
+        self.assertEqual(r.data["auth_token"], vpn1.auth_token)
 
     def test_vpn_put_api(self):
         vpn1 = self._create_vpn(name="test-vpn")
@@ -977,6 +993,8 @@ class TestConfigApi(
             "organization": org.pk,
             "ca": ca1.pk,
             "backend": vpn1.backend,
+            "webhook_endpoint": "https://vpn1.changetest.com/webhook",
+            "auth_token": "test-auth-token",
             "config": vpn1.config,
         }
         r = self.client.put(path, data, content_type="application/json")
@@ -984,6 +1002,8 @@ class TestConfigApi(
         self.assertEqual(r.data["name"], "change-test-vpn")
         self.assertEqual(r.data["ca"], ca1.pk)
         self.assertEqual(r.data["organization"], org.pk)
+        self.assertEqual(r.data["webhook_endpoint"], data["webhook_endpoint"])
+        self.assertEqual(r.data["auth_token"], data["auth_token"])
 
     def test_vpn_patch_api(self):
         vpn1 = self._create_vpn(name="test-vpn")

--- a/openwisp_controller/config/tests/test_api.py
+++ b/openwisp_controller/config/tests/test_api.py
@@ -892,12 +892,26 @@ class TestConfigApi(
     def test_vpn_list_api(self):
         org = self._get_org()
         vpn = self._create_wireguard_vpn(organization=org)
+        vpn.webhook_endpoint = "https://vpn.testing.com/webhook"
+        vpn.auth_token = "test-auth-token"
+        vpn.save()
+        self._create_wireguard_vpn(
+            name="second-vpn",
+            organization=org,
+            subnet=vpn.subnet,
+        )
         path = reverse("config_api:vpn_list")
         with self.assertNumQueries(3):
             r = self.client.get(path)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.data["results"][0]["subnet"], vpn.subnet.pk)
-        self.assertEqual(r.data["results"][0]["ip"], vpn.ip.pk)
+        self.assertEqual(r.data["count"], 2)
+        result = next(
+            result for result in r.data["results"] if result["id"] == str(vpn.pk)
+        )
+        self.assertEqual(result["subnet"], vpn.subnet.pk)
+        self.assertEqual(result["ip"], vpn.ip.pk)
+        self.assertNotIn("webhook_endpoint", result)
+        self.assertNotIn("auth_token", result)
 
     def test_vpn_list_api_filter(self):
         org1 = self._create_org()
@@ -1006,12 +1020,17 @@ class TestConfigApi(
         self.assertEqual(r.data["auth_token"], data["auth_token"])
 
     def test_vpn_patch_api(self):
-        vpn1 = self._create_vpn(name="test-vpn")
+        vpn1 = self._create_wireguard_vpn(name="test-vpn")
+        original_ip = vpn1.ip
+        other_ip = vpn1.subnet.request_ip()
         path = reverse("config_api:vpn_detail", args=[vpn1.pk])
-        data = dict(name="test-vpn-change")
+        data = dict(name="test-vpn-change", ip=other_ip.pk)
         r = self.client.patch(path, data, content_type="application/json")
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.data["name"], "test-vpn-change")
+        vpn1.refresh_from_db()
+        self.assertEqual(vpn1.ip, original_ip)
+        self.assertEqual(r.data["ip"], original_ip.pk)
 
     def test_vpn_download_api(self):
         vpn1 = self._create_vpn(name="test-vpn")


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- N/A I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #1003.

## Description of Changes

Adds subnet and IP relation IDs to VPN list responses. Extends VPN detail and write responses with subnet, IP, webhook endpoint, and auth token fields, while keeping IP read-only to preserve tenant isolation.

## Screenshot

N/A