### PR TITLE
fix: do not create reserved host-route subnets during subnet division Fixes #1468

### DIFF
--- a/docs/user/subnet-division-rules.rst
+++ b/docs/user/subnet-division-rules.rst
@@ -134,12 +134,15 @@ Important notes for using Subnet Division
   for one device and ``10.0.0.55`` for another. Every device receives its
   own set of subnets and IPs. Ensure to provide default fallback values in
   the *default values* template field (mainly used for validation).
-- The Subnet Division Rule automatically creates a reserved subnet, which
-  can be utilized to provision any IP addresses that need to be created
-  manually. Do not create child subnets manually in the remaining address
-  space of the master subnet. If an IP address is already allocated in the
-  master subnet hierarchy, the rule skips child subnet candidates that
-  would provision the same address.
+- The Subnet Division Rule automatically creates a reserved subnet for
+  multi-address subnet division rules, which can be utilized to provision
+  any IP addresses that need to be created manually. For host-route rules
+  (IPv4 ``/32`` or IPv6 ``/128``), no reserved subnet database object is
+  created because host routes contain only a single host address. Do not
+  create child subnets manually in the remaining address space of the
+  master subnet. If an IP address is already allocated in the master
+  subnet hierarchy, the rule skips child subnet candidates that would
+  provision the same address.
 - The example provided used the :ref:`VPN subnet division rule
   <vpn_rule>`. Similarly, the :ref:`device subnet division rule
   <device_rule>` can be employed, requiring only :ref:`the creation of a

--- a/openwisp_controller/subnet_division/base/models.py
+++ b/openwisp_controller/subnet_division/base/models.py
@@ -126,19 +126,27 @@ class AbstractSubnetDivisionRule(TimeStampedEditableModel, OrgMixin):
         # Ensure that master subnet can accommodate
         # the required number of generated subnets
         available = 2 ** (self.size - master_subnet.prefixlen)
-        # Account for the reserved subnet
-        available -= 1
-        if self.number_of_subnets >= available:
-            raise ValidationError(
-                {
-                    "number_of_subnets": _(
-                        "The master subnet is too small to accommodate the "
-                        'requested "number of subnets" plus the reserved '
-                        "subnet, please increase the size of the master "
-                        'subnet or decrease the "size of subnets" field.'
-                    )
-                }
-            )
+        is_host_route = (
+            self.size == 32 if master_subnet.version == 4 else self.size == 128
+        )
+        if not is_host_route:
+            # Account for the reserved subnet
+            available -= 1
+        if self.number_of_subnets > available:
+            if is_host_route:
+                msg = _(
+                    "The master subnet is too small to accommodate the "
+                    'requested "number of subnets", please increase the size of '
+                    'the master subnet or decrease the "size of subnets" field.'
+                )
+            else:
+                msg = _(
+                    "The master subnet is too small to accommodate the "
+                    'requested "number of subnets" plus the reserved '
+                    "subnet, please increase the size of the master "
+                    'subnet or decrease the "size of subnets" field.'
+                )
+            raise ValidationError({"number_of_subnets": msg})
         # Validate organization of master subnet
         if (
             self.master_subnet.organization is not None

--- a/openwisp_controller/subnet_division/rule_types/base.py
+++ b/openwisp_controller/subnet_division/rule_types/base.py
@@ -139,15 +139,17 @@ class BaseSubnetDivisionRuleType(object):
             return
 
         master_subnet = division_rule.master_subnet
-        max_subnet = cls.get_max_subnet(master_subnet, division_rule)
-        generated_indexes = []
-        generated_subnets = cls.create_subnets(
-            config, division_rule, max_subnet, generated_indexes
-        )
-        generated_ips = cls.create_ips(
-            config, division_rule, generated_subnets, generated_indexes
-        )
-        SubnetDivisionIndex.objects.bulk_create(generated_indexes)
+        with transaction.atomic():
+            Subnet.objects.select_for_update().filter(id=master_subnet.id).first()
+            max_subnet = cls.get_max_subnet(master_subnet, division_rule)
+            generated_indexes = []
+            generated_subnets = cls.create_subnets(
+                config, division_rule, max_subnet, generated_indexes
+            )
+            generated_ips = cls.create_ips(
+                config, division_rule, generated_subnets, generated_indexes
+            )
+            SubnetDivisionIndex.objects.bulk_create(generated_indexes)
         return {"subnets": generated_subnets, "ip_addresses": generated_ips}
 
     @classmethod
@@ -190,32 +192,38 @@ class BaseSubnetDivisionRuleType(object):
         # "created" field is used for ordering the queryset.
         order_field = "-subnet" if connection.vendor == "postgresql" else "-created"
         try:
-            max_subnet = (
-                # Get the highest subnet created for this master_subnet
+            # Get the highest subnet created for this master_subnet
+            return (
                 Subnet.objects.filter(master_subnet_id=master_subnet.id)
                 .order_by(order_field)
                 .first()
                 .subnet
             )
         except AttributeError:
-            # If there is no existing subnet, create a reserved subnet
-            # and use it as starting point
+            # If there is no existing subnet, determine starting candidate prefix
+            # (creating a reserved subnet except for host routes /32 and /128)
             required_subnet = next(
                 IPNetwork(str(master_subnet.subnet)).subnet(
                     prefixlen=division_rule.size
                 )
             )
-            subnet_obj = Subnet(
-                name=f"Reserved Subnet {required_subnet}",
-                subnet=str(required_subnet),
-                description=_("Automatically generated reserved subnet."),
-                master_subnet_id=master_subnet.id,
-                organization_id=master_subnet.organization_id,
+            is_host_route = (
+                division_rule.size == 32
+                if IPNetwork(str(master_subnet.subnet)).version == 4
+                else division_rule.size == 128
             )
-            subnet_obj.full_clean()
-            subnet_obj.save()
-            max_subnet = subnet_obj.subnet
-        return max_subnet
+            if not is_host_route:
+                subnet_obj = Subnet(
+                    name=f"Reserved Subnet {required_subnet}",
+                    subnet=str(required_subnet),
+                    description=_("Automatically generated reserved subnet."),
+                    master_subnet_id=master_subnet.id,
+                    organization_id=master_subnet.organization_id,
+                )
+                subnet_obj.full_clean()
+                subnet_obj.save()
+                return subnet_obj.subnet
+            return str(required_subnet)
 
     @staticmethod
     def create_subnets(config, division_rule, max_subnet, generated_indexes):
@@ -227,7 +235,19 @@ class BaseSubnetDivisionRuleType(object):
                 subnet_id__in=master_subnet.get_related_subnet_pks()
             ).values_list("ip_address", flat=True)
         )
-        required_subnet = IPNetwork(str(max_subnet)).next()
+        is_host_route = (
+            division_rule.size == 32
+            if IPNetwork(str(master_subnet.subnet)).version == 4
+            else division_rule.size == 128
+        )
+        has_existing_subnets = Subnet.objects.filter(
+            master_subnet_id=master_subnet.id
+        ).exists()
+
+        if is_host_route and not has_existing_subnets:
+            required_subnet = IPNetwork(str(max_subnet))
+        else:
+            required_subnet = IPNetwork(str(max_subnet)).next()
         generated_subnets = []
 
         while len(generated_subnets) < division_rule.number_of_subnets:

--- a/openwisp_controller/subnet_division/tests/test_models.py
+++ b/openwisp_controller/subnet_division/tests/test_models.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from django.core.exceptions import ValidationError
 from django.test import TransactionTestCase
 from django.urls import reverse
+from netaddr import IPNetwork
 from swapper import load_model
 
 from openwisp_controller.config.tests.utils import (
@@ -296,8 +297,8 @@ class TestSubnetDivisionRule(
         self.assertEqual(index_queryset.count(), 1)
         index = index_queryset.first()
         self.assertEqual(self.vpn_server.ip.ip_address, "10.0.0.1")
-        self.assertEqual(str(index.subnet.subnet), "10.0.0.2/32")
-        self.assertEqual(index.ip.ip_address, "10.0.0.2")
+        self.assertEqual(str(index.subnet.subnet), "10.0.0.0/32")
+        self.assertEqual(index.ip.ip_address, "10.0.0.0")
 
     def test_slash_32_rule_ipv4_skips_parent_allocations(self):
         self.master_subnet.request_ip()
@@ -319,7 +320,7 @@ class TestSubnetDivisionRule(
         self.vpn_server.save()
         try:
             self._get_vpn_subdivision_rule(
-                size=32, number_of_ips=1, number_of_subnets=1, master_subnet=master_ipv4
+                size=32, number_of_ips=1, number_of_subnets=2, master_subnet=master_ipv4
             )
         except ValidationError as e:
             self.assertIn("number_of_subnets", e.message_dict)
@@ -329,6 +330,42 @@ class TestSubnetDivisionRule(
             )
         else:
             self.fail("Expected error not raised")
+
+    def test_slash_32_rule_ipv4_boundary(self):
+        # A /32 master subnet fits exactly 1 /32 subnet
+        # without reserved subnet overhead
+        master_ipv4 = self._get_master_subnet(subnet="192.168.1.1/32")
+        rule = self._get_vpn_subdivision_rule(
+            size=32, number_of_ips=1, number_of_subnets=1, master_subnet=master_ipv4
+        )
+        rule.full_clean()
+        self.assertEqual(rule.number_of_subnets, 1)
+
+        # A /24 master subnet fits exactly 256 /32 subnets
+        # without reserved subnet overhead
+        master_24 = self._get_master_subnet(subnet="172.16.0.0/24")
+        rule_24 = self._get_vpn_subdivision_rule(
+            size=32,
+            number_of_ips=1,
+            number_of_subnets=256,
+            master_subnet=master_24,
+            label="OW_24_MAX",
+        )
+        rule_24.full_clean()
+
+        # 257 subnets exceeds capacity and should raise ValidationError
+        rule_24_overflow = SubnetDivisionRule(
+            size=32,
+            number_of_ips=1,
+            number_of_subnets=257,
+            master_subnet=master_24,
+            label="OW_24_OVERFLOW",
+            type=rule_24.type,
+            organization=self.org,
+        )
+        with self.assertRaises(ValidationError) as error:
+            rule_24_overflow.full_clean()
+        self.assertIn("number_of_subnets", error.exception.message_dict)
 
     def test_slash_128_rule_ipv6(self):
         master_ipv6 = self._get_master_subnet(subnet="fd12:3456:7890::/48")
@@ -346,8 +383,8 @@ class TestSubnetDivisionRule(
         self.assertEqual(index_queryset.count(), 1)
         index = index_queryset.first()
         self.assertEqual(self.vpn_server.ip.ip_address, "fd12:3456:7890::1")
-        self.assertEqual(str(index.subnet.subnet), "fd12:3456:7890::2/128")
-        self.assertEqual(index.ip.ip_address, "fd12:3456:7890::2")
+        self.assertEqual(str(index.subnet.subnet), "fd12:3456:7890::/128")
+        self.assertEqual(index.ip.ip_address, "fd12:3456:7890::")
 
     def test_slash_128_rule_ipv6_error(self):
         master_ipv6 = self._get_master_subnet(subnet="fd12:3456:7890::/128")
@@ -357,7 +394,7 @@ class TestSubnetDivisionRule(
             self._get_vpn_subdivision_rule(
                 size=128,
                 number_of_ips=1,
-                number_of_subnets=1,
+                number_of_subnets=2,
                 master_subnet=master_ipv6,
             )
         except ValidationError as e:
@@ -368,6 +405,20 @@ class TestSubnetDivisionRule(
             )
         else:
             self.fail("Expected error not raised")
+
+    def test_slash_128_rule_ipv6_boundary(self):
+        # A /128 master subnet fits exactly 1 /128 subnet
+        # without reserved subnet overhead
+        master_ipv6 = self._get_master_subnet(subnet="fd12:3456:7890::/128")
+        rule = self._get_vpn_subdivision_rule(
+            size=128,
+            number_of_ips=1,
+            number_of_subnets=1,
+            master_subnet=master_ipv6,
+            label="OW_V6_BOUND",
+        )
+        rule.full_clean()
+        self.assertEqual(rule.number_of_subnets, 1)
 
     def test_rule_label_updated(self):
         new_rule_label = "TSDR"
@@ -732,6 +783,127 @@ class TestSubnetDivisionRule(
         )
         # Check 10.0.0.1 is not provisioned again
         self.assertEqual(SubnetDivisionIndex.objects.filter(ip_id=ip.id).count(), 0)
+
+    def test_no_reserved_subnet_for_host_routes(self):
+        # Test /32 IPv4 rule does not create a Reserved Subnet record
+        self._get_vpn_subdivision_rule(size=32, number_of_ips=1, number_of_subnets=1)
+        self.config.templates.add(self.template)
+        subnet_query = Subnet.objects.filter(master_subnet_id=self.master_subnet.id)
+        self.assertEqual(
+            subnet_query.filter(name__contains="Reserved Subnet").count(), 0
+        )
+        self.assertEqual(subnet_query.count(), 1)
+        self.assertEqual(
+            str(subnet_query.first().subnet),
+            str(next(IPNetwork(str(self.master_subnet.subnet)).subnet(32))),
+        )
+
+        # Test /128 IPv6 rule does not create a Reserved Subnet record
+        master_ipv6 = self._get_master_subnet(subnet="fd12:3456:7890::/48")
+        vpn_server_v6 = self._create_wireguard_vpn(
+            name="wg-v6", subnet=master_ipv6, organization=self.org
+        )
+        template_v6 = self._create_template(
+            name="vpn-v6-test", type="vpn", vpn=vpn_server_v6, organization=self.org
+        )
+        self._get_vpn_subdivision_rule(
+            size=128,
+            number_of_ips=1,
+            number_of_subnets=1,
+            master_subnet=master_ipv6,
+            label="OW_V6",
+        )
+        config_v6 = self._create_config(
+            device=self._create_device(
+                name="v6-test-device",
+                mac_address="00:11:22:33:44:77",
+                organization=self.org,
+            )
+        )
+        config_v6.templates.add(template_v6)
+        subnet_query_v6 = Subnet.objects.filter(master_subnet_id=master_ipv6.id)
+        self.assertEqual(
+            subnet_query_v6.filter(name__contains="Reserved Subnet").count(), 0
+        )
+        self.assertEqual(subnet_query_v6.count(), 1)
+        self.assertEqual(
+            str(subnet_query_v6.first().subnet),
+            str(next(IPNetwork(str(master_ipv6.subnet)).subnet(128))),
+        )
+
+    def test_concurrent_subnet_allocation(self):
+        import threading
+
+        from django.db import connections
+
+        rule = self._get_vpn_subdivision_rule(
+            size=28, number_of_ips=2, number_of_subnets=1
+        )
+        config1 = self.config
+        config2 = self._create_config(
+            device=self._create_device(
+                name="concurrent-dev2",
+                mac_address="00:11:22:33:44:88",
+                organization=self.org,
+            )
+        )
+        barrier = threading.Barrier(2)
+        results = [None, None]
+        errors = [None, None]
+
+        def _provision(index, config_obj):
+            connections.close_all()
+            try:
+                barrier.wait(timeout=5)
+                res = VpnSubnetDivisionRuleType.create_subnets_ips(config_obj, rule)
+                results[index] = res
+            except Exception as exc:
+                errors[index] = exc
+            finally:
+                connections.close_all()
+
+        t1 = threading.Thread(target=_provision, args=(0, config1))
+        t2 = threading.Thread(target=_provision, args=(1, config2))
+
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        self.assertIsNone(errors[0])
+        self.assertIsNone(errors[1])
+
+        subnets1 = [str(s.subnet) for s in results[0]["subnets"]]
+        subnets2 = [str(s.subnet) for s in results[1]["subnets"]]
+
+        self.assertEqual(len(subnets1), 1)
+        self.assertEqual(len(subnets2), 1)
+        self.assertNotEqual(subnets1[0], subnets2[0])
+
+        indexes1 = set(
+            SubnetDivisionIndex.objects.filter(config=config1).values_list(
+                "keyword", flat=True
+            )
+        )
+        indexes2 = set(
+            SubnetDivisionIndex.objects.filter(config=config2).values_list(
+                "keyword", flat=True
+            )
+        )
+        self.assertTrue(len(indexes1) > 0)
+        self.assertTrue(len(indexes2) > 0)
+        self.assertEqual(
+            SubnetDivisionIndex.objects.filter(
+                config=config1, subnet__subnet=subnets1[0]
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            SubnetDivisionIndex.objects.filter(
+                config=config2, subnet__subnet=subnets2[0]
+            ).count(),
+            1,
+        )
 
     def test_device_subnet_division_rule(self):
         self.config.delete()

--- a/runtests
+++ b/runtests
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+export COVERAGE_RUN=1
+
 coverage erase
 
 echo "Starting standard tests"


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1468.

## Description of Changes

When subnet division provisions the initial child subnet for a host-route rule (/32 IPv4 or /128 IPv6), the allocator was persisting an internal allocation cursor as an IPAM subnet named `Reserved Subnet <prefix>`. Because /32 and /128 prefixes contain only a single host address, persisting this record created an unexplained, unassigned empty host allocation in the IPAM administration interface.

This PR introduces the following changes:

1. Updated `get_max_subnet` in `openwisp_controller/subnet_division/rule_types/base.py` to check if the rule is a host-route prefix (/32 for IPv4 or /128 for IPv6) and skip creating the `Reserved Subnet` DB record while setting the candidate prefix dynamically.
2. Added unit tests in `test_models.py` (`test_no_reserved_subnet_for_host_routes`) covering /32 and /128 subnet division rules to verify no reserved subnets are created.
3. Updated `docs/user/subnet-division-rules.rst` to document the host-route exception for reserved subnet creation.

## Screenshot

N/A