### PR TITLE
fix: prevent renewing revoked X.509 certificates Fixes #1467

### DIFF
--- a/docs/user/rest-api.rst
+++ b/docs/user/rest-api.rst
@@ -1408,6 +1408,11 @@ Renew Cert
 
     POST /api/v1/controller/cert/{id}/renew/
 
+.. note::
+
+    Attempting to renew a revoked certificate will return an HTTP 400 Bad Request
+    response with localized error message (e.g., ``{"detail": "Cannot renew a revoked certificate."}``).
+
 Revoke Cert
 ~~~~~~~~~~~
 

--- a/openwisp_controller/pki/api/views.py
+++ b/openwisp_controller/pki/api/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.generics import (
     GenericAPIView,
@@ -95,6 +96,11 @@ class CertRenewView(CertRevokeRenewBaseView):
         Renews the Certificate.
         """
         instance = self.get_object()
+        if instance.revoked:
+            return Response(
+                {"detail": _("Cannot renew a revoked certificate.")},
+                status=400,
+            )
         instance.renew()
         serializer = CertRevokeRenewSerializer(instance)
         return Response(serializer.data, status=200)

--- a/openwisp_controller/pki/base/models.py
+++ b/openwisp_controller/pki/base/models.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django_x509.base.models import AbstractCa as BaseCa
@@ -38,3 +39,8 @@ class AbstractCert(ShareableOrgMixin, UnqiueCommonNameMixin, BaseCert):
 
     def clean(self):
         self._validate_org_relation("ca")
+
+    def renew(self, *args, **kwargs):
+        if self.revoked:
+            raise ValidationError(_("Cannot renew a revoked certificate."))
+        return super().renew(*args, **kwargs)

--- a/openwisp_controller/pki/tests/test_api.py
+++ b/openwisp_controller/pki/tests/test_api.py
@@ -1,3 +1,5 @@
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
 from django.test import TestCase, TransactionTestCase
 from django.urls import reverse
 from packaging.version import parse as parse_version
@@ -370,6 +372,35 @@ class TestTransactionPkiApi(
         cert1.refresh_from_db()
         self.assertNotEqual(cert1.serial_number, old_serial_num)
         self.assertNotEqual(r.data["serial_number"], old_serial_num)
+
+    def test_post_cert_renew_revoked_api(self):
+        cert1 = self._create_cert(name="cert1")
+        old_serial_num = cert1.serial_number
+        cert1.revoke()
+        crl_bytes_before = (
+            cert1.ca.crl
+            if isinstance(cert1.ca.crl, bytes)
+            else cert1.ca.crl.encode("utf-8")
+        )
+        crl_before = x509.load_pem_x509_crl(crl_bytes_before, default_backend())
+        revoked_serials_before = [r.serial_number for r in crl_before]
+        self.assertIn(old_serial_num, revoked_serials_before)
+        path = reverse("pki_api:cert_renew", args=[cert1.pk])
+        r = self.client.post(path)
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.data["detail"], "Cannot renew a revoked certificate.")
+        cert1.refresh_from_db()
+        self.assertEqual(cert1.serial_number, old_serial_num)
+        self.assertTrue(cert1.revoked)
+        crl_bytes_after = (
+            cert1.ca.crl
+            if isinstance(cert1.ca.crl, bytes)
+            else cert1.ca.crl.encode("utf-8")
+        )
+        crl_after = x509.load_pem_x509_crl(crl_bytes_after, default_backend())
+        revoked_serials_after = [r.serial_number for r in crl_after]
+        self.assertIn(old_serial_num, revoked_serials_after)
+        self.assertEqual(revoked_serials_after, revoked_serials_before)
 
     def test_post_cert_revoke_api(self):
         cert1 = self._create_cert(name="cert1")

--- a/openwisp_controller/pki/tests/test_models.py
+++ b/openwisp_controller/pki/tests/test_models.py
@@ -63,3 +63,30 @@ class TestModels(TestAdminMixin, TestPkiMixin, TestOrganizationMixin, TestCase):
         self._create_cert(ca=ca)
         with self.assertRaises(ValidationError):
             self._create_cert(ca=ca)
+
+    def test_renew_revoked_cert_raises_validation_error(self):
+        cert = self._create_cert()
+        old_serial = cert.serial_number
+        cert.revoke()
+        crl_bytes_before = (
+            cert.ca.crl
+            if isinstance(cert.ca.crl, bytes)
+            else cert.ca.crl.encode("utf-8")
+        )
+        crl_before = x509.load_pem_x509_crl(crl_bytes_before, default_backend())
+        revoked_serials_before = [r.serial_number for r in crl_before]
+        self.assertIn(old_serial, revoked_serials_before)
+        with self.assertRaises(ValidationError):
+            cert.renew()
+        cert.refresh_from_db()
+        self.assertEqual(cert.serial_number, old_serial)
+        self.assertTrue(cert.revoked)
+        crl_bytes_after = (
+            cert.ca.crl
+            if isinstance(cert.ca.crl, bytes)
+            else cert.ca.crl.encode("utf-8")
+        )
+        crl_after = x509.load_pem_x509_crl(crl_bytes_after, default_backend())
+        revoked_serials_after = [r.serial_number for r in crl_after]
+        self.assertIn(old_serial, revoked_serials_after)
+        self.assertEqual(revoked_serials_after, revoked_serials_before)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #1467.

## Description of Changes

Currently, the certificate renewal API endpoint (`CertRenewView.post()`) accepts revoked X.509 certificates. When `Cert.renew()` was called on a revoked certificate, it generated a new serial number while leaving `revoked=True`, replacing the original revoked serial in the CA CRL with the new serial number. As a result, the original revoked certificate could no longer be matched by the CRL.

This PR introduces the following changes:

1. Updated `CertRenewView.post()` in `openwisp_controller/pki/api/views.py` to check if `instance.revoked` is True and return an HTTP 400 Bad Request response (`{"detail": "Cannot renew a revoked certificate."}`).
2. Overrode `renew()` in `AbstractCert` in `openwisp_controller/pki/base/models.py` to raise a `ValidationError` if renewal is attempted on a revoked certificate instance.
3. Added API regression test `test_post_cert_renew_revoked_api` in `test_api.py` and model test `test_renew_revoked_cert_raises_validation_error` in `test_models.py`.
4. Updated `docs/user/rest-api.rst` to document the 400 Bad Request response for revoked certificate renewal.

## Screenshot

N/A